### PR TITLE
Attribute commits to dispatchers by provenance, not trailers

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -35,6 +35,10 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	if err := ensureBranch(r.Path, branch); err != nil {
 		return nil, err
 	}
+	baseSHA := ""
+	if out, err := exec.Command("git", "-C", r.Path, "rev-parse", "HEAD").Output(); err == nil {
+		baseSHA = strings.TrimSpace(string(out))
+	}
 
 	d := &state.Dispatch{
 		ID:          state.NewID(),
@@ -44,6 +48,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		RepoName:    r.Name,
 		Product:     r.Product,
 		Branch:      branch,
+		BaseSHA:     baseSHA,
 		Prompt:      prompt,
 		TmuxSession: tmux.UniqueName("disp-" + slug),
 		Status:      state.StatusLaunching,

--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -23,7 +23,10 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"claude-dispatcher/internal/state"
 )
@@ -58,10 +61,34 @@ func Run(args []string) int {
 	if d == nil {
 		return 0
 	}
-	if apply(d, event, in) {
+	changed := apply(d, event, in)
+	if event == "Stop" || event == "SessionEnd" {
+		changed = refreshCommits(d) || changed
+	}
+	if changed {
 		state.Save(d)
 	}
 	return 0
+}
+
+// refreshCommits records the SHAs produced on the feature branch since
+// launch. Provenance ("this dispatch made these commits") is the attribution
+// signal — no trailers or markers in the repo's public history.
+func refreshCommits(d *state.Dispatch) bool {
+	if d.BaseSHA == "" || d.Branch == "" {
+		return false
+	}
+	out, err := exec.Command("git", "-C", d.RepoPath, "rev-list",
+		d.BaseSHA+"..refs/heads/"+d.Branch).Output()
+	if err != nil {
+		return false
+	}
+	shas := strings.Fields(string(out))
+	if slices.Equal(shas, d.Commits) {
+		return false
+	}
+	d.Commits = shas
+	return true
 }
 
 func resolve(dispatcherID, event string, in hookInput) *state.Dispatch {

--- a/internal/ship/ship.go
+++ b/internal/ship/ship.go
@@ -1,6 +1,7 @@
 // Package ship collects shipping stats across all tracked repos: the
-// credibility layer. Claude-stamped commits are detected by the
-// Co-Authored-By: Claude trailer.
+// credibility layer. Commits are attributed to dispatchers by provenance —
+// the SHAs each dispatch recorded on its feature branch — never by trailers
+// or markers in the repo's public history.
 package ship
 
 import (
@@ -10,24 +11,32 @@ import (
 	"time"
 
 	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
 )
 
 type Stats struct {
 	Commits     int // commits today across all tracked repos (all branches)
-	Stamped     int // of which carry a Co-Authored-By: Claude trailer
+	Dispatched  int // of which were produced under a dispatch
 	ReposActive int // repos with at least one commit today
 	ReposTotal  int
 	CollectedAt time.Time
 }
 
-func (s Stats) StampedPct() int {
+func (s Stats) DispatchedPct() int {
 	if s.Commits == 0 {
 		return 0
 	}
-	return s.Stamped * 100 / s.Commits
+	return s.Dispatched * 100 / s.Commits
 }
 
-func Collect(rs []repos.Repo) Stats {
+func Collect(rs []repos.Repo, ds []*state.Dispatch) Stats {
+	dispatched := map[string]bool{}
+	for _, d := range ds {
+		for _, sha := range d.Commits {
+			dispatched[sha] = true
+		}
+	}
+
 	stats := Stats{ReposTotal: len(rs), CollectedAt: time.Now()}
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -38,11 +47,17 @@ func Collect(rs []repos.Repo) Stats {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			commits, stamped := repoToday(path)
+			shas := repoToday(path)
+			viaDispatch := 0
+			for _, sha := range shas {
+				if dispatched[sha] {
+					viaDispatch++
+				}
+			}
 			mu.Lock()
-			stats.Commits += commits
-			stats.Stamped += stamped
-			if commits > 0 {
+			stats.Commits += len(shas)
+			stats.Dispatched += viaDispatch
+			if len(shas) > 0 {
 				stats.ReposActive++
 			}
 			mu.Unlock()
@@ -52,18 +67,11 @@ func Collect(rs []repos.Repo) Stats {
 	return stats
 }
 
-func repoToday(path string) (commits, stamped int) {
-	// %x1e delimits commits so multi-line bodies can be scanned per commit.
+func repoToday(path string) []string {
 	out, err := exec.Command("git", "-C", path, "log", "--all",
-		"--since=midnight", "--format=%x1e%B").Output()
+		"--since=midnight", "--format=%H").Output()
 	if err != nil {
-		return 0, 0
+		return nil
 	}
-	for _, body := range strings.Split(string(out), "\x1e")[1:] {
-		commits++
-		if strings.Contains(body, "Co-Authored-By:") && strings.Contains(body, "Claude") {
-			stamped++
-		}
-	}
-	return commits, stamped
+	return strings.Fields(string(out))
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,6 +63,11 @@ type Dispatch struct {
 	TmuxSession    string    `json:"tmux_session"`
 	SessionID      string    `json:"session_id,omitempty"`
 	TranscriptPath string    `json:"transcript_path,omitempty"`
+	// BaseSHA is the branch tip at launch; commits in BaseSHA..Branch were
+	// produced under this dispatch. That provenance — not commit trailers —
+	// is how work is attributed to dispatchers.
+	BaseSHA        string    `json:"base_sha,omitempty"`
+	Commits        []string  `json:"commits,omitempty"`
 	Status         Status    `json:"status"`
 	StatusReason   string    `json:"status_reason,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -137,7 +137,7 @@ func loadDispatches() tea.Msg {
 }
 
 func collectShip(rs []repos.Repo) tea.Cmd {
-	return func() tea.Msg { return shipMsg(ship.Collect(rs)) }
+	return func() tea.Msg { return shipMsg(ship.Collect(rs, state.LoadAll())) }
 }
 
 func waitState(ch chan struct{}) tea.Cmd {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -209,6 +209,7 @@ func (m model) detailView(w, h int) string {
 		kv("product", orDash(d.Product), w),
 		kv("tmux", d.TmuxSession, w),
 		kv("session", orDash(sid), w),
+		kv("commits", fmt.Sprintf("%d", len(d.Commits)), w),
 		kv("updated", humanAge(time.Since(d.UpdatedAt))+" ago", w),
 		"",
 		dimStyle.Render("prompt"),
@@ -233,7 +234,7 @@ func (m model) shipView(w int) string {
 	}
 	lines := []string{
 		kv("commits", fmt.Sprintf("%d", s.Commits), w),
-		kv("claude-stamped", fmt.Sprintf("%d (%d%%)", s.Stamped, s.StampedPct()), w),
+		kv("via dispatch", fmt.Sprintf("%d (%d%%)", s.Dispatched, s.DispatchedPct()), w),
 		kv("repos active", fmt.Sprintf("%d of %d", s.ReposActive, s.ReposTotal), w),
 		"",
 		dimStyle.Render(fmt.Sprintf("as of %s · all branches", s.CollectedAt.Format("15:04"))),


### PR DESCRIPTION
Records the branch tip at launch (`BaseSHA`); on `Stop`/`SessionEnd` the hook captures `BaseSHA..branch` as the dispatch's commits. The shipping strip's "via dispatch" stat counts today's commits against that record, replacing `Co-Authored-By` trailer detection — no markers in public git history.

- `state`: `BaseSHA` + `Commits` on the dispatch record
- `dispatch`: snapshot branch tip at launch
- `hookcmd`: refresh attributed SHAs at turn boundaries
- `ship`: provenance-based "via dispatch" stat (trailer detection removed)

Verified: hook smoke test records 2/2 branch commits on Stop.