### PR TITLE
Release on merge, and fix the workflow that never ran

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,34 +2,96 @@
 # claude-dispatcher's own deploy detection correctly treats a successful run
 # as "feature live".
 #
+# Two triggers:
+#   - push to main (a folded PR): auto-tags the next patch version and
+#     publishes. Put "release: minor" or "release: major" in the merge commit
+#     message for a bigger bump, or "[skip release]" to not release. Merges
+#     touching only docs/meta files (paths-ignore below) skip automatically;
+#     path filters are not evaluated for tag pushes, so the escape hatch is
+#     unaffected.
+#   - pushing a v* tag by hand remains the manual escape hatch.
+#
 # Requires the HOMEBREW_TAP_TOKEN secret (fine-grained PAT with contents:write
-# on Innovology/homebrew-tap). Without it the release step is skipped so tag
-# pushes never half-publish.
+# on Innovology/homebrew-tap). Without it nothing is tagged or published, so
+# merges and tag pushes never half-release.
 name: Release
 
 on:
   push:
     tags: ["v*"]
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - LICENSE
+      - .gitignore
+      - .github/**
 
 permissions:
   contents: write
 
+# Serialize runs so two quick merges cannot compute the same next version.
+concurrency:
+  group: release
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    # The `secrets` context is NOT available in `if:` expressions — putting it
+    # there makes the whole workflow file invalid, which is why every release
+    # run before this failed in 0s. Map it into env once and gate on that.
+    env:
+      HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Check tap token
+        id: gate
+        run: |
+          if [ -n "${HOMEBREW_TAP_TOKEN:-}" ]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "HOMEBREW_TAP_TOKEN is not set — skipping tag and publish." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Tag next version
+        id: autotag
+        if: ${{ github.ref_type == 'branch' && steps.gate.outputs.ok == 'true' }}
+        run: |
+          set -euo pipefail
+          msg="$(git log -1 --pretty=%B)"
+          if grep -qiF '[skip release]' <<<"$msg"; then
+            echo "merge commit says [skip release] — not releasing"
+            exit 0
+          fi
+          latest="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
+          latest="${latest:-v0.0.0}"
+          if [ "$(git rev-list -n 1 "$latest" 2>/dev/null || true)" = "$(git rev-parse HEAD)" ]; then
+            echo "HEAD is already tagged $latest — nothing to release"
+            exit 0
+          fi
+          IFS=. read -r major minor patch <<<"${latest#v}"
+          if grep -qiE 'release: *major' <<<"$msg"; then
+            major=$((major + 1)); minor=0; patch=0
+          elif grep -qiE 'release: *minor' <<<"$msg"; then
+            minor=$((minor + 1)); patch=0
+          else
+            patch=$((patch + 1))
+          fi
+          next="v$major.$minor.$patch"
+          echo "tagging $next (previous: $latest)"
+          git tag "$next"
+          git push origin "$next"
+          echo "tag=$next" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-go@v5
         with:
           go-version: stable
       - uses: goreleaser/goreleaser-action@v6
-        if: ${{ secrets.HOMEBREW_TAP_TOKEN != '' }}
+        if: ${{ steps.gate.outputs.ok == 'true' && (github.ref_type == 'tag' || steps.autotag.outputs.tag != '') }}
         with:
           distribution: goreleaser
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,10 @@ builds:
       - CGO_ENABLED=0
     goos: [darwin, linux]
     goarch: [amd64, arm64]
+    # -trimpath keeps builder filesystem paths (home dir, module cache) out
+    # of the shipped binaries.
+    flags:
+      - -trimpath
     ldflags:
       - -s -w -X main.version={{.Version}}
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@ Note: the status hook embeds the absolute path of the binary that ran
 `init`. If you switch install methods later, re-run `init` so the hook
 points at the new binary.
 
-Releases are cut by tagging (`git tag v0.x.y && git push --tags`); the
-Release workflow needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained PAT with
-contents:write on `Innovology/homebrew-tap`) and skips publishing when the
-secret is absent.
+Releases are cut automatically: folding a PR into main makes the Release
+workflow tag the next patch version and publish the tarballs + Homebrew cask.
+Put `release: minor` or `release: major` in the merge commit message for a
+bigger bump, or `[skip release]` to merge without releasing; merges touching
+only docs/meta files (`*.md`, `LICENSE`, `.gitignore`, `.github/`) skip on
+their own. Manual tagging (`git tag v0.x.y && git push --tags`) remains the
+escape hatch. The workflow needs a `HOMEBREW_TAP_TOKEN` secret (fine-grained
+PAT with contents:write on `Innovology/homebrew-tap`) and neither tags nor
+publishes when the secret is absent.
 
 Config lives at `~/.config/claude-dispatcher/config.toml`: scan `roots` and
 an optional `[products]` map (product → repo names) for the roll-up lens.


### PR DESCRIPTION
The Release workflow gated its steps on `secrets.HOMEBREW_TAP_TOKEN != ''''`. The `secrets` context is **not available in `if:` expressions**, so the workflow file was invalid and every release run since the pipeline landed failed in 0s ("This run likely failed because of a workflow file issue").

That is the root cause of a leak found separately: because CI releases never ran, v0.1.0 and v0.1.1 were published by hand from a laptop, and both embed `/Users/<user>/...` build paths in the shipped binaries.

## Changes

- **Fix the gate.** Map `HOMEBREW_TAP_TOKEN` into job-level `env` once, and gate steps on a `steps.gate.outputs.ok` step output. Valid, and still fails closed: no token means nothing is tagged and nothing is published.
- **Release on merge.** A push to `main` auto-tags the next patch version and publishes tarballs + the Homebrew cask. `release: minor` / `release: major` in the merge commit bumps wider; `[skip release]` opts out; docs/meta-only merges skip via `paths-ignore`. Manual tag pushes remain the escape hatch (path filters are not evaluated for tags).
- **Guards.** `concurrency: release` serialises runs so two quick merges cannot compute the same version; an already-tagged HEAD short-circuits; goreleaser runs in the same job as the tag (a tag pushed with `GITHUB_TOKEN` does not re-trigger workflows, so tag-then-wait would silently do nothing).
- **`-trimpath`** on the goreleaser build, so builder paths stay out of binaries wherever a release is cut.

## Verification

- Bump logic simulated against six cases: patch default, `release: minor`, `release: major`, `[skip release]`, already-tagged HEAD, and no tags at all. Version sort verified so `v0.10.x` beats `v0.9.x`.
- `goreleaser check` passes; workflow YAML parses.

## Follow-up that only you can do

`HOMEBREW_TAP_TOKEN` **does not currently exist** on this repo (`actions/secrets` returns `total_count: 0`). Until it is added as a fine-grained PAT with contents:write on `Innovology/homebrew-tap`, merges will skip tagging and publishing by design — the pipeline starts working the moment the secret lands.