### PR TITLE
Close the shipping loop: PR linkage and deploy-driven done

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# Named "CI" on purpose: claude-dispatcher's own deploy detection treats
+# workflows named deploy/release/publish/ship/prod as a live signal, and this
+# repo's checks must never read as a deploy.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go build ./...
+      - run: go test ./... -race -count=1
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: gofmt
+        run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      # Lifecycle-critical paths (the hook, the cockpit loop) deliberately
+      # swallow errors — a failed status write must never disturb a live
+      # Claude session. Those spots use explicit `_ =` assignments instead.
+      check-blank: false
+
+formatters:
+  enable:
+    - gofmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,13 @@
   dispatch works on a feature branch, even in repos that ship from main
   (PR from branch onto main).
 - "Done means live": a feature stays open until deployed, unless explicitly
-  stated otherwise. Deploys are always GitHub Actions — automatic done-signal
-  from Actions is the first roadmap item. `d` in the cockpit is the manual
-  override.
+  stated otherwise. Deploys are always GitHub Actions; `internal/track`
+  flips features to done when the deploy workflow succeeds after PR merge
+  (merge counts as live for repos with no deploy workflow). `d` in the
+  cockpit is the manual override. Auto-done only advances while a cockpit
+  is open (the tracker runs from the cockpit's poll loop).
+- Commit attribution is by provenance (dispatch records its branch SHAs),
+  NEVER by Co-Authored-By trailers — the user strips those from commits.
 - User is on a Claude subscription (not API billing): portfolio roll-up
   speaks in tokens/effort, never dollars.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := $(HOME)/.local/bin/claude-dispatcher
 
-.PHONY: build install vet run
+.PHONY: build install vet run test lint check
 
 build:
 	go build ./...
@@ -12,6 +12,15 @@ install:
 
 vet:
 	go vet ./...
+
+test:
+	go test ./... -race -count=1
+
+lint:
+	golangci-lint run
+	@test -z "$$(gofmt -l .)" || { echo "gofmt needed:"; gofmt -l .; exit 1; }
+
+check: build vet lint test
 
 run: install
 	$(BIN)

--- a/README.md
+++ b/README.md
@@ -54,17 +54,31 @@ an optional `[products]` map (product → repo names) for the roll-up lens.
 | `r` | refresh |
 | `q` | quit |
 
-## Roadmap (deliberately deferred from the MVP)
+## The shipping loop
 
-1. Automatic done-signal from GitHub Actions deploys ("done means live").
-2. PR tracking via `gh`; deploys on the shipping strip.
-3. Portfolio roll-up: effort and token spend per product (tokens, not
+- Commits are attributed to dispatchers by **provenance**: each dispatch
+  records the SHAs produced on its feature branch (base tip at launch →
+  branch tip at each turn). No trailers or markers in your git history.
+- Each dispatch is linked to its PR by branch name (`gh pr list --head`).
+- **Done means live**: when the PR merges, the tracker watches the repo's
+  deploy workflow (auto-detected by name — deploy/release/publish/ship/prod
+  — or overridden in `[deploy_workflows]`) and flips the feature to done on
+  a successful run. Repos with no deploy workflow count merge as live.
+  Auto-done advances while a cockpit is open; `d` remains the manual
+  override.
+- The shipping strip shows: commits today, via-dispatch %, PRs launched
+  today (one `gh search` across all of GitHub), features that went live
+  today, and active repos.
+
+## Roadmap (deliberately deferred)
+
+1. Portfolio roll-up: effort and token spend per product (tokens, not
    dollars — subscription billing).
-4. Feature history: jump back into a shipped feature and rehydrate its
+2. Feature history: jump back into a shipped feature and rehydrate its
    sessions (`claude --resume`) and branch diff.
-5. Adopting sessions started outside the cockpit (the hook already logs
+3. Adopting sessions started outside the cockpit (the hook already logs
    them to `events.jsonl`).
-6. Diff pane on ultrawide layouts.
+4. Diff pane on ultrawide layouts.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ an optional `[products]` map (product → repo names) for the roll-up lens.
    them to `events.jsonl`).
 4. Diff pane on ultrawide layouts.
 
+## Development
+
+`make check` runs build, vet, lint (golangci-lint), and the race-enabled
+test suite — the same gates CI runs on every PR. The CI workflow is named
+"CI" deliberately: this tool's own deploy detection treats deploy-ish
+workflow names as a live signal.
+
 ## Troubleshooting
 
 - **Everything stuck on "launching"** — the hook isn't firing. Re-run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	// Products maps a product name to the repo directory names that belong to
 	// it, powering the portfolio roll-up lens.
 	Products map[string][]string `toml:"products"`
+	// DeployWorkflows overrides deploy-workflow auto-detection per repo
+	// directory name. Unlisted repos use the first workflow whose name looks
+	// deploy-ish (deploy/release/publish/ship/prod).
+	DeployWorkflows map[string]string `toml:"deploy_workflows"`
 }
 
 func Dir() string {
@@ -81,6 +85,14 @@ roots = [%q]
 # acme-shop = ["shop-api", "shop-web"]
 # side-thing = ["side-thing"]
 [products]
+
+# Per-repo deploy workflow override ("done means live" watches this workflow
+# succeed after a feature's PR merges). Unlisted repos auto-detect the first
+# workflow named like deploy/release/publish/ship/prod; repos with no deploy
+# workflow count merge itself as live.
+# [deploy_workflows]
+# shop-api = "Deploy production"
+[deploy_workflows]
 `
 
 // WriteDefault creates the config file if absent, defaulting the scan root to

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExpandHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if got := ExpandHome("~/x"); got != filepath.Join(home, "x") {
+		t.Errorf("ExpandHome(~/x) = %q", got)
+	}
+	if got := ExpandHome("/abs/path"); got != "/abs/path" {
+		t.Errorf("absolute path must pass through, got %q", got)
+	}
+	if got := ExpandHome("~"); got != home {
+		t.Errorf("ExpandHome(~) = %q, want home", got)
+	}
+}
+
+func TestExpandedRootsDedupes(t *testing.T) {
+	c := &Config{Roots: []string{"/a", "/a", "~/b", ""}}
+	got := c.ExpandedRoots()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 roots, got %v", got)
+	}
+	if got[0] != "/a" || !strings.HasSuffix(got[1], "/b") {
+		t.Errorf("unexpected roots %v", got)
+	}
+}
+
+func TestProductFor(t *testing.T) {
+	c := &Config{Products: map[string][]string{
+		"shop": {"shop-api", "shop-web"},
+	}}
+	if got := c.ProductFor("shop-web"); got != "shop" {
+		t.Errorf("ProductFor(shop-web) = %q", got)
+	}
+	if got := c.ProductFor("unrelated"); got != "" {
+		t.Errorf("unmapped repo should be empty, got %q", got)
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -65,7 +65,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	if err := tmux.NewSession(d.TmuxSession, r.Path, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"
-		state.Save(d)
+		_ = state.Save(d)
 		return nil, err
 	}
 	return d, nil

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -35,6 +35,10 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	if err := ensureBranch(r.Path, branch); err != nil {
 		return nil, err
 	}
+	baseSHA := ""
+	if out, err := exec.Command("git", "-C", r.Path, "rev-parse", "HEAD").Output(); err == nil {
+		baseSHA = strings.TrimSpace(string(out))
+	}
 
 	d := &state.Dispatch{
 		ID:          state.NewID(),
@@ -44,6 +48,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		RepoName:    r.Name,
 		Product:     r.Product,
 		Branch:      branch,
+		BaseSHA:     baseSHA,
 		Prompt:      prompt,
 		TmuxSession: tmux.UniqueName("disp-" + slug),
 		Status:      state.StatusLaunching,

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1,0 +1,46 @@
+package dispatch
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Payment Retry Flow!":   "payment-retry-flow",
+		"--already-sluggy--":    "already-sluggy",
+		"  spaces  every/where": "spaces-every-where",
+		"":                      "",
+		"???":                   "",
+	}
+	for in, want := range cases {
+		if got := Slugify(in); got != want {
+			t.Errorf("Slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestShellQuoteRoundTrip(t *testing.T) {
+	prompts := []string{
+		"plain",
+		"it's got 'quotes' in it",
+		`double "quotes" and $vars and ` + "`backticks`",
+		"multi\nline\nprompt",
+	}
+	for _, p := range prompts {
+		out, err := exec.Command("sh", "-c", "printf %s "+shellQuote(p)).Output()
+		if err != nil {
+			t.Fatalf("sh failed for %q: %v", p, err)
+		}
+		if string(out) != p {
+			t.Errorf("round trip of %q gave %q", p, string(out))
+		}
+	}
+}
+
+func TestSlugifyStripsNonASCII(t *testing.T) {
+	if got := Slugify("héllo wörld"); strings.Contains(got, "é") || strings.Contains(got, "ö") {
+		t.Errorf("expected non-ascii stripped, got %q", got)
+	}
+}

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -1,0 +1,140 @@
+// Package gh wraps the GitHub CLI for PR and deploy signals. Every call is
+// best-effort: a repo without a GitHub remote, an offline machine, or a
+// missing gh binary degrades to "no signal", never an error surfaced to the
+// cockpit loop.
+package gh
+
+import (
+	"encoding/json"
+	"os/exec"
+	"regexp"
+	"sync"
+	"time"
+)
+
+func Available() bool {
+	_, err := exec.LookPath("gh")
+	return err == nil
+}
+
+type PR struct {
+	Number   int        `json:"number"`
+	State    string     `json:"state"` // OPEN, MERGED, CLOSED
+	URL      string     `json:"url"`
+	MergedAt *time.Time `json:"mergedAt"`
+}
+
+// PRForBranch returns the PR whose head is the given branch, preferring a
+// live one (merged or open) over closed. Nil when there is none.
+func PRForBranch(repoPath, branch string) *PR {
+	out, err := command(repoPath, "pr", "list", "--head", branch, "--state", "all",
+		"--json", "number,state,url,mergedAt").Output()
+	if err != nil {
+		return nil
+	}
+	var prs []PR
+	if json.Unmarshal(out, &prs) != nil || len(prs) == 0 {
+		return nil
+	}
+	for _, preferred := range []string{"MERGED", "OPEN"} {
+		for i := range prs {
+			if prs[i].State == preferred {
+				return &prs[i]
+			}
+		}
+	}
+	return &prs[0]
+}
+
+var deployRe = regexp.MustCompile(`(?i)deploy|release|publish|ship|prod`)
+
+var (
+	wfMu    sync.Mutex
+	wfCache = map[string][]string{}
+)
+
+func workflows(repoPath string) []string {
+	wfMu.Lock()
+	cached, ok := wfCache[repoPath]
+	wfMu.Unlock()
+	if ok {
+		return cached
+	}
+	var names []string
+	if out, err := command(repoPath, "workflow", "list", "--json", "name").Output(); err == nil {
+		var rows []struct {
+			Name string `json:"name"`
+		}
+		if json.Unmarshal(out, &rows) == nil {
+			for _, r := range rows {
+				names = append(names, r.Name)
+			}
+		}
+	}
+	wfMu.Lock()
+	wfCache[repoPath] = names
+	wfMu.Unlock()
+	return names
+}
+
+// DeploySignal reports whether a deploy workflow succeeded after `since`.
+// The deploy workflow is the override from config if set, otherwise the
+// first workflow with a deploy-ish name. hasWorkflow=false means the repo
+// has no deploy workflow at all — callers treat merge itself as "live".
+func DeploySignal(repoPath string, since time.Time, override string) (deployed bool, at time.Time, hasWorkflow bool) {
+	target := override
+	if target == "" {
+		for _, name := range workflows(repoPath) {
+			if deployRe.MatchString(name) {
+				target = name
+				break
+			}
+		}
+	}
+	if target == "" {
+		return false, time.Time{}, false
+	}
+	out, err := command(repoPath, "run", "list", "--workflow", target,
+		"--json", "conclusion,createdAt,status", "--limit", "20").Output()
+	if err != nil {
+		return false, time.Time{}, true
+	}
+	var runs []struct {
+		Conclusion string    `json:"conclusion"`
+		CreatedAt  time.Time `json:"createdAt"`
+	}
+	if json.Unmarshal(out, &runs) != nil {
+		return false, time.Time{}, true
+	}
+	for _, r := range runs {
+		if r.Conclusion == "success" && r.CreatedAt.After(since) {
+			return true, r.CreatedAt, true
+		}
+	}
+	return false, time.Time{}, true
+}
+
+// PRsCreatedToday counts PRs the user launched today across all of GitHub —
+// one search call, no per-repo fan-out. ok=false when gh is unavailable.
+func PRsCreatedToday() (count int, ok bool) {
+	if !Available() {
+		return 0, false
+	}
+	out, err := exec.Command("gh", "search", "prs",
+		"--author=@me", "--created="+time.Now().Format("2006-01-02"),
+		"--json", "url", "--limit", "200").Output()
+	if err != nil {
+		return 0, false
+	}
+	var rows []struct{}
+	if json.Unmarshal(out, &rows) != nil {
+		return 0, false
+	}
+	return len(rows), true
+}
+
+func command(repoPath string, args ...string) *exec.Cmd {
+	cmd := exec.Command("gh", args...)
+	cmd.Dir = repoPath
+	return cmd
+}

--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -45,7 +45,7 @@ func Run(args []string) int {
 	}
 	raw, _ := io.ReadAll(os.Stdin)
 	var in hookInput
-	json.Unmarshal(raw, &in)
+	_ = json.Unmarshal(raw, &in)
 
 	dispatcherID := os.Getenv("CLAUDE_DISPATCHER_ID")
 	if event != "PostToolUse" { // PostToolUse is too chatty for the log
@@ -66,7 +66,7 @@ func Run(args []string) int {
 		changed = refreshCommits(d) || changed
 	}
 	if changed {
-		state.Save(d)
+		_ = state.Save(d)
 	}
 	return 0
 }

--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -23,7 +23,10 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"claude-dispatcher/internal/state"
 )
@@ -58,10 +61,34 @@ func Run(args []string) int {
 	if d == nil {
 		return 0
 	}
-	if apply(d, event, in) {
+	changed := apply(d, event, in)
+	if event == "Stop" || event == "SessionEnd" {
+		changed = refreshCommits(d) || changed
+	}
+	if changed {
 		state.Save(d)
 	}
 	return 0
+}
+
+// refreshCommits records the SHAs produced on the feature branch since
+// launch. Provenance ("this dispatch made these commits") is the attribution
+// signal — no trailers or markers in the repo's public history.
+func refreshCommits(d *state.Dispatch) bool {
+	if d.BaseSHA == "" || d.Branch == "" {
+		return false
+	}
+	out, err := exec.Command("git", "-C", d.RepoPath, "rev-list",
+		d.BaseSHA+"..refs/heads/"+d.Branch).Output()
+	if err != nil {
+		return false
+	}
+	shas := strings.Fields(string(out))
+	if slices.Equal(shas, d.Commits) {
+		return false
+	}
+	d.Commits = shas
+	return true
 }
 
 func resolve(dispatcherID, event string, in hookInput) *state.Dispatch {

--- a/internal/hookcmd/hookcmd_test.go
+++ b/internal/hookcmd/hookcmd_test.go
@@ -1,0 +1,112 @@
+package hookcmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"claude-dispatcher/internal/state"
+)
+
+func TestApplyTransitions(t *testing.T) {
+	cases := []struct {
+		from    state.Status
+		event   string
+		want    state.Status
+		changed bool
+	}{
+		{state.StatusLaunching, "SessionStart", state.StatusWorking, true},
+		{state.StatusNeedsInput, "UserPromptSubmit", state.StatusWorking, true},
+		{state.StatusWorking, "Stop", state.StatusNeedsInput, true},
+		{state.StatusWorking, "Notification:idle_prompt", state.StatusNeedsInput, true},
+		{state.StatusWorking, "Notification:permission_prompt", state.StatusBlocked, true},
+		{state.StatusBlocked, "PostToolUse", state.StatusWorking, true},
+		{state.StatusWorking, "PostToolUse", state.StatusWorking, false},
+		{state.StatusWorking, "SessionEnd", state.StatusExited, true},
+		{state.StatusDone, "Stop", state.StatusDone, false},
+		{state.StatusDone, "SessionEnd", state.StatusDone, false},
+		{state.StatusWorking, "SomeUnknownEvent", state.StatusWorking, false},
+	}
+	for _, c := range cases {
+		d := &state.Dispatch{Status: c.from}
+		changed := apply(d, c.event, hookInput{})
+		if changed != c.changed || d.Status != c.want {
+			t.Errorf("%s + %s: got (%s, changed=%v), want (%s, changed=%v)",
+				c.from, c.event, d.Status, changed, c.want, c.changed)
+		}
+	}
+}
+
+func TestApplySessionStartBindsSession(t *testing.T) {
+	d := &state.Dispatch{Status: state.StatusLaunching}
+	apply(d, "SessionStart", hookInput{SessionID: "s1", TranscriptPath: "/t.jsonl"})
+	if d.SessionID != "s1" || d.TranscriptPath != "/t.jsonl" {
+		t.Errorf("session not bound: %+v", d)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	bySession := &state.Dispatch{ID: "id1", SessionID: "sess1", Status: state.StatusWorking}
+	launching := &state.Dispatch{ID: "id2", RepoPath: "/repo/two", Status: state.StatusLaunching}
+	for _, d := range []*state.Dispatch{bySession, launching} {
+		if err := state.Save(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if d := resolve("id2", "Stop", hookInput{}); d == nil || d.ID != "id2" {
+		t.Error("env dispatcher id should win")
+	}
+	if d := resolve("", "Stop", hookInput{SessionID: "sess1"}); d == nil || d.ID != "id1" {
+		t.Error("session id should match")
+	}
+	if d := resolve("", "SessionStart", hookInput{Cwd: "/repo/two"}); d == nil || d.ID != "id2" {
+		t.Error("SessionStart should bind launching dispatch by cwd")
+	}
+	if d := resolve("", "Stop", hookInput{Cwd: "/repo/two"}); d != nil {
+		t.Error("cwd binding must be SessionStart-only")
+	}
+	if d := resolve("", "Stop", hookInput{SessionID: "unknown"}); d != nil {
+		t.Error("foreign session should not resolve")
+	}
+}
+
+func TestRefreshCommits(t *testing.T) {
+	repo := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		full := append([]string{"-C", repo, "-c", "user.email=t@t", "-c", "user.name=t"}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-b", "main")
+	git("commit", "--allow-empty", "-m", "base")
+	base := git("rev-parse", "HEAD")
+	git("checkout", "-b", "feature/f")
+	git("commit", "--allow-empty", "-m", "one")
+	git("commit", "--allow-empty", "-m", "two")
+
+	d := &state.Dispatch{RepoPath: repo, Branch: "feature/f", BaseSHA: base}
+	if !refreshCommits(d) || len(d.Commits) != 2 {
+		t.Fatalf("expected 2 attributed commits, got %d", len(d.Commits))
+	}
+	if refreshCommits(d) {
+		t.Error("unchanged commits should report no change")
+	}
+	if d := (&state.Dispatch{RepoPath: repo, Branch: "feature/f"}); refreshCommits(d) {
+		t.Error("missing BaseSHA must be a no-op")
+	}
+}
+
+func TestSamePath(t *testing.T) {
+	if !samePath("/a/b/../b", "/a/b") {
+		t.Error("cleaned paths should match")
+	}
+	if samePath("/a", "/b") {
+		t.Error("different paths should not match")
+	}
+}

--- a/internal/repos/repos.go
+++ b/internal/repos/repos.go
@@ -34,7 +34,7 @@ func Discover(cfg *config.Config) []Repo {
 	var out []Repo
 	for _, root := range cfg.ExpandedRoots() {
 		root := filepath.Clean(root)
-		filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || !d.IsDir() {
 				return nil
 			}

--- a/internal/repos/repos_test.go
+++ b/internal/repos/repos_test.go
@@ -1,0 +1,49 @@
+package repos
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"claude-dispatcher/internal/config"
+)
+
+func TestDiscover(t *testing.T) {
+	root := t.TempDir()
+	mk := func(parts ...string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(append([]string{root}, parts...)...), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("alpha", ".git")
+	mk("group", "sub", "beta", ".git")
+	mk("alpha", "nested", ".git")      // inside a repo: not descended into
+	mk("node_modules", "dep", ".git")  // skipped dir
+	mk(".hidden", "gamma", ".git")     // hidden dir skipped
+	mk("group", "a", "b", "c", ".git") // beyond maxDepth
+	mk("plain", "not-a-repo")
+
+	cfg := &config.Config{
+		Roots:    []string{root},
+		Products: map[string][]string{"prod": {"alpha"}},
+	}
+	got := Discover(cfg)
+
+	if len(got) != 2 {
+		names := []string{}
+		for _, r := range got {
+			names = append(names, r.Name)
+		}
+		t.Fatalf("expected [alpha beta], got %v", names)
+	}
+	if got[0].Name != "alpha" || got[1].Name != "beta" {
+		t.Errorf("expected sorted [alpha beta], got [%s %s]", got[0].Name, got[1].Name)
+	}
+	if got[0].Product != "prod" {
+		t.Errorf("alpha should map to product 'prod', got %q", got[0].Product)
+	}
+	if got[1].Product != "" {
+		t.Errorf("beta should have no product, got %q", got[1].Product)
+	}
+}

--- a/internal/ship/ship.go
+++ b/internal/ship/ship.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
 )
 
+// Stats are pure git + dispatch-record numbers; PRsToday/PRsOK are filled in
+// by the caller (the cockpit adds them from gh) so Collect stays hermetic.
 type Stats struct {
 	Commits      int // commits today across all tracked repos (all branches)
 	Dispatched   int // of which were produced under a dispatch
@@ -42,7 +43,6 @@ func Collect(rs []repos.Repo, ds []*state.Dispatch) Stats {
 	}
 
 	stats := Stats{ReposTotal: len(rs), CollectedAt: time.Now()}
-	stats.PRsToday, stats.PRsOK = gh.PRsCreatedToday()
 	today := time.Now().Format("2006-01-02")
 	for _, d := range ds {
 		if d.DeployedAt != nil && d.DeployedAt.Local().Format("2006-01-02") == today {

--- a/internal/ship/ship.go
+++ b/internal/ship/ship.go
@@ -1,6 +1,7 @@
 // Package ship collects shipping stats across all tracked repos: the
-// credibility layer. Claude-stamped commits are detected by the
-// Co-Authored-By: Claude trailer.
+// credibility layer. Commits are attributed to dispatchers by provenance —
+// the SHAs each dispatch recorded on its feature branch — never by trailers
+// or markers in the repo's public history.
 package ship
 
 import (
@@ -10,24 +11,32 @@ import (
 	"time"
 
 	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
 )
 
 type Stats struct {
 	Commits     int // commits today across all tracked repos (all branches)
-	Stamped     int // of which carry a Co-Authored-By: Claude trailer
+	Dispatched  int // of which were produced under a dispatch
 	ReposActive int // repos with at least one commit today
 	ReposTotal  int
 	CollectedAt time.Time
 }
 
-func (s Stats) StampedPct() int {
+func (s Stats) DispatchedPct() int {
 	if s.Commits == 0 {
 		return 0
 	}
-	return s.Stamped * 100 / s.Commits
+	return s.Dispatched * 100 / s.Commits
 }
 
-func Collect(rs []repos.Repo) Stats {
+func Collect(rs []repos.Repo, ds []*state.Dispatch) Stats {
+	dispatched := map[string]bool{}
+	for _, d := range ds {
+		for _, sha := range d.Commits {
+			dispatched[sha] = true
+		}
+	}
+
 	stats := Stats{ReposTotal: len(rs), CollectedAt: time.Now()}
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -38,11 +47,17 @@ func Collect(rs []repos.Repo) Stats {
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			commits, stamped := repoToday(path)
+			shas := repoToday(path)
+			viaDispatch := 0
+			for _, sha := range shas {
+				if dispatched[sha] {
+					viaDispatch++
+				}
+			}
 			mu.Lock()
-			stats.Commits += commits
-			stats.Stamped += stamped
-			if commits > 0 {
+			stats.Commits += len(shas)
+			stats.Dispatched += viaDispatch
+			if len(shas) > 0 {
 				stats.ReposActive++
 			}
 			mu.Unlock()
@@ -52,18 +67,11 @@ func Collect(rs []repos.Repo) Stats {
 	return stats
 }
 
-func repoToday(path string) (commits, stamped int) {
-	// %x1e delimits commits so multi-line bodies can be scanned per commit.
+func repoToday(path string) []string {
 	out, err := exec.Command("git", "-C", path, "log", "--all",
-		"--since=midnight", "--format=%x1e%B").Output()
+		"--since=midnight", "--format=%H").Output()
 	if err != nil {
-		return 0, 0
+		return nil
 	}
-	for _, body := range strings.Split(string(out), "\x1e")[1:] {
-		commits++
-		if strings.Contains(body, "Co-Authored-By:") && strings.Contains(body, "Claude") {
-			stamped++
-		}
-	}
-	return commits, stamped
+	return strings.Fields(string(out))
 }

--- a/internal/ship/ship.go
+++ b/internal/ship/ship.go
@@ -10,16 +10,20 @@ import (
 	"sync"
 	"time"
 
+	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
 )
 
 type Stats struct {
-	Commits     int // commits today across all tracked repos (all branches)
-	Dispatched  int // of which were produced under a dispatch
-	ReposActive int // repos with at least one commit today
-	ReposTotal  int
-	CollectedAt time.Time
+	Commits      int // commits today across all tracked repos (all branches)
+	Dispatched   int // of which were produced under a dispatch
+	PRsToday     int // PRs the user launched today, across all of GitHub
+	PRsOK        bool
+	FeaturesLive int // features that went live today
+	ReposActive  int // repos with at least one commit today
+	ReposTotal   int
+	CollectedAt  time.Time
 }
 
 func (s Stats) DispatchedPct() int {
@@ -38,6 +42,13 @@ func Collect(rs []repos.Repo, ds []*state.Dispatch) Stats {
 	}
 
 	stats := Stats{ReposTotal: len(rs), CollectedAt: time.Now()}
+	stats.PRsToday, stats.PRsOK = gh.PRsCreatedToday()
+	today := time.Now().Format("2006-01-02")
+	for _, d := range ds {
+		if d.DeployedAt != nil && d.DeployedAt.Local().Format("2006-01-02") == today {
+			stats.FeaturesLive++
+		}
+	}
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	sem := make(chan struct{}, 8)

--- a/internal/ship/ship_test.go
+++ b/internal/ship/ship_test.go
@@ -1,0 +1,74 @@
+package ship
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
+)
+
+func gitRepo(t *testing.T, commits int) (path string, shas []string) {
+	t.Helper()
+	path = t.TempDir()
+	git := func(args ...string) string {
+		full := append([]string{"-C", path, "-c", "user.email=t@t", "-c", "user.name=t"}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-b", "main")
+	for i := 0; i < commits; i++ {
+		git("commit", "--allow-empty", "-m", "c")
+		shas = append(shas, git("rev-parse", "HEAD"))
+	}
+	return path, shas
+}
+
+func TestCollectAttributesByProvenance(t *testing.T) {
+	active, shas := gitRepo(t, 3)
+	idle, _ := gitRepo(t, 0) // init'd but no commits
+
+	ds := []*state.Dispatch{{ID: "d1", Commits: shas[:2]}}
+	got := Collect([]repos.Repo{
+		{Name: "active", Path: active},
+		{Name: "idle", Path: idle},
+	}, ds)
+
+	if got.Commits != 3 {
+		t.Errorf("Commits = %d, want 3", got.Commits)
+	}
+	if got.Dispatched != 2 {
+		t.Errorf("Dispatched = %d, want 2", got.Dispatched)
+	}
+	if got.DispatchedPct() != 66 {
+		t.Errorf("DispatchedPct = %d, want 66", got.DispatchedPct())
+	}
+	if got.ReposActive != 1 || got.ReposTotal != 2 {
+		t.Errorf("repos: active=%d total=%d, want 1/2", got.ReposActive, got.ReposTotal)
+	}
+}
+
+func TestCollectCountsFeaturesLiveToday(t *testing.T) {
+	now := time.Now()
+	yesterday := now.Add(-48 * time.Hour)
+	ds := []*state.Dispatch{
+		{ID: "a", DeployedAt: &now},
+		{ID: "b", DeployedAt: &yesterday},
+		{ID: "c"},
+	}
+	got := Collect(nil, ds)
+	if got.FeaturesLive != 1 {
+		t.Errorf("FeaturesLive = %d, want 1", got.FeaturesLive)
+	}
+}
+
+func TestDispatchedPctZeroCommits(t *testing.T) {
+	if (Stats{}).DispatchedPct() != 0 {
+		t.Error("zero commits must not divide by zero")
+	}
+}

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -1,0 +1,13 @@
+package state
+
+import (
+	"os"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,6 +63,11 @@ type Dispatch struct {
 	TmuxSession    string    `json:"tmux_session"`
 	SessionID      string    `json:"session_id,omitempty"`
 	TranscriptPath string    `json:"transcript_path,omitempty"`
+	// BaseSHA is the branch tip at launch; commits in BaseSHA..Branch were
+	// produced under this dispatch. That provenance — not commit trailers —
+	// is how work is attributed to dispatchers.
+	BaseSHA        string    `json:"base_sha,omitempty"`
+	Commits        []string  `json:"commits,omitempty"`
 	Status         Status    `json:"status"`
 	StatusReason   string    `json:"status_reason,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -170,6 +170,6 @@ func AppendEvent(ev Event) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	f.Write(append(b, '\n'))
+	defer func() { _ = f.Close() }()
+	_, _ = f.Write(append(b, '\n'))
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -52,26 +52,31 @@ func (s Status) Priority() int {
 }
 
 type Dispatch struct {
-	ID             string    `json:"id"`
-	Feature        string    `json:"feature"`
-	Slug           string    `json:"slug"`
-	RepoPath       string    `json:"repo_path"`
-	RepoName       string    `json:"repo_name"`
-	Product        string    `json:"product,omitempty"`
-	Branch         string    `json:"branch"`
-	Prompt         string    `json:"prompt"`
-	TmuxSession    string    `json:"tmux_session"`
-	SessionID      string    `json:"session_id,omitempty"`
-	TranscriptPath string    `json:"transcript_path,omitempty"`
+	ID             string `json:"id"`
+	Feature        string `json:"feature"`
+	Slug           string `json:"slug"`
+	RepoPath       string `json:"repo_path"`
+	RepoName       string `json:"repo_name"`
+	Product        string `json:"product,omitempty"`
+	Branch         string `json:"branch"`
+	Prompt         string `json:"prompt"`
+	TmuxSession    string `json:"tmux_session"`
+	SessionID      string `json:"session_id,omitempty"`
+	TranscriptPath string `json:"transcript_path,omitempty"`
 	// BaseSHA is the branch tip at launch; commits in BaseSHA..Branch were
 	// produced under this dispatch. That provenance — not commit trailers —
 	// is how work is attributed to dispatchers.
-	BaseSHA        string    `json:"base_sha,omitempty"`
-	Commits        []string  `json:"commits,omitempty"`
-	Status         Status    `json:"status"`
-	StatusReason   string    `json:"status_reason,omitempty"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	BaseSHA      string     `json:"base_sha,omitempty"`
+	Commits      []string   `json:"commits,omitempty"`
+	PRNumber     int        `json:"pr_number,omitempty"`
+	PRState      string     `json:"pr_state,omitempty"` // OPEN, MERGED, CLOSED
+	PRURL        string     `json:"pr_url,omitempty"`
+	PRMergedAt   *time.Time `json:"pr_merged_at,omitempty"`
+	DeployedAt   *time.Time `json:"deployed_at,omitempty"`
+	Status       Status     `json:"status"`
+	StatusReason string     `json:"status_reason,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }
 
 func Dir() string {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,66 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatusPriorityOrdering(t *testing.T) {
+	order := []Status{StatusBlocked, StatusNeedsInput, StatusLaunching,
+		StatusWorking, StatusExited, StatusDone}
+	for i := 1; i < len(order); i++ {
+		if order[i-1].Priority() >= order[i].Priority() {
+			t.Errorf("%s should outrank %s", order[i-1], order[i])
+		}
+	}
+}
+
+func TestSaveLoadAllSortsByUrgency(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	for _, d := range []*Dispatch{
+		{ID: "w", Feature: "working", Status: StatusWorking},
+		{ID: "b", Feature: "blocked", Status: StatusBlocked},
+		{ID: "d", Feature: "done", Status: StatusDone},
+		{ID: "n", Feature: "needs", Status: StatusNeedsInput},
+	} {
+		if err := Save(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := LoadAll()
+	if len(got) != 4 {
+		t.Fatalf("expected 4 records, got %d", len(got))
+	}
+	wantOrder := []string{"b", "n", "w", "d"}
+	for i, id := range wantOrder {
+		if got[i].ID != id {
+			t.Errorf("position %d: got %s, want %s", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestSaveStampsUpdatedAt(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	d := &Dispatch{ID: "x", Status: StatusWorking}
+	before := time.Now()
+	if err := Save(d); err != nil {
+		t.Fatal(err)
+	}
+	if d.UpdatedAt.Before(before) {
+		t.Error("UpdatedAt not stamped on save")
+	}
+}
+
+func TestLoadAllSkipsCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_DISPATCHER_STATE", dir)
+	if err := Save(&Dispatch{ID: "ok", Status: StatusWorking}); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, DispatchesDir()+"/broken.json", "{not json")
+	writeFile(t, DispatchesDir()+"/empty-id.json", "{}")
+	got := LoadAll()
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("expected only the valid record, got %d", len(got))
+	}
+}

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -51,7 +51,7 @@ func Refresh(ds []*state.Dispatch, cfg *config.Config) int {
 			}
 		}
 		if changed {
-			state.Save(d)
+			_ = state.Save(d)
 			updated++
 		}
 	}

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -1,0 +1,59 @@
+// Package track closes the shipping loop: it links each open dispatch to its
+// PR by branch name and flips features to done when they go live — "done
+// means live". A repo with no deploy workflow treats merge itself as live.
+//
+// Refresh runs from the cockpit's periodic poll; changes are written to the
+// state dir, and the cockpit's fsnotify watcher picks them up like any other
+// status change. (Consequence: auto-done only advances while a cockpit is
+// open somewhere.)
+package track
+
+import (
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/gh"
+	"claude-dispatcher/internal/state"
+)
+
+// Refresh polls PR and deploy state for every non-done dispatch. Returns how
+// many records changed.
+func Refresh(ds []*state.Dispatch, cfg *config.Config) int {
+	if !gh.Available() {
+		return 0
+	}
+	updated := 0
+	for _, d := range ds {
+		if d.Status == state.StatusDone {
+			continue
+		}
+		changed := false
+		if pr := gh.PRForBranch(d.RepoPath, d.Branch); pr != nil &&
+			(pr.Number != d.PRNumber || pr.State != d.PRState) {
+			d.PRNumber = pr.Number
+			d.PRState = pr.State
+			d.PRURL = pr.URL
+			d.PRMergedAt = pr.MergedAt
+			changed = true
+		}
+		if d.PRState == "MERGED" && d.PRMergedAt != nil && d.DeployedAt == nil {
+			deployed, at, hasWorkflow := gh.DeploySignal(
+				d.RepoPath, *d.PRMergedAt, cfg.DeployWorkflows[d.RepoName])
+			switch {
+			case deployed:
+				d.DeployedAt = &at
+				d.Status = state.StatusDone
+				d.StatusReason = "deployed — live"
+				changed = true
+			case !hasWorkflow:
+				d.DeployedAt = d.PRMergedAt
+				d.Status = state.StatusDone
+				d.StatusReason = "PR merged (repo has no deploy workflow)"
+				changed = true
+			}
+		}
+		if changed {
+			state.Save(d)
+			updated++
+		}
+	}
+	return updated
+}

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -38,9 +38,9 @@ func Tail(path string, n int) []string {
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if fi, err := f.Stat(); err == nil && fi.Size() > tailBytes {
-		f.Seek(fi.Size()-tailBytes, io.SeekStart)
+		_, _ = f.Seek(fi.Size()-tailBytes, io.SeekStart)
 	}
 	data, err := io.ReadAll(f)
 	if err != nil {
@@ -58,9 +58,12 @@ func Tail(path string, n int) []string {
 		if json.Unmarshal([]byte(row), &l) != nil || l.Type != "assistant" {
 			continue
 		}
-		for _, s := range renderContent(l.Message.Content) {
+		// Blocks are appended reversed so the final whole-slice flip restores
+		// their in-message order.
+		blocks := renderContent(l.Message.Content)
+		for i := len(blocks) - 1; i >= 0; i-- {
 			if len(out) < n {
-				out = append(out, s)
+				out = append(out, blocks[i])
 			}
 		}
 	}

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,0 +1,52 @@
+package transcript
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const fixture = `{"type":"user","message":{"role":"user","content":"ignore me"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first answer\nwith a second line"}]}}
+this line is garbage, not json
+{"type":"assistant","message":{"role":"assistant","content":"plain string content"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"},{"type":"text","text":"done"}]}}
+`
+
+func writeFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestTailOrderAndContent(t *testing.T) {
+	got := Tail(writeFixture(t), 10)
+	want := []string{"first answer", "plain string content", "⚙ Bash", "done"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Tail = %v, want %v", got, want)
+	}
+}
+
+func TestTailLimitKeepsNewest(t *testing.T) {
+	got := Tail(writeFixture(t), 2)
+	want := []string{"⚙ Bash", "done"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Tail(2) = %v, want %v", got, want)
+	}
+}
+
+func TestTailDegradesToNil(t *testing.T) {
+	if Tail("", 5) != nil {
+		t.Error("empty path should be nil")
+	}
+	if Tail("/nonexistent/file.jsonl", 5) != nil {
+		t.Error("missing file should be nil")
+	}
+	if Tail(writeFixture(t), 0) != nil {
+		t.Error("n=0 should be nil")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -137,7 +137,7 @@ func loadDispatches() tea.Msg {
 }
 
 func collectShip(rs []repos.Repo) tea.Cmd {
-	return func() tea.Msg { return shipMsg(ship.Collect(rs)) }
+	return func() tea.Msg { return shipMsg(ship.Collect(rs, state.LoadAll())) }
 }
 
 func waitState(ch chan struct{}) tea.Cmd {

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -13,6 +13,7 @@ import (
 
 	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/dispatch"
+	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/ship"
 	"claude-dispatcher/internal/state"
@@ -77,7 +78,7 @@ func Run() error {
 	if err == nil {
 		if err := watcher.Add(state.DispatchesDir()); err == nil {
 			go forwardEvents(watcher, stateCh)
-			defer watcher.Close()
+			defer func() { _ = watcher.Close() }()
 		}
 	}
 
@@ -141,14 +142,18 @@ func loadDispatches() tea.Msg {
 		if !tmux.HasSession(d.TmuxSession) {
 			d.Status = state.StatusExited
 			d.StatusReason = "tmux session gone"
-			state.Save(d)
+			_ = state.Save(d)
 		}
 	}
 	return dispatchesMsg(state.LoadAll())
 }
 
 func collectShip(rs []repos.Repo) tea.Cmd {
-	return func() tea.Msg { return shipMsg(ship.Collect(rs, state.LoadAll())) }
+	return func() tea.Msg {
+		s := ship.Collect(rs, state.LoadAll())
+		s.PRsToday, s.PRsOK = gh.PRsCreatedToday()
+		return shipMsg(s)
+	}
 }
 
 func waitState(ch chan struct{}) tea.Cmd {
@@ -261,18 +266,18 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if d := m.selected(); d != nil {
 			d.Status = state.StatusDone
 			d.StatusReason = "marked shipped"
-			state.Save(d)
+			_ = state.Save(d)
 			m.notice = fmt.Sprintf("%q marked shipped", d.Feature)
 			return m, loadDispatches
 		}
 	case "x":
 		if d := m.selected(); d != nil {
-			tmux.KillSession(d.TmuxSession)
+			_ = tmux.KillSession(d.TmuxSession)
 			if d.Status != state.StatusDone {
 				d.Status = state.StatusExited
 				d.StatusReason = "killed from cockpit"
 			}
-			state.Save(d)
+			_ = state.Save(d)
 			m.notice = fmt.Sprintf("killed %q", d.Feature)
 			return m, loadDispatches
 		}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -17,6 +17,7 @@ import (
 	"claude-dispatcher/internal/ship"
 	"claude-dispatcher/internal/state"
 	"claude-dispatcher/internal/tmux"
+	"claude-dispatcher/internal/track"
 )
 
 type mode int
@@ -51,6 +52,7 @@ type (
 	stateChangedMsg struct{}
 	tickMsg         struct{}
 	shipTickMsg     struct{}
+	trackedMsg      struct{ updated int }
 	launchedMsg     struct {
 		d   *state.Dispatch
 		err error
@@ -112,10 +114,19 @@ func (m model) Init() tea.Cmd {
 	return tea.Batch(
 		loadDispatches,
 		collectShip(m.repos),
+		trackRefresh(m.cfg),
 		waitState(m.stateCh),
 		tick(),
 		shipTick(),
 	)
+}
+
+// trackRefresh polls PR/deploy state and persists changes; the fsnotify
+// watcher then reloads the records like any other status change.
+func trackRefresh(cfg *config.Config) tea.Cmd {
+	return func() tea.Msg {
+		return trackedMsg{updated: track.Refresh(state.LoadAll(), cfg)}
+	}
 }
 
 // loadDispatches reads all records, reconciling any whose tmux session has
@@ -175,7 +186,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(loadDispatches, tick())
 
 	case shipTickMsg:
-		return m, tea.Batch(collectShip(m.repos), shipTick())
+		return m, tea.Batch(trackRefresh(m.cfg), shipTick())
+
+	case trackedMsg:
+		return m, collectShip(m.repos)
 
 	case dispatchesMsg:
 		m.dispatches = msg
@@ -232,7 +246,7 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.form = f
 		m.mode = modeForm
 	case "r":
-		return m, tea.Batch(loadDispatches, collectShip(m.repos))
+		return m, tea.Batch(loadDispatches, trackRefresh(m.cfg))
 	case "enter", "a":
 		if d := m.selected(); d != nil {
 			if !tmux.HasSession(d.TmuxSession) {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -209,6 +209,7 @@ func (m model) detailView(w, h int) string {
 		kv("product", orDash(d.Product), w),
 		kv("tmux", d.TmuxSession, w),
 		kv("session", orDash(sid), w),
+		kv("pr", prLabel(d), w),
 		kv("commits", fmt.Sprintf("%d", len(d.Commits)), w),
 		kv("updated", humanAge(time.Since(d.UpdatedAt))+" ago", w),
 		"",
@@ -232,13 +233,18 @@ func (m model) shipView(w int) string {
 	if s.CollectedAt.IsZero() {
 		return dimStyle.Render("collecting…")
 	}
+	prs := "—"
+	if s.PRsOK {
+		prs = fmt.Sprintf("%d", s.PRsToday)
+	}
 	lines := []string{
 		kv("commits", fmt.Sprintf("%d", s.Commits), w),
 		kv("via dispatch", fmt.Sprintf("%d (%d%%)", s.Dispatched, s.DispatchedPct()), w),
+		kv("prs launched", prs, w),
+		kv("features live", fmt.Sprintf("%d", s.FeaturesLive), w),
 		kv("repos active", fmt.Sprintf("%d of %d", s.ReposActive, s.ReposTotal), w),
 		"",
 		dimStyle.Render(fmt.Sprintf("as of %s · all branches", s.CollectedAt.Format("15:04"))),
-		dimStyle.Render("PRs + deploys: roadmap"),
 	}
 	return strings.Join(lines, "\n")
 }
@@ -295,6 +301,17 @@ func (m model) formView() string {
 
 func kv(k, v string, w int) string {
 	return dimStyle.Render(fmt.Sprintf("%-15s", k)) + truncate(v, max(1, w-15))
+}
+
+func prLabel(d *state.Dispatch) string {
+	if d.PRNumber == 0 {
+		return "—"
+	}
+	label := fmt.Sprintf("#%d %s", d.PRNumber, strings.ToLower(d.PRState))
+	if d.DeployedAt != nil {
+		label += " · live " + humanAge(time.Since(*d.DeployedAt)) + " ago"
+	}
+	return label
 }
 
 func orDash(s string) string {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -209,6 +209,7 @@ func (m model) detailView(w, h int) string {
 		kv("product", orDash(d.Product), w),
 		kv("tmux", d.TmuxSession, w),
 		kv("session", orDash(sid), w),
+		kv("commits", fmt.Sprintf("%d", len(d.Commits)), w),
 		kv("updated", humanAge(time.Since(d.UpdatedAt))+" ago", w),
 		"",
 		dimStyle.Render("prompt"),
@@ -233,7 +234,7 @@ func (m model) shipView(w int) string {
 	}
 	lines := []string{
 		kv("commits", fmt.Sprintf("%d", s.Commits), w),
-		kv("claude-stamped", fmt.Sprintf("%d (%d%%)", s.Stamped, s.StampedPct()), w),
+		kv("via dispatch", fmt.Sprintf("%d (%d%%)", s.Dispatched, s.DispatchedPct()), w),
 		kv("repos active", fmt.Sprintf("%d of %d", s.ReposActive, s.ReposTotal), w),
 		"",
 		dimStyle.Render(fmt.Sprintf("as of %s · all branches", s.CollectedAt.Format("15:04"))),

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/state"
+)
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		w    int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 3, "he…"},
+		{"hello", 1, "…"},
+		{"hello", 0, ""},
+	}
+	for _, c := range cases {
+		if got := truncate(c.in, c.w); got != c.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", c.in, c.w, got, c.want)
+		}
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	cases := map[time.Duration]string{
+		30 * time.Second: "30s",
+		90 * time.Second: "1m",
+		2 * time.Hour:    "2h",
+		72 * time.Hour:   "3d",
+	}
+	for d, want := range cases {
+		if got := humanAge(d); got != want {
+			t.Errorf("humanAge(%v) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+func TestPRLabel(t *testing.T) {
+	if got := prLabel(&state.Dispatch{}); got != "—" {
+		t.Errorf("no PR should render dash, got %q", got)
+	}
+	d := &state.Dispatch{PRNumber: 7, PRState: "MERGED"}
+	if got := prLabel(d); got != "#7 merged" {
+		t.Errorf("prLabel = %q", got)
+	}
+	now := time.Now().Add(-2 * time.Hour)
+	d.DeployedAt = &now
+	if got := prLabel(d); got != "#7 merged · live 2h ago" {
+		t.Errorf("prLabel with deploy = %q", got)
+	}
+}
+
+func TestStatusGlyphCoversAllStatuses(t *testing.T) {
+	for _, s := range []state.Status{
+		state.StatusLaunching, state.StatusWorking, state.StatusNeedsInput,
+		state.StatusBlocked, state.StatusDone, state.StatusExited,
+	} {
+		if statusGlyph(s) == "?" {
+			t.Errorf("no glyph for %s", s)
+		}
+		if statusLabel(s) == "" {
+			t.Errorf("no label for %s", s)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #1. Links each dispatch to its PR by branch name (`gh pr list --head`); when the PR merges, watches the repo's deploy workflow — auto-detected by deploy-ish name or overridden per repo in `[deploy_workflows]` — and flips the feature to done on a successful run ("done means live"). Repos with no deploy workflow count merge itself as live. Auto-done advances while a cockpit is open (tracker runs on the cockpit poll loop).

- `internal/gh`: best-effort gh wrappers (PR by branch, deploy signal, PRs-launched-today via one `gh search`)
- `internal/track`: the reconciler that closes the loop
- shipping strip: PRs launched today, features live today
- detail pane: PR state + live-since

Base is the attribution branch; will retarget to main when that merges.