### PR TITLE
Configure repo scan roots from the cockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,16 @@ secret is absent.
 
 Config lives at `~/.config/claude-dispatcher/config.toml`: scan `roots` and
 an optional `[products]` map (product → repo names) for the roll-up lens.
+Opening the cockpit with no config drops you into a first-run settings view
+to pick the scan roots; press `s` in the cockpit any time to edit them
+(`init` is still what installs the status hook).
 
 ## Keys
 
 | key | action |
 |---|---|
 | `n` | dispatch: pick repo → name feature → write prompt (`ctrl+d` to launch) |
+| `s` | settings: edit the repo scan roots (add/remove, saves config.toml) |
 | `enter` / `a` | attach to the selected dispatcher's tmux session |
 | `Ctrl-\` (inside a session) | detach, back to the cockpit (`Ctrl-b d` also works) |
 | `d` | mark shipped (done means live — manual until Actions integration) |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,8 +4,11 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -75,25 +78,63 @@ func ExpandHome(p string) string {
 	return p
 }
 
-const defaultConfig = `# Claude Dispatcher configuration.
+// DefaultRoot suggests a scan root: the parent of the working directory
+// (running from inside one repo usually means its siblings are repos too),
+// falling back to ~.
+func DefaultRoot() string {
+	if wd, err := os.Getwd(); err == nil {
+		return filepath.Dir(wd)
+	}
+	return "~"
+}
 
