### PR TITLE
Add CI, lint config, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# Named "CI" on purpose: claude-dispatcher's own deploy detection treats
+# workflows named deploy/release/publish/ship/prod as a live signal, and this
+# repo's checks must never read as a deploy.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go build ./...
+      - run: go test ./... -race -count=1
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: gofmt
+        run: test -z "$(gofmt -l .)" || { gofmt -l .; exit 1; }
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+linters:
+  default: standard
+  settings:
+    errcheck:
+      # Lifecycle-critical paths (the hook, the cockpit loop) deliberately
+      # swallow errors — a failed status write must never disturb a live
+      # Claude session. Those spots use explicit `_ =` assignments instead.
+      check-blank: false
+
+formatters:
+  enable:
+    - gofmt

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 BIN := $(HOME)/.local/bin/claude-dispatcher
 
-.PHONY: build install vet run
+.PHONY: build install vet run test lint check
 
 build:
 	go build ./...
@@ -12,6 +12,15 @@ install:
 
 vet:
 	go vet ./...
+
+test:
+	go test ./... -race -count=1
+
+lint:
+	golangci-lint run
+	@test -z "$$(gofmt -l .)" || { echo "gofmt needed:"; gofmt -l .; exit 1; }
+
+check: build vet lint test
 
 run: install
 	$(BIN)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ an optional `[products]` map (product → repo names) for the roll-up lens.
    them to `events.jsonl`).
 4. Diff pane on ultrawide layouts.
 
