### PR TITLE
Add Homebrew release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+# Named "Release" deliberately: for this repo a release IS the deploy, so
+# claude-dispatcher's own deploy detection correctly treats a successful run
+# as "feature live".
+#
+# Requires the HOMEBREW_TAP_TOKEN secret (fine-grained PAT with contents:write
+# on Innovology/homebrew-tap). Without it the release step is skipped so tag
+# pushes never half-publish.
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - uses: goreleaser/goreleaser-action@v6
+        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+version: 2
+
+project_name: claude-dispatcher
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos: [darwin, linux]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X main.version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+
+checksum:
+  name_template: checksums.txt
+
+changelog:
+  use: github
+
+homebrew_casks:
+  - repository:
+      owner: Innovology
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/Innovology/claude-dispatcher
+    description: Terminal dispatch cockpit for Claude Code sessions across many repositories
+    dependencies:
+      - formula: tmux
+    caveats: |
+      Requires the claude CLI (Claude Code) on your PATH.
+      Run `claude-dispatcher init` to configure repo roots and install the
+      status hook.
+    # Unsigned binary: clear the quarantine attribute so Gatekeeper does not
+    # block first run.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/claude-dispatcher"]
+          end

--- a/README.md
+++ b/README.md
@@ -34,11 +34,28 @@ working, which are done, and — critically — which are blocked waiting on you
 
 ## Install
 
+Via Homebrew:
+
 ```sh
-make install                  # builds to ~/.local/bin/claude-dispatcher
+brew install innovology/tap/claude-dispatcher
 claude-dispatcher init        # config + repo scan + hook install (asks first)
 claude-dispatcher             # open the cockpit
 ```
+
+Or from source:
+
+```sh
+make install                  # builds to ~/.local/bin/claude-dispatcher
+```
+
+Note: the status hook embeds the absolute path of the binary that ran
+`init`. If you switch install methods later, re-run `init` so the hook
+points at the new binary.
+
+Releases are cut by tagging (`git tag v0.x.y && git push --tags`); the
+Release workflow needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with
+contents:write on `Innovology/homebrew-tap`) and skips publishing when the
+secret is absent.
 
 Config lives at `~/.config/claude-dispatcher/config.toml`: scan `roots` and
 an optional `[products]` map (product → repo names) for the roll-up lens.

--- a/main.go
+++ b/main.go
@@ -15,12 +15,16 @@ import (
 	"claude-dispatcher/internal/ui"
 )
 
+// version is stamped by the release build via -ldflags.
+var version = "dev"
+
 const usage = `claude-dispatcher — dispatch cockpit for Claude Code sessions
 
 Usage:
   claude-dispatcher            open the cockpit
   claude-dispatcher init       write config, discover repos, install the status hook
   claude-dispatcher hook <ev>  (internal) invoked by Claude Code lifecycle hooks
+  claude-dispatcher version    print the version
   claude-dispatcher help       show this help
 `
 
@@ -42,6 +46,8 @@ func main() {
 	case "hook":
 		// Never fail loudly: a hook error must not disturb the Claude session.
 		os.Exit(hookcmd.Run(args[1:]))
+	case "version", "--version", "-v":
+		fmt.Println("claude-dispatcher", version)
 	case "help", "-h", "--help":
 		fmt.Print(usage)
 	default:


### PR DESCRIPTION
- `version` subcommand, stamped by GoReleaser via `-ldflags -X main.version`
- `.goreleaser.yml`: darwin/linux × amd64/arm64, publishes a Homebrew cask (the current GoReleaser path — `brews` is deprecated) to `Innovology/homebrew-tap`, with tmux as a formula dependency and a quarantine-clearing post-install hook for the unsigned binary
- `Release` workflow on `v*` tags — named "Release" deliberately: for this repo a release IS the deploy, so the tool's own deploy detection treats a successful run as "feature live", which is correct here. The GoReleaser step is skipped when `HOMEBREW_TAP_TOKEN` is absent so a tag push never half-publishes
- README: brew install instructions + release/runbook notes

v0.1.0 will be cut locally (no tap token secret exists yet); future releases automate once a fine-grained PAT with contents:write on the tap repo is added as `HOMEBREW_TAP_TOKEN`.