-# Directories scanned (up to 3 levels deep) for git repositories.
-roots = [%q]
+// Save writes the config file, regenerating the commented template around the
+// current values so the file stays self-documenting after edits from the
+// cockpit settings view.
+func Save(c *Config) error {
+	if err := os.MkdirAll(Dir(), 0o755); err != nil {
+		return err
+	}
+	var b strings.Builder
+	b.WriteString("# Claude Dispatcher configuration.\n\n")
+	b.WriteString("# Directories scanned (up to 3 levels deep) for git repositories.\n")
+	b.WriteString("# Editable from the cockpit: press s.\n")
+	b.WriteString("roots = " + tomlStrings(c.Roots) + "\n\n")
+	b.WriteString("# Map product names to repo directory names for the portfolio roll-up.\n")
+	b.WriteString("# acme-shop = [\"shop-api\", \"shop-web\"]\n")
+	b.WriteString("[products]\n")
+	for _, k := range slices.Sorted(maps.Keys(c.Products)) {
+		b.WriteString(tomlKey(k) + " = " + tomlStrings(c.Products[k]) + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString("# Per-repo deploy workflow override (\"done means live\" watches this workflow\n")
+	b.WriteString("# succeed after a feature's PR merges). Unlisted repos auto-detect the first\n")
+	b.WriteString("# workflow named like deploy/release/publish/ship/prod; repos with no deploy\n")
+	b.WriteString("# workflow count merge itself as live.\n")
+	b.WriteString("# shop-api = \"Deploy production\"\n")
+	b.WriteString("[deploy_workflows]\n")
+	for _, k := range slices.Sorted(maps.Keys(c.DeployWorkflows)) {
+		fmt.Fprintf(&b, "%s = %q\n", tomlKey(k), c.DeployWorkflows[k])
+	}
+	return os.WriteFile(Path(), []byte(b.String()), 0o644)
+}
 
-# Map product names to repo directory names for the portfolio roll-up.
-# [products]
-# acme-shop = ["shop-api", "shop-web"]
-# side-thing = ["side-thing"]
-[products]
+var bareKeyRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
 
-# Per-repo deploy workflow override ("done means live" watches this workflow
-# succeed after a feature's PR merges). Unlisted repos auto-detect the first
-# workflow named like deploy/release/publish/ship/prod; repos with no deploy
-# workflow count merge itself as live.
-# [deploy_workflows]
-# shop-api = "Deploy production"
-[deploy_workflows]
-`
+func tomlKey(k string) string {
+	if bareKeyRe.MatchString(k) {
+		return k
+	}
+	return fmt.Sprintf("%q", k)
+}
+
+func tomlStrings(vals []string) string {
+	quoted := make([]string, len(vals))
+	for i, v := range vals {
+		quoted[i] = fmt.Sprintf("%q", v)
+	}
+	return "[" + strings.Join(quoted, ", ") + "]"
+}
 
 // WriteDefault creates the config file if absent, defaulting the scan root to
 // the parent directory of the current working directory (or ~).
@@ -102,15 +143,7 @@ func WriteDefault() (string, bool, error) {
 	if _, err := os.Stat(path); err == nil {
 		return path, false, nil
 	}
-	root := "~"
-	if wd, err := os.Getwd(); err == nil {
-		root = filepath.Dir(wd)
-	}
-	if err := os.MkdirAll(Dir(), 0o755); err != nil {
-		return path, false, err
-	}
-	content := fmt.Sprintf(defaultConfig, root)
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := Save(&Config{Roots: []string{DefaultRoot()}}); err != nil {
 		return path, false, err
 	}
 	return path, true, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -28,6 +29,55 @@ func TestExpandedRootsDedupes(t *testing.T) {
 	}
 	if got[0] != "/a" || !strings.HasSuffix(got[1], "/b") {
 		t.Errorf("unexpected roots %v", got)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	in := &Config{
+		Roots: []string{"~/repos", "/work/other"},
+		Products: map[string][]string{
+			"acme shop": {"shop-api", "shop-web"},
+		},
+		DeployWorkflows: map[string]string{
+			"shop-api": "Deploy production",
+		},
+	}
+	if err := Save(in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(out.Roots, in.Roots) {
+		t.Errorf("roots = %v, want %v", out.Roots, in.Roots)
+	}
+	if !slices.Equal(out.Products["acme shop"], in.Products["acme shop"]) {
+		t.Errorf("products = %v, want %v", out.Products, in.Products)
+	}
+	if out.DeployWorkflows["shop-api"] != "Deploy production" {
+		t.Errorf("deploy_workflows = %v", out.DeployWorkflows)
+	}
+}
+
+func TestWriteDefaultDoesNotOverwrite(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if _, created, err := WriteDefault(); err != nil || !created {
+		t.Fatalf("first WriteDefault: created=%v err=%v", created, err)
+	}
+	if err := Save(&Config{Roots: []string{"/custom"}}); err != nil {
+		t.Fatal(err)
+	}
+	if _, created, err := WriteDefault(); err != nil || created {
+		t.Fatalf("second WriteDefault must be a no-op: created=%v err=%v", created, err)
+	}
+	cfg, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(cfg.Roots, []string{"/custom"}) {
+		t.Errorf("roots clobbered: %v", cfg.Roots)
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -6,6 +6,7 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"io/fs"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -26,6 +27,7 @@ type mode int
 const (
 	modeList mode = iota
 	modeForm
+	modeSettings
 )
 
 const (
@@ -42,6 +44,7 @@ type model struct {
 	cursor        int
 	mode          mode
 	form          *form
+	settings      *settings
 	ship          ship.Stats
 	stateCh       chan struct{}
 	notice        string
@@ -62,9 +65,16 @@ type (
 )
 
 func Run() error {
+	firstRun := false
 	cfg, err := config.Load()
 	if err != nil {
-		return errors.New("no config found — run `claude-dispatcher init` first")
+		if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("reading %s: %w", config.Path(), err)
+		}
+		// No config yet: open straight into the settings view so the first
+		// launch configures scan roots instead of bouncing to `init`.
+		firstRun = true
+		cfg = &config.Config{}
 	}
 	if !tmux.Available() {
 		return errors.New("tmux not found on PATH — it is required")
@@ -87,6 +97,10 @@ func Run() error {
 		cfg:     cfg,
 		repos:   repos.Discover(cfg),
 		stateCh: stateCh,
+	}
+	if firstRun {
+		m.mode = modeSettings
+		m.settings = newSettings([]string{config.DefaultRoot()}, true)
 	}
 	_, err = tea.NewProgram(m, tea.WithAltScreen()).Run()
 	return err
@@ -113,14 +127,18 @@ func forwardEvents(w *fsnotify.Watcher, ch chan struct{}) {
 }
 
 func (m model) Init() tea.Cmd {
-	return tea.Batch(
+	cmds := []tea.Cmd{
 		loadDispatches,
 		collectShip(m.repos),
 		trackRefresh(m.cfg),
 		waitState(m.stateCh),
 		tick(),
 		shipTick(),
-	)
+	}
+	if m.settings != nil {
+		cmds = append(cmds, countRoots(m.settings.roots))
+	}
+	return tea.Batch(cmds...)
 }
 
 // trackRefresh polls PR/deploy state and persists changes; the fsnotify
@@ -183,6 +201,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.form != nil {
 			m.form.resize(m.width, m.height)
 		}
+		if m.settings != nil {
+			m.settings.resize(m.width, m.height)
+		}
+		return m, nil
+
+	case rootCountsMsg:
+		if m.settings != nil {
+			for root, n := range msg {
+				m.settings.counts[root] = n
+			}
+		}
 		return m, nil
 
 	case stateChangedMsg:
@@ -225,8 +254,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, loadDispatches
 
 	case tea.KeyMsg:
-		if m.mode == modeForm {
+		switch m.mode {
+		case modeForm:
 			return m.updateForm(msg)
+		case modeSettings:
+			return m.updateSettings(msg)
 		}
 		return m.updateList(msg)
 	}
@@ -251,6 +283,12 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		f.resize(m.width, m.height)
 		m.form = f
 		m.mode = modeForm
+	case "s":
+		s := newSettings(m.cfg.Roots, false)
+		s.resize(m.width, m.height)
+		m.settings = s
+		m.mode = modeSettings
+		return m, countRoots(s.roots)
 	case "r":
 		return m, tea.Batch(loadDispatches, trackRefresh(m.cfg))
 	case "enter", "a":
@@ -291,6 +329,35 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selectedID = d.ID
 	}
 	return m, nil
+}
+
+func (m model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	done, cmd := m.settings.update(msg)
+	switch done {
+	case settingsCancelled:
+		if m.settings.firstRun {
+			// Nothing to fall back to without a config — leave the cockpit.
+			return m, tea.Quit
+		}
+		m.mode = modeList
+		m.settings = nil
+		return m, nil
+	case settingsSaved:
+		m.cfg.Roots = m.settings.roots
+		if err := config.Save(m.cfg); err != nil {
+			m.settings.errMsg = "save failed: " + err.Error()
+			return m, nil
+		}
+		m.repos = repos.Discover(m.cfg)
+		m.mode = modeList
+		m.notice = fmt.Sprintf("config saved — %d repos discovered", len(m.repos))
+		if m.settings.firstRun {
+			m.notice += " · run `claude-dispatcher init` to install the status hook"
+		}
+		m.settings = nil
+		return m, collectShip(m.repos)
+	}
+	return m, cmd
 }
 
 func (m model) updateForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -132,7 +132,7 @@ func (f *form) updateRepoStep(msg tea.KeyMsg) (formResult, tea.Cmd) {
 		return formActive, nil
 	case "enter":
 		if len(visible) == 0 {
-			f.errMsg = "no repo matches — check roots in config"
+			f.errMsg = "no repo matches — esc then s to edit scan roots"
 			return formActive, nil
 		}
 		f.cursor = min(f.cursor, len(visible)-1)

--- a/internal/ui/settings.go
+++ b/internal/ui/settings.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"os"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/repos"
+)
+
+// settings edits the repo scan roots. It opens on first run (no config yet)
+// and any time via `s`; saving rewrites config.toml and re-runs discovery.
+type settingsResult int
+
+const (
+	settingsActive settingsResult = iota
+	settingsCancelled
+	settingsSaved
+)
+
+type settings struct {
+	roots    []string
+	cursor   int
+	adding   bool
+	input    textinput.Model
+	firstRun bool
+	errMsg   string
+	// counts maps a root (as typed) to how many repos discovery finds under
+	// it; -1 while a recount is in flight.
+	counts map[string]int
+}
+
+type rootCountsMsg map[string]int
+
+func newSettings(roots []string, firstRun bool) *settings {
+	input := textinput.New()
+	input.Placeholder = "~/path/to/your/repos"
+	input.CharLimit = 200
+	s := &settings{
+		roots:    append([]string(nil), roots...),
+		firstRun: firstRun,
+		input:    input,
+		counts:   map[string]int{},
+	}
+	for _, r := range s.roots {
+		s.counts[r] = -1
+	}
+	return s
+}
+
+func (s *settings) resize(width, _ int) {
+	s.input.Width = min(width-8, 100)
+}
+
+// countRoots discovers each root independently so the settings view can show
+// per-root repo counts.
+func countRoots(roots []string) tea.Cmd {
+	rs := append([]string(nil), roots...)
+	return func() tea.Msg {
+		counts := map[string]int{}
+		for _, r := range rs {
+			counts[r] = len(repos.Discover(&config.Config{Roots: []string{r}}))
+		}
+		return rootCountsMsg(counts)
+	}
+}
+
+func (s *settings) update(msg tea.KeyMsg) (settingsResult, tea.Cmd) {
+	s.errMsg = ""
+	if s.adding {
+		return s.updateAdding(msg)
+	}
+	switch msg.String() {
+	case "esc", "q":
+		return settingsCancelled, nil
+	case "up", "k":
+		if s.cursor > 0 {
+			s.cursor--
+		}
+	case "down", "j":
+		if s.cursor < len(s.roots)-1 {
+			s.cursor++
+		}
+	case "a", "n":
+		s.adding = true
+		return settingsActive, s.input.Focus()
+	case "x", "d", "backspace":
+		if len(s.roots) > 0 {
+			s.roots = append(s.roots[:s.cursor], s.roots[s.cursor+1:]...)
+			s.cursor = min(s.cursor, max(0, len(s.roots)-1))
+		}
+	case "enter":
+		if len(s.roots) == 0 {
+			s.errMsg = "at least one root is required — press a to add one"
+			return settingsActive, nil
+		}
+		return settingsSaved, nil
+	}
+	return settingsActive, nil
+}
+
+func (s *settings) updateAdding(msg tea.KeyMsg) (settingsResult, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		s.adding = false
+		s.input.Reset()
+		s.input.Blur()
+		return settingsActive, nil
+	case "enter":
+		root := strings.TrimSpace(s.input.Value())
+		if root == "" {
+			s.errMsg = "enter a directory path"
+			return settingsActive, nil
+		}
+		if info, err := os.Stat(config.ExpandHome(root)); err != nil || !info.IsDir() {
+			s.errMsg = "not a directory: " + root
+			return settingsActive, nil
+		}
+		for _, r := range s.roots {
+			if r == root {
+				s.errMsg = "already listed: " + root
+				return settingsActive, nil
+			}
+		}
+		s.roots = append(s.roots, root)
+		s.counts[root] = -1
+		s.cursor = len(s.roots) - 1
+		s.adding = false
+		s.input.Reset()
+		s.input.Blur()
+		return settingsActive, countRoots(s.roots)
+	}
+	var cmd tea.Cmd
+	s.input, cmd = s.input.Update(msg)
+	return settingsActive, cmd
+}

--- a/internal/ui/settings_test.go
+++ b/internal/ui/settings_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func key(s string) tea.KeyMsg {
+	switch s {
+	case "enter":
+		return tea.KeyMsg{Type: tea.KeyEnter}
+	case "esc":
+		return tea.KeyMsg{Type: tea.KeyEsc}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func TestSettingsAddRoot(t *testing.T) {
+	dir := t.TempDir()
+	s := newSettings(nil, false)
+	if res, _ := s.update(key("a")); res != settingsActive || !s.adding {
+		t.Fatal("a must open the add input")
+	}
+	s.update(key(dir))
+	if res, _ := s.update(key("enter")); res != settingsActive {
+		t.Fatal("adding a root must not close settings")
+	}
+	if s.adding || len(s.roots) != 1 || s.roots[0] != dir {
+		t.Fatalf("root not added: adding=%v roots=%v", s.adding, s.roots)
+	}
+}
+
+func TestSettingsRejectsMissingDir(t *testing.T) {
+	s := newSettings(nil, false)
+	s.update(key("a"))
+	s.update(key("/does/not/exist-anywhere"))
+	s.update(key("enter"))
+	if len(s.roots) != 0 || s.errMsg == "" {
+		t.Fatalf("nonexistent dir must be rejected: roots=%v err=%q", s.roots, s.errMsg)
+	}
+}
+
+func TestSettingsRejectsDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	s := newSettings([]string{dir}, false)
+	s.update(key("a"))
+	s.update(key(dir))
+	s.update(key("enter"))
+	if len(s.roots) != 1 || s.errMsg == "" {
+		t.Fatalf("duplicate root must be rejected: roots=%v err=%q", s.roots, s.errMsg)
+	}
+}
+
+func TestSettingsSaveRequiresRoot(t *testing.T) {
+	s := newSettings([]string{"/a"}, false)
+	s.update(key("x"))
+	if len(s.roots) != 0 {
+		t.Fatalf("x must remove the selected root, got %v", s.roots)
+	}
+	if res, _ := s.update(key("enter")); res != settingsActive || s.errMsg == "" {
+		t.Fatal("saving with no roots must be refused")
+	}
+}
+
+func TestSettingsSaveAndCancel(t *testing.T) {
+	s := newSettings([]string{"/a", "/b"}, false)
+	if res, _ := s.update(key("enter")); res != settingsSaved {
+		t.Fatal("enter with roots must save")
+	}
+	if res, _ := s.update(key("esc")); res != settingsCancelled {
+		t.Fatal("esc must cancel")
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -2,11 +2,13 @@ package ui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
+	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/state"
 	"claude-dispatcher/internal/transcript"
 )
@@ -75,9 +77,12 @@ func (m model) View() string {
 	footer := m.footerView()
 	bodyH := m.height - lipgloss.Height(header) - lipgloss.Height(footer)
 	var body string
-	if m.mode == modeForm && m.form != nil {
+	switch {
+	case m.mode == modeForm && m.form != nil:
 		body = pane("dispatch", m.formView(), m.width, bodyH)
-	} else {
+	case m.mode == modeSettings && m.settings != nil:
+		body = pane("settings", m.settingsView(), m.width, bodyH)
+	default:
 		body = m.tiledView(m.width, bodyH)
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
@@ -136,7 +141,8 @@ func (m model) headerView() string {
 
 func (m model) footerView() string {
 	var help string
-	if m.mode == modeForm && m.form != nil {
+	switch {
+	case m.mode == modeForm && m.form != nil:
 		switch m.form.step {
 		case stepRepo:
 			help = "type to filter · ↑/↓ · enter select repo · esc cancel"
@@ -148,8 +154,22 @@ func (m model) footerView() string {
 		if m.form.errMsg != "" {
 			return " " + errStyle.Render(m.form.errMsg) + dimStyle.Render("  ·  "+help)
 		}
-	} else {
-		help = "n dispatch · enter attach · d shipped · x kill · r refresh · q quit"
+	case m.mode == modeSettings && m.settings != nil:
+		if m.settings.adding {
+			help = "enter add · esc back"
+		} else {
+			help = "a add root · x remove · ↑/↓ · enter save"
+			if m.settings.firstRun {
+				help += " · esc quit"
+			} else {
+				help += " · esc cancel"
+			}
+		}
+		if m.settings.errMsg != "" {
+			return " " + errStyle.Render(m.settings.errMsg) + dimStyle.Render("  ·  "+help)
+		}
+	default:
+		help = "n dispatch · s settings · enter attach · d shipped · x kill · r refresh · q quit"
 	}
 	if m.notice != "" {
 		return " " + noticeStyle.Render(m.notice) + dimStyle.Render("  ·  "+help)
@@ -249,6 +269,48 @@ func (m model) shipView(w int) string {
 	return strings.Join(lines, "\n")
 }
 
+func (m model) settingsView() string {
+	s := m.settings
+	var b strings.Builder
+	if s.firstRun {
+		b.WriteString(headerStyle.Render("welcome — where do your repos live?") + "\n")
+		b.WriteString(dimStyle.Render("dispatch works across every git repo found under these roots") + "\n\n")
+	}
+	b.WriteString(headerStyle.Render("scan roots") +
+		dimStyle.Render("  ·  scanned 3 levels deep for git repos") + "\n\n")
+	if len(s.roots) == 0 {
+		b.WriteString(dimStyle.Render("  no roots configured — press a to add one") + "\n")
+	}
+	for i, root := range s.roots {
+		marker := "  "
+		line := root
+		if i == s.cursor && !s.adding {
+			marker = "▸ "
+			line = headerStyle.Render(root)
+		}
+		count := ""
+		switch n, ok := s.counts[root]; {
+		case !ok || n < 0:
+			count = dimStyle.Render("  scanning…")
+		case n == 1:
+			count = dimStyle.Render("  1 repo")
+		default:
+			count = dimStyle.Render(fmt.Sprintf("  %d repos", n))
+		}
+		b.WriteString(marker + line + count + "\n")
+	}
+	if s.adding {
+		b.WriteString("\n" + headerStyle.Render("add root") + "\n")
+		b.WriteString(s.input.View() + "\n")
+	}
+	b.WriteString("\n" + dimStyle.Render("saved to "+configPathLabel()))
+	if s.firstRun {
+		b.WriteString("\n" + dimStyle.Render(
+			"tip: run `claude-dispatcher init` afterwards to install the status hook"))
+	}
+	return b.String()
+}
+
 func (m model) formView() string {
 	f := m.form
 	stepTitle := func(n int, label string, active bool) string {
@@ -297,6 +359,14 @@ func (m model) formView() string {
 		b.WriteString(f.prompt.View())
 	}
 	return b.String()
+}
+
+func configPathLabel() string {
+	p := config.Path()
+	if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(p, home) {
+		return "~" + strings.TrimPrefix(p, home)
+	}
+	return p
 }
 
 func kv(k, v string, w int) string {


### PR DESCRIPTION
Repo discovery has always been driven by `roots` in `config.toml`, but the only way to set them was hand-editing the file — and launching with no config at all just errored out with "run `claude-dispatcher init` first".

## Changes

- **First run.** No config now opens a welcome/settings view instead of erroring, pre-filled with the same root `init` would suggest (the parent of the working directory). Any *other* config read error still fails loudly rather than silently rewriting a file the user broke. `esc` there quits, since the cockpit is useless without a config.
- **`s` for settings, any time.** Add a root (validated as a real directory, duplicates rejected, `~` expanded), remove one, save. At least one root is required to save.
- **Answers "does it see my repos?" in place.** Each root shows how many repos discovery finds under it, counted asynchronously so the UI never blocks, and saving re-runs discovery immediately with a `config saved — N repos discovered` notice. No restart needed.
- **`config.Save`** regenerates `config.toml` with its explanatory comments intact, round-tripping `[products]` and `[deploy_workflows]` untouched (sorted keys, proper TOML key quoting). `WriteDefault` now builds on it via a shared `DefaultRoot()`.

## Scope

Deliberately roots-only. Products and deploy-workflow overrides stay file-edited for now — preserved through saves — but the view could grow tabs for them.

## Verification

`go build ./...`, `go vet ./...`, `gofmt` clean. New tests: config Save/Load round-trip, `WriteDefault` does not overwrite an existing config, and settings-editor behaviour (add, reject missing dir, reject duplicate, refuse empty save, save/cancel).