### PR TITLE
Hold working status while background tasks are in flight

### DIFF
--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -5,10 +5,16 @@
 //	SessionStart                   -> working (binds session_id/transcript)
 //	UserPromptSubmit               -> working
 //	PostToolUse                    -> working, only to clear "blocked"
-//	Stop                           -> needs-input (turn complete)
-//	Notification:idle_prompt       -> needs-input
+//	Stop                           -> needs-input (turn complete), or working
+//	                                  if background tasks are still in flight
+//	Notification:idle_prompt       -> needs-input (unless waiting on tasks)
 //	Notification:permission_prompt -> blocked
 //	SessionEnd                     -> exited (unless already done)
+//
+// A Stop with a non-empty background_tasks payload means the session is
+// paused waiting for background work to wake it, not waiting on the human;
+// the idle_prompt payload carries no task info, so the Stop's verdict is
+// persisted (WaitingOnTasks) and idle_prompt defers to it.
 //
 // Events are attributed to a dispatch by, in order: the CLAUDE_DISPATCHER_ID
 // env var (set at launch, inherited through tmux -> claude -> hook), the
@@ -21,6 +27,7 @@ package hookcmd
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -36,6 +43,9 @@ type hookInput struct {
 	TranscriptPath string `json:"transcript_path"`
 	Cwd            string `json:"cwd"`
 	HookEventName  string `json:"hook_event_name"`
+	// Stop/SubagentStop only; item shape is Claude Code's business — only the
+	// count matters here.
+	BackgroundTasks []json.RawMessage `json:"background_tasks"`
 }
 
 func Run(args []string) int {
@@ -136,9 +146,11 @@ func apply(d *state.Dispatch, event string, in hookInput) bool {
 		}
 		d.Status = state.StatusWorking
 		d.StatusReason = "session started"
+		d.WaitingOnTasks = false
 	case "UserPromptSubmit":
 		d.Status = state.StatusWorking
 		d.StatusReason = "processing your prompt"
+		d.WaitingOnTasks = false
 	case "PostToolUse":
 		// A tool completing means any permission prompt was approved.
 		if d.Status != state.StatusBlocked {
@@ -147,9 +159,19 @@ func apply(d *state.Dispatch, event string, in hookInput) bool {
 		d.Status = state.StatusWorking
 		d.StatusReason = "permission approved, working"
 	case "Stop":
+		d.WaitingOnTasks = len(in.BackgroundTasks) > 0
+		if d.WaitingOnTasks {
+			d.Status = state.StatusWorking
+			d.StatusReason = fmt.Sprintf("waiting on %d background %s",
+				len(in.BackgroundTasks), plural(len(in.BackgroundTasks), "task"))
+			break
+		}
 		d.Status = state.StatusNeedsInput
 		d.StatusReason = "turn complete — waiting on you"
 	case "Notification:idle_prompt":
+		if d.WaitingOnTasks {
+			return false // paused on background work, not on the human
+		}
 		d.Status = state.StatusNeedsInput
 		d.StatusReason = "waiting for your next prompt"
 	case "Notification:permission_prompt":
@@ -162,6 +184,13 @@ func apply(d *state.Dispatch, event string, in hookInput) bool {
 		return false
 	}
 	return true
+}
+
+func plural(n int, word string) string {
+	if n == 1 {
+		return word
+	}
+	return word + "s"
 }
 
 func samePath(a, b string) bool {

--- a/internal/hookcmd/hookcmd_test.go
+++ b/internal/hookcmd/hookcmd_test.go
@@ -1,6 +1,7 @@
 package hookcmd
 
 import (
+	"encoding/json"
 	"os/exec"
 	"strings"
 	"testing"
@@ -34,6 +35,52 @@ func TestApplyTransitions(t *testing.T) {
 			t.Errorf("%s + %s: got (%s, changed=%v), want (%s, changed=%v)",
 				c.from, c.event, d.Status, changed, c.want, c.changed)
 		}
+	}
+}
+
+// A Stop with in-flight background tasks means the session is paused waiting
+// to be woken, not waiting on the human — and the later idle_prompt (which
+// carries no task info) must not undo that verdict.
+func TestApplyBackgroundTaskWait(t *testing.T) {
+	tasks := []json.RawMessage{json.RawMessage(`{"task_id":"t1"}`), json.RawMessage(`{"task_id":"t2"}`)}
+	d := &state.Dispatch{Status: state.StatusWorking}
+
+	if !apply(d, "Stop", hookInput{BackgroundTasks: tasks}) {
+		t.Fatal("Stop with pending tasks should report a change")
+	}
+	if d.Status != state.StatusWorking || !d.WaitingOnTasks {
+		t.Fatalf("want working+waiting, got %s waiting=%v", d.Status, d.WaitingOnTasks)
+	}
+	if d.StatusReason != "waiting on 2 background tasks" {
+		t.Errorf("unexpected reason %q", d.StatusReason)
+	}
+
+	if apply(d, "Notification:idle_prompt", hookInput{}) {
+		t.Error("idle_prompt must not downgrade a task-waiting dispatch")
+	}
+	if d.Status != state.StatusWorking {
+		t.Errorf("status downgraded to %s", d.Status)
+	}
+
+	// Background work done, session woke, ran, and stopped for real.
+	if !apply(d, "Stop", hookInput{}) {
+		t.Fatal("plain Stop should report a change")
+	}
+	if d.Status != state.StatusNeedsInput || d.WaitingOnTasks {
+		t.Fatalf("want needs-input+cleared, got %s waiting=%v", d.Status, d.WaitingOnTasks)
+	}
+}
+
+func TestApplyUserPromptClearsTaskWait(t *testing.T) {
+	d := &state.Dispatch{Status: state.StatusWorking, WaitingOnTasks: true}
+	apply(d, "UserPromptSubmit", hookInput{})
+	if d.WaitingOnTasks {
+		t.Error("UserPromptSubmit should clear WaitingOnTasks")
+	}
+	d = &state.Dispatch{Status: state.StatusLaunching, WaitingOnTasks: true}
+	apply(d, "SessionStart", hookInput{})
+	if d.WaitingOnTasks {
+		t.Error("SessionStart should clear WaitingOnTasks")
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -75,6 +75,11 @@ type Dispatch struct {
 	DeployedAt   *time.Time `json:"deployed_at,omitempty"`
 	Status       Status     `json:"status"`
 	StatusReason string     `json:"status_reason,omitempty"`
+	// WaitingOnTasks records that the last Stop event carried in-flight
+	// background tasks: the session is paused, not waiting on the human, and
+	// will wake itself. Guards against a later idle_prompt notification (whose
+	// payload has no task info) downgrading the status to needs-input.
+	WaitingOnTasks bool `json:"waiting_on_tasks,omitempty"`
 	CreatedAt    time.Time  `json:"created_at"`
 	UpdatedAt    time.Time  `json:"updated_at"`
 }


### PR DESCRIPTION
A dispatch whose session paused for a background task showed **needs-input** ("waiting on you") even though nothing was waiting on the human — the session wakes itself when the task finishes.

Root cause: the hook mapped every `Stop` to needs-input and discarded the rest of the payload. Claude Code's `Stop` input carries a `background_tasks` array precisely to distinguish "session is done" from "session is paused waiting for background work to wake it" (verified in the installed 2.1.220 binary's hook schema).

- Parse `background_tasks` in `hookInput`; a non-empty array keeps the dispatch **working** ("waiting on N background tasks").
- Persist the verdict as `WaitingOnTasks` on the record: the `idle_prompt` notification ~60s later carries no task info, so it now defers to the last Stop's verdict instead of downgrading. The flag is recomputed on every Stop and cleared on SessionStart/UserPromptSubmit, so it cannot go stale.
- Full-cycle test (Stop-with-tasks → idle_prompt ignored → clean Stop → needs-input) plus flag-clearing cases; verified end-to-end by piping real-shaped payloads through `claude-dispatcher hook` against a scratch state dir.

Out of scope by design: sessions sleeping on `session_crons` (/loop, scheduled wakeups) still read needs-input — neither working nor waiting-on-human, deserves its own treatment.
