### PR TITLE
Document the tap token and the PATH that install assumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,40 @@ Or from source:
 make install                  # builds to ~/.local/bin/claude-dispatcher
 ```
 
+`~/.local/bin` must be on your PATH, ahead of Homebrew's, or a `brew`-installed
+copy will keep winning and you will run an older cockpit than you just built:
+
+```sh
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
+```
+
 Note: the status hook embeds the absolute path of the binary that ran
-`init`. If you switch install methods later, re-run `init` so the hook
-points at the new binary.
+`init`. If you switch install methods later, re-run `init` so the hook points
+at the new binary — otherwise the cockpit runs one build while the hooks that
+feed it status run another.
+
+## Releasing
+
+Releases need a `HOMEBREW_TAP_TOKEN` secret on this repo: a fine-grained
+personal access token, scoped to the `Innovology/homebrew-tap` repository,
+with **Repository permissions -> Contents: Read and write**. Create it at
+[github.com/settings/personal-access-tokens/new](https://github.com/settings/personal-access-tokens/new),
+then add it:
+
+```sh
+gh secret set HOMEBREW_TAP_TOKEN -R Innovology/claude-dispatcher
+```
+
+Verify it is registered (`total_count` must be 1, not 0):
+
+```sh
+gh api repos/Innovology/claude-dispatcher/actions/secrets
+```
+
+Without the secret the Release workflow succeeds but tags and publishes
+nothing, so a merge never half-releases. Note that the token is only read by
+the workflow — publishing from a laptop instead bakes the builder's home
+directory into the shipped binaries.
 
 Releases are cut automatically: folding a PR into main makes the Release
 workflow tag the next patch version and publish the tarballs + Homebrew cask.


### PR DESCRIPTION
Two documentation gaps that each caused a real problem on a live machine.

## `HOMEBREW_TAP_TOKEN` had no setup instructions

It was mentioned only in passing inside the release paragraph, so the secret was never set (`actions/secrets` returns `total_count: 0`) and both published releases were cut by hand from a laptop — which is how `/Users/<user>/...` build paths ended up inside the shipped binaries.

Adds a **Releasing** section with the exact permission scope (fine-grained PAT, `Contents: Read and write`, scoped to `Innovology/homebrew-tap`), the `gh secret set` command, and the `gh api` check that proves it registered.

## `make install` assumes a PATH entry it only prints as a reminder

`~/.local/bin` was not on PATH on the machine this was found. With a `brew`-installed copy also present, `claude-dispatcher` resolved to the stale **v0.1.1** cask while the status hooks — which use an absolute path — ran the freshly built binary. The cockpit and the hooks feeding it status were two different builds, and newly built features were invisible.

Documents the PATH requirement where install is described, and extends the existing hook-path note to explain that failure mode.

Docs-only, so `paths-ignore` means this merge cuts no release.