+## Development
+
+`make check` runs build, vet, lint (golangci-lint), and the race-enabled
+test suite — the same gates CI runs on every PR. The CI workflow is named
+"CI" deliberately: this tool's own deploy detection treats deploy-ish
+workflow names as a live signal.
+
 ## Troubleshooting
 
 - **Everything stuck on "launching"** — the hook isn't firing. Re-run

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExpandHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+	if got := ExpandHome("~/x"); got != filepath.Join(home, "x") {
+		t.Errorf("ExpandHome(~/x) = %q", got)
+	}
+	if got := ExpandHome("/abs/path"); got != "/abs/path" {
+		t.Errorf("absolute path must pass through, got %q", got)
+	}
+	if got := ExpandHome("~"); got != home {
+		t.Errorf("ExpandHome(~) = %q, want home", got)
+	}
+}
+
+func TestExpandedRootsDedupes(t *testing.T) {
+	c := &Config{Roots: []string{"/a", "/a", "~/b", ""}}
+	got := c.ExpandedRoots()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 roots, got %v", got)
+	}
+	if got[0] != "/a" || !strings.HasSuffix(got[1], "/b") {
+		t.Errorf("unexpected roots %v", got)
+	}
+}
+
+func TestProductFor(t *testing.T) {
+	c := &Config{Products: map[string][]string{
+		"shop": {"shop-api", "shop-web"},
+	}}
+	if got := c.ProductFor("shop-web"); got != "shop" {
+		t.Errorf("ProductFor(shop-web) = %q", got)
+	}
+	if got := c.ProductFor("unrelated"); got != "" {
+		t.Errorf("unmapped repo should be empty, got %q", got)
+	}
+}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -65,7 +65,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	if err := tmux.NewSession(d.TmuxSession, r.Path, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"
-		state.Save(d)
+		_ = state.Save(d)
 		return nil, err
 	}
 	return d, nil

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1,0 +1,46 @@
+package dispatch
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Payment Retry Flow!":   "payment-retry-flow",
+		"--already-sluggy--":    "already-sluggy",
+		"  spaces  every/where": "spaces-every-where",
+		"":                      "",
+		"???":                   "",
+	}
+	for in, want := range cases {
+		if got := Slugify(in); got != want {
+			t.Errorf("Slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestShellQuoteRoundTrip(t *testing.T) {
+	prompts := []string{
+		"plain",
+		"it's got 'quotes' in it",
+		`double "quotes" and $vars and ` + "`backticks`",
+		"multi\nline\nprompt",
+	}
+	for _, p := range prompts {
+		out, err := exec.Command("sh", "-c", "printf %s "+shellQuote(p)).Output()
+		if err != nil {
+			t.Fatalf("sh failed for %q: %v", p, err)
+		}
+		if string(out) != p {
+			t.Errorf("round trip of %q gave %q", p, string(out))
+		}
+	}
+}
+
+func TestSlugifyStripsNonASCII(t *testing.T) {
+	if got := Slugify("héllo wörld"); strings.Contains(got, "é") || strings.Contains(got, "ö") {
+		t.Errorf("expected non-ascii stripped, got %q", got)
+	}
+}

--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -45,7 +45,7 @@ func Run(args []string) int {
 	}
 	raw, _ := io.ReadAll(os.Stdin)
 	var in hookInput
-	json.Unmarshal(raw, &in)
+	_ = json.Unmarshal(raw, &in)
 
 	dispatcherID := os.Getenv("CLAUDE_DISPATCHER_ID")
 	if event != "PostToolUse" { // PostToolUse is too chatty for the log
@@ -66,7 +66,7 @@ func Run(args []string) int {
 		changed = refreshCommits(d) || changed
 	}
 	if changed {
-		state.Save(d)
+		_ = state.Save(d)
 	}
 	return 0
 }

--- a/internal/hookcmd/hookcmd_test.go
+++ b/internal/hookcmd/hookcmd_test.go
@@ -1,0 +1,112 @@
+package hookcmd
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"claude-dispatcher/internal/state"
+)
+
+func TestApplyTransitions(t *testing.T) {
+	cases := []struct {
+		from    state.Status
+		event   string
+		want    state.Status
+		changed bool
+	}{
+		{state.StatusLaunching, "SessionStart", state.StatusWorking, true},
+		{state.StatusNeedsInput, "UserPromptSubmit", state.StatusWorking, true},
+		{state.StatusWorking, "Stop", state.StatusNeedsInput, true},
+		{state.StatusWorking, "Notification:idle_prompt", state.StatusNeedsInput, true},
+		{state.StatusWorking, "Notification:permission_prompt", state.StatusBlocked, true},
+		{state.StatusBlocked, "PostToolUse", state.StatusWorking, true},
+		{state.StatusWorking, "PostToolUse", state.StatusWorking, false},
+		{state.StatusWorking, "SessionEnd", state.StatusExited, true},
+		{state.StatusDone, "Stop", state.StatusDone, false},
+		{state.StatusDone, "SessionEnd", state.StatusDone, false},
+		{state.StatusWorking, "SomeUnknownEvent", state.StatusWorking, false},
+	}
+	for _, c := range cases {
+		d := &state.Dispatch{Status: c.from}
+		changed := apply(d, c.event, hookInput{})
+		if changed != c.changed || d.Status != c.want {
+			t.Errorf("%s + %s: got (%s, changed=%v), want (%s, changed=%v)",
+				c.from, c.event, d.Status, changed, c.want, c.changed)
+		}
+	}
+}
+
+func TestApplySessionStartBindsSession(t *testing.T) {
+	d := &state.Dispatch{Status: state.StatusLaunching}
+	apply(d, "SessionStart", hookInput{SessionID: "s1", TranscriptPath: "/t.jsonl"})
+	if d.SessionID != "s1" || d.TranscriptPath != "/t.jsonl" {
+		t.Errorf("session not bound: %+v", d)
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	bySession := &state.Dispatch{ID: "id1", SessionID: "sess1", Status: state.StatusWorking}
+	launching := &state.Dispatch{ID: "id2", RepoPath: "/repo/two", Status: state.StatusLaunching}
+	for _, d := range []*state.Dispatch{bySession, launching} {
+		if err := state.Save(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if d := resolve("id2", "Stop", hookInput{}); d == nil || d.ID != "id2" {
+		t.Error("env dispatcher id should win")
+	}
+	if d := resolve("", "Stop", hookInput{SessionID: "sess1"}); d == nil || d.ID != "id1" {
+		t.Error("session id should match")
+	}
+	if d := resolve("", "SessionStart", hookInput{Cwd: "/repo/two"}); d == nil || d.ID != "id2" {
+		t.Error("SessionStart should bind launching dispatch by cwd")
+	}
+	if d := resolve("", "Stop", hookInput{Cwd: "/repo/two"}); d != nil {
+		t.Error("cwd binding must be SessionStart-only")
+	}
+	if d := resolve("", "Stop", hookInput{SessionID: "unknown"}); d != nil {
+		t.Error("foreign session should not resolve")
+	}
+}
+
+func TestRefreshCommits(t *testing.T) {
+	repo := t.TempDir()
+	git := func(args ...string) string {
+		t.Helper()
+		full := append([]string{"-C", repo, "-c", "user.email=t@t", "-c", "user.name=t"}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-b", "main")
+	git("commit", "--allow-empty", "-m", "base")
+	base := git("rev-parse", "HEAD")
+	git("checkout", "-b", "feature/f")
+	git("commit", "--allow-empty", "-m", "one")
+	git("commit", "--allow-empty", "-m", "two")
+
+	d := &state.Dispatch{RepoPath: repo, Branch: "feature/f", BaseSHA: base}
+	if !refreshCommits(d) || len(d.Commits) != 2 {
+		t.Fatalf("expected 2 attributed commits, got %d", len(d.Commits))
+	}
+	if refreshCommits(d) {
+		t.Error("unchanged commits should report no change")
+	}
+	if d := (&state.Dispatch{RepoPath: repo, Branch: "feature/f"}); refreshCommits(d) {
+		t.Error("missing BaseSHA must be a no-op")
+	}
+}
+
+func TestSamePath(t *testing.T) {
+	if !samePath("/a/b/../b", "/a/b") {
+		t.Error("cleaned paths should match")
+	}
+	if samePath("/a", "/b") {
+		t.Error("different paths should not match")
+	}
+}

--- a/internal/repos/repos.go
+++ b/internal/repos/repos.go
@@ -34,7 +34,7 @@ func Discover(cfg *config.Config) []Repo {
 	var out []Repo
 	for _, root := range cfg.ExpandedRoots() {
 		root := filepath.Clean(root)
-		filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil || !d.IsDir() {
 				return nil
 			}

--- a/internal/repos/repos_test.go
+++ b/internal/repos/repos_test.go
@@ -1,0 +1,49 @@
+package repos
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"claude-dispatcher/internal/config"
+)
+
+func TestDiscover(t *testing.T) {
+	root := t.TempDir()
+	mk := func(parts ...string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Join(append([]string{root}, parts...)...), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("alpha", ".git")
+	mk("group", "sub", "beta", ".git")
+	mk("alpha", "nested", ".git")      // inside a repo: not descended into
+	mk("node_modules", "dep", ".git")  // skipped dir
+	mk(".hidden", "gamma", ".git")     // hidden dir skipped
+	mk("group", "a", "b", "c", ".git") // beyond maxDepth
+	mk("plain", "not-a-repo")
+
+	cfg := &config.Config{
+		Roots:    []string{root},
+		Products: map[string][]string{"prod": {"alpha"}},
+	}
+	got := Discover(cfg)
+
+	if len(got) != 2 {
+		names := []string{}
+		for _, r := range got {
+			names = append(names, r.Name)
+		}
+		t.Fatalf("expected [alpha beta], got %v", names)
+	}
+	if got[0].Name != "alpha" || got[1].Name != "beta" {
+		t.Errorf("expected sorted [alpha beta], got [%s %s]", got[0].Name, got[1].Name)
+	}
+	if got[0].Product != "prod" {
+		t.Errorf("alpha should map to product 'prod', got %q", got[0].Product)
+	}
+	if got[1].Product != "" {
+		t.Errorf("beta should have no product, got %q", got[1].Product)
+	}
+}

--- a/internal/ship/ship.go
+++ b/internal/ship/ship.go
@@ -10,11 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
 )
 
+// Stats are pure git + dispatch-record numbers; PRsToday/PRsOK are filled in
+// by the caller (the cockpit adds them from gh) so Collect stays hermetic.
 type Stats struct {
 	Commits      int // commits today across all tracked repos (all branches)
 	Dispatched   int // of which were produced under a dispatch
@@ -42,7 +43,6 @@ func Collect(rs []repos.Repo, ds []*state.Dispatch) Stats {
 	}
 
 	stats := Stats{ReposTotal: len(rs), CollectedAt: time.Now()}
-	stats.PRsToday, stats.PRsOK = gh.PRsCreatedToday()
 	today := time.Now().Format("2006-01-02")
 	for _, d := range ds {
 		if d.DeployedAt != nil && d.DeployedAt.Local().Format("2006-01-02") == today {

--- a/internal/ship/ship_test.go
+++ b/internal/ship/ship_test.go
@@ -1,0 +1,74 @@
+package ship
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
+)
+
+func gitRepo(t *testing.T, commits int) (path string, shas []string) {
+	t.Helper()
+	path = t.TempDir()
+	git := func(args ...string) string {
+		full := append([]string{"-C", path, "-c", "user.email=t@t", "-c", "user.name=t"}, args...)
+		out, err := exec.Command("git", full...).CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	git("init", "-b", "main")
+	for i := 0; i < commits; i++ {
+		git("commit", "--allow-empty", "-m", "c")
+		shas = append(shas, git("rev-parse", "HEAD"))
+	}
+	return path, shas
+}
+
+func TestCollectAttributesByProvenance(t *testing.T) {
+	active, shas := gitRepo(t, 3)
+	idle, _ := gitRepo(t, 0) // init'd but no commits
+
+	ds := []*state.Dispatch{{ID: "d1", Commits: shas[:2]}}
+	got := Collect([]repos.Repo{
+		{Name: "active", Path: active},
+		{Name: "idle", Path: idle},
+	}, ds)
+
+	if got.Commits != 3 {
+		t.Errorf("Commits = %d, want 3", got.Commits)
+	}
+	if got.Dispatched != 2 {
+		t.Errorf("Dispatched = %d, want 2", got.Dispatched)
+	}
+	if got.DispatchedPct() != 66 {
+		t.Errorf("DispatchedPct = %d, want 66", got.DispatchedPct())
+	}
+	if got.ReposActive != 1 || got.ReposTotal != 2 {
+		t.Errorf("repos: active=%d total=%d, want 1/2", got.ReposActive, got.ReposTotal)
+	}
+}
+
+func TestCollectCountsFeaturesLiveToday(t *testing.T) {
+	now := time.Now()
+	yesterday := now.Add(-48 * time.Hour)
+	ds := []*state.Dispatch{
+		{ID: "a", DeployedAt: &now},
+		{ID: "b", DeployedAt: &yesterday},
+		{ID: "c"},
+	}
+	got := Collect(nil, ds)
+	if got.FeaturesLive != 1 {
+		t.Errorf("FeaturesLive = %d, want 1", got.FeaturesLive)
+	}
+}
+
+func TestDispatchedPctZeroCommits(t *testing.T) {
+	if (Stats{}).DispatchedPct() != 0 {
+		t.Error("zero commits must not divide by zero")
+	}
+}

--- a/internal/state/helpers_test.go
+++ b/internal/state/helpers_test.go
@@ -1,0 +1,13 @@
+package state
+
+import (
+	"os"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -170,6 +170,6 @@ func AppendEvent(ev Event) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
-	f.Write(append(b, '\n'))
+	defer func() { _ = f.Close() }()
+	_, _ = f.Write(append(b, '\n'))
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,66 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatusPriorityOrdering(t *testing.T) {
+	order := []Status{StatusBlocked, StatusNeedsInput, StatusLaunching,
+		StatusWorking, StatusExited, StatusDone}
+	for i := 1; i < len(order); i++ {
+		if order[i-1].Priority() >= order[i].Priority() {
+			t.Errorf("%s should outrank %s", order[i-1], order[i])
+		}
+	}
+}
+
+func TestSaveLoadAllSortsByUrgency(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	for _, d := range []*Dispatch{
+		{ID: "w", Feature: "working", Status: StatusWorking},
+		{ID: "b", Feature: "blocked", Status: StatusBlocked},
+		{ID: "d", Feature: "done", Status: StatusDone},
+		{ID: "n", Feature: "needs", Status: StatusNeedsInput},
+	} {
+		if err := Save(d); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := LoadAll()
+	if len(got) != 4 {
+		t.Fatalf("expected 4 records, got %d", len(got))
+	}
+	wantOrder := []string{"b", "n", "w", "d"}
+	for i, id := range wantOrder {
+		if got[i].ID != id {
+			t.Errorf("position %d: got %s, want %s", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestSaveStampsUpdatedAt(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	d := &Dispatch{ID: "x", Status: StatusWorking}
+	before := time.Now()
+	if err := Save(d); err != nil {
+		t.Fatal(err)
+	}
+	if d.UpdatedAt.Before(before) {
+		t.Error("UpdatedAt not stamped on save")
+	}
+}
+
+func TestLoadAllSkipsCorruptRecords(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_DISPATCHER_STATE", dir)
+	if err := Save(&Dispatch{ID: "ok", Status: StatusWorking}); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, DispatchesDir()+"/broken.json", "{not json")
+	writeFile(t, DispatchesDir()+"/empty-id.json", "{}")
+	got := LoadAll()
+	if len(got) != 1 || got[0].ID != "ok" {
+		t.Fatalf("expected only the valid record, got %d", len(got))
+	}
+}

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -51,7 +51,7 @@ func Refresh(ds []*state.Dispatch, cfg *config.Config) int {
 			}
 		}
 		if changed {
-			state.Save(d)
+			_ = state.Save(d)
 			updated++
 		}
 	}

--- a/internal/transcript/transcript.go
+++ b/internal/transcript/transcript.go
@@ -38,9 +38,9 @@ func Tail(path string, n int) []string {
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if fi, err := f.Stat(); err == nil && fi.Size() > tailBytes {
-		f.Seek(fi.Size()-tailBytes, io.SeekStart)
+		_, _ = f.Seek(fi.Size()-tailBytes, io.SeekStart)
 	}
 	data, err := io.ReadAll(f)
 	if err != nil {
@@ -58,9 +58,12 @@ func Tail(path string, n int) []string {
 		if json.Unmarshal([]byte(row), &l) != nil || l.Type != "assistant" {
 			continue
 		}
-		for _, s := range renderContent(l.Message.Content) {
+		// Blocks are appended reversed so the final whole-slice flip restores
+		// their in-message order.
+		blocks := renderContent(l.Message.Content)
+		for i := len(blocks) - 1; i >= 0; i-- {
 			if len(out) < n {
-				out = append(out, s)
+				out = append(out, blocks[i])
 			}
 		}
 	}

--- a/internal/transcript/transcript_test.go
+++ b/internal/transcript/transcript_test.go
@@ -1,0 +1,52 @@
+package transcript
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+const fixture = `{"type":"user","message":{"role":"user","content":"ignore me"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"first answer\nwith a second line"}]}}
+this line is garbage, not json
+{"type":"assistant","message":{"role":"assistant","content":"plain string content"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash"},{"type":"text","text":"done"}]}}
+`
+
+func writeFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := os.WriteFile(path, []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestTailOrderAndContent(t *testing.T) {
+	got := Tail(writeFixture(t), 10)
+	want := []string{"first answer", "plain string content", "⚙ Bash", "done"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Tail = %v, want %v", got, want)
+	}
+}
+
+func TestTailLimitKeepsNewest(t *testing.T) {
+	got := Tail(writeFixture(t), 2)
+	want := []string{"⚙ Bash", "done"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Tail(2) = %v, want %v", got, want)
+	}
+}
+
+func TestTailDegradesToNil(t *testing.T) {
+	if Tail("", 5) != nil {
+		t.Error("empty path should be nil")
+	}
+	if Tail("/nonexistent/file.jsonl", 5) != nil {
+		t.Error("missing file should be nil")
+	}
+	if Tail(writeFixture(t), 0) != nil {
+		t.Error("n=0 should be nil")
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -13,6 +13,7 @@ import (
 
 	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/dispatch"
+	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/ship"
 	"claude-dispatcher/internal/state"
@@ -77,7 +78,7 @@ func Run() error {
 	if err == nil {
 		if err := watcher.Add(state.DispatchesDir()); err == nil {
 			go forwardEvents(watcher, stateCh)
-			defer watcher.Close()
+			defer func() { _ = watcher.Close() }()
 		}
 	}
 
@@ -141,14 +142,18 @@ func loadDispatches() tea.Msg {
 		if !tmux.HasSession(d.TmuxSession) {
 			d.Status = state.StatusExited
 			d.StatusReason = "tmux session gone"
-			state.Save(d)
+			_ = state.Save(d)
 		}
 	}
 	return dispatchesMsg(state.LoadAll())
 }
 
 func collectShip(rs []repos.Repo) tea.Cmd {
-	return func() tea.Msg { return shipMsg(ship.Collect(rs, state.LoadAll())) }
+	return func() tea.Msg {
+		s := ship.Collect(rs, state.LoadAll())
+		s.PRsToday, s.PRsOK = gh.PRsCreatedToday()
+		return shipMsg(s)
+	}
 }
 
 func waitState(ch chan struct{}) tea.Cmd {
@@ -261,18 +266,18 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if d := m.selected(); d != nil {
 			d.Status = state.StatusDone
 			d.StatusReason = "marked shipped"
-			state.Save(d)
+			_ = state.Save(d)
 			m.notice = fmt.Sprintf("%q marked shipped", d.Feature)
 			return m, loadDispatches
 		}
 	case "x":
 		if d := m.selected(); d != nil {
-			tmux.KillSession(d.TmuxSession)
+			_ = tmux.KillSession(d.TmuxSession)
 			if d.Status != state.StatusDone {
 				d.Status = state.StatusExited
 				d.StatusReason = "killed from cockpit"
 			}
-			state.Save(d)
+			_ = state.Save(d)
 			m.notice = fmt.Sprintf("killed %q", d.Feature)
 			return m, loadDispatches
 		}

--- a/internal/ui/view_test.go
+++ b/internal/ui/view_test.go
@@ -1,0 +1,70 @@
+package ui
+
+import (
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/state"
+)
+
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		w    int
+		want string
+	}{
+		{"hello", 10, "hello"},
+		{"hello", 5, "hello"},
+		{"hello", 3, "he…"},
+		{"hello", 1, "…"},
+		{"hello", 0, ""},
+	}
+	for _, c := range cases {
+		if got := truncate(c.in, c.w); got != c.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", c.in, c.w, got, c.want)
+		}
+	}
+}
+
+func TestHumanAge(t *testing.T) {
+	cases := map[time.Duration]string{
+		30 * time.Second: "30s",
+		90 * time.Second: "1m",
+		2 * time.Hour:    "2h",
+		72 * time.Hour:   "3d",
+	}
+	for d, want := range cases {
+		if got := humanAge(d); got != want {
+			t.Errorf("humanAge(%v) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+func TestPRLabel(t *testing.T) {
+	if got := prLabel(&state.Dispatch{}); got != "—" {
+		t.Errorf("no PR should render dash, got %q", got)
+	}
+	d := &state.Dispatch{PRNumber: 7, PRState: "MERGED"}
+	if got := prLabel(d); got != "#7 merged" {
+		t.Errorf("prLabel = %q", got)
+	}
+	now := time.Now().Add(-2 * time.Hour)
+	d.DeployedAt = &now
+	if got := prLabel(d); got != "#7 merged · live 2h ago" {
+		t.Errorf("prLabel with deploy = %q", got)
+	}
+}
+
+func TestStatusGlyphCoversAllStatuses(t *testing.T) {
+	for _, s := range []state.Status{
+		state.StatusLaunching, state.StatusWorking, state.StatusNeedsInput,
+		state.StatusBlocked, state.StatusDone, state.StatusExited,
+	} {
+		if statusGlyph(s) == "?" {
+			t.Errorf("no glyph for %s", s)
+		}
+		if statusLabel(s) == "" {
+			t.Errorf("no label for %s", s)
+		}
+	}
+}


### PR DESCRIPTION
Stacked on #2 (will retarget as the stack merges).

- **CI workflow** (`.github/workflows/ci.yml`): build + `go test -race`, gofmt check, golangci-lint. Named "CI" deliberately — this tool's own deploy detection treats deploy/release/publish/ship/prod workflow names as a live signal, so the repo's checks must never read as a deploy.
- **Lint**: `.golangci.yml` (v2, standard set + gofmt). All errcheck findings fixed with explicit `_ =` ignores on the lifecycle paths that must never fail loudly (hook writes, cockpit saves).
- **Tests** (~8 packages): hook state machine + event attribution (env var / session id / cwd binding), provenance commit recording against real temp git repos, shipping stats math, repo discovery rules (depth, hidden/node_modules, no descent into repos), transcript preview parsing incl. malformed lines, config product mapping, slug/shell-quote round-trips, view formatting.
- **Refactor motivated by testability**: `ship.Collect` is now hermetic (pure git + records); the cockpit layers the `gh search` PR count on top. Also fixes tool-use block ordering in the transcript preview.
- `make check` = the same gates locally.