### PR TITLE
Worktree isolation and product grouping for v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,16 @@
   by commit hash.
 
 ## Agreed decisions (2026-08-06)
-- Multi-repo, not multi-worktree: independent repos are the organising
-  primitive; discovery via configured roots.
+- Multi-repo: independent repos are the organising primitive; discovery via
+  configured roots. Each dispatch runs in its own git worktree of its repo,
+  under `~/.local/state/claude-dispatcher/worktrees/<repo>/<slug>`, so
+  concurrent dispatches — and the human — never fight over one checkout.
+  `x` removes a clean worktree; a dirty one is kept for inspection.
+  (Supersedes the original "not multi-worktree" call, revised later the
+  same day after two sessions collided in one working copy.)
+- Products are the grouping lens: the cockpit list and the dispatch form's
+  repo picker group by the `[products]` config, most urgent group first;
+  unmapped repos fall under "other". No separate group concept.
 - Sessions run as interactive `claude` inside per-dispatch tmux sessions
   (`disp-<slug>`); tmux is a hard dependency and the process supervisor. The
   cockpit is a stateless viewer — "jump in" hands the terminal to tmux.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,17 +7,20 @@
 - **Feature** — the human unit of work; history is navigated by feature, not
   by commit hash.
 
-## Agreed decisions (2026-08-06)
-- Multi-repo: independent repos are the organising primitive; discovery via
-  configured roots. Each dispatch runs in its own git worktree of its repo,
-  under `~/.local/state/claude-dispatcher/worktrees/<repo>/<slug>`, so
-  concurrent dispatches — and the human — never fight over one checkout.
-  `x` removes a clean worktree; a dirty one is kept for inspection.
-  (Supersedes the original "not multi-worktree" call, revised later the
-  same day after two sessions collided in one working copy.)
-- Products are the grouping lens: the cockpit list and the dispatch form's
-  repo picker group by the `[products]` config, most urgent group first;
-  unmapped repos fall under "other". No separate group concept.
+## Agreed decisions (2026-08-06, worktrees added 2026-08-07)
+- **Multi-repo, multi-worktree, multi-product** — three independent axes:
+  - *Repo* is the organising primitive; discovery via configured roots.
+  - *Worktree* is per-dispatch isolation: each dispatch gets its own git
+    worktree of its repo under
+    `~/.local/state/claude-dispatcher/worktrees/<repo>/<slug>`, so concurrent
+    dispatches — and the human — never fight over one checkout. `x` removes a
+    clean worktree; a dirty one is kept for inspection. (Supersedes the
+    original "multi-repo, not multi-worktree" call, reversed the next day
+    after two sessions collided in one working copy and a commit landed on
+    the wrong branch.)
+  - *Product* is the grouping lens: the cockpit list and the dispatch form's
+    repo picker group by the `[products]` config, most urgent group first;
+    unmapped repos fall under "other". No separate group concept.
 - Sessions run as interactive `claude` inside per-dispatch tmux sessions
   (`disp-<slug>`); tmux is a hard dependency and the process supervisor. The
   cockpit is a stateless viewer — "jump in" hands the terminal to tmux.

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -44,10 +44,13 @@ func (m model) attach(feature string) (model, tea.Cmd) {
 	})
 }
 
-// killCmd kills each feature's tmux session and marks the record exited.
+// killCmd kills each feature's tmux session, marks the record exited, and
+// reclaims its worktree. A worktree with uncommitted changes is left alone —
+// killing a dispatcher must never discard unshipped work — and the notice
+// says how many were kept.
 func killCmd(features []string) tea.Cmd {
 	return func() tea.Msg {
-		n := 0
+		n, kept := 0, 0
 		for _, f := range features {
 			rec := recordFor(f)
 			if rec == nil {
@@ -59,6 +62,9 @@ func killCmd(features []string) tea.Cmd {
 				rec.StatusReason = "killed from cockpit"
 				_ = state.Save(rec)
 			}
+			if rec.WorktreePath != "" && !dispatchpkg.CleanupWorktree(rec.RepoPath, rec.WorktreePath) {
+				kept++
+			}
 			n++
 		}
 		if n == 0 {
@@ -68,7 +74,11 @@ func killCmd(features []string) tea.Cmd {
 		if n != 1 {
 			word += "s"
 		}
-		return actionMsg{notice: fmt.Sprintf("killed %d %s", n, word)}
+		notice := fmt.Sprintf("killed %d %s", n, word)
+		if kept > 0 {
+			notice += fmt.Sprintf(" · %d worktree(s) kept (uncommitted changes)", kept)
+		}
+		return actionMsg{notice: notice}
 	}
 }
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -105,13 +105,22 @@ func ensureWorktree(repoPath, path, branch string) error {
 }
 
 // CleanupWorktree removes a dispatch's worktree when git deems it safe (no
-// modified or untracked files); a dirty worktree is kept for inspection.
-// Reports whether the worktree was removed.
+// modified or untracked files); a dirty worktree is kept for inspection so
+// killing a dispatcher never discards unshipped work.
+//
+// It reports whether the worktree is gone, not whether this call removed it:
+// an absent path (never had a worktree, or already cleaned up) is "gone", so
+// callers can report "kept" on false without special-casing.
 func CleanupWorktree(repoPath, worktreePath string) bool {
 	if worktreePath == "" {
-		return false
+		return true
 	}
-	return exec.Command("git", "-C", repoPath, "worktree", "remove", worktreePath).Run() == nil
+	if _, err := os.Stat(worktreePath); os.IsNotExist(err) {
+		return true
+	}
+	_ = exec.Command("git", "-C", repoPath, "worktree", "remove", worktreePath).Run()
+	_, err := os.Stat(worktreePath)
+	return os.IsNotExist(err)
 }
 
 func shellQuote(s string) string {

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -1,10 +1,13 @@
-// Package dispatch launches a dispatcher: a feature branch in the target
-// repo plus an interactive claude session inside a dedicated tmux session.
+// Package dispatch launches a dispatcher: a feature branch materialised in a
+// dedicated git worktree, plus an interactive claude session inside a
+// dedicated tmux session.
 package dispatch
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -22,37 +25,41 @@ func Slugify(feature string) string {
 	return strings.Trim(s, "-")
 }
 
-// Launch creates (or checks out) feature/<slug> in the repo, records the
-// dispatch, and starts claude with the prompt inside tmux session
-// disp-<slug>. The CLAUDE_DISPATCHER_ID environment variable is the join key
-// that lets the lifecycle hook attribute events back to this record.
+// Launch materialises feature/<slug> in its own git worktree under the state
+// dir, records the dispatch, and starts claude with the prompt inside tmux
+// session disp-<slug>. Per-dispatch worktrees keep concurrent dispatches —
+// and the human — from fighting over the repo's single checkout. The
+// CLAUDE_DISPATCHER_ID environment variable is the join key that lets the
+// lifecycle hook attribute events back to this record.
 func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	slug := Slugify(feature)
 	if slug == "" {
 		return nil, fmt.Errorf("feature name %q produces an empty slug", feature)
 	}
 	branch := "feature/" + slug
-	if err := ensureBranch(r.Path, branch); err != nil {
+	worktree := filepath.Join(state.WorktreesDir(), r.Name, slug)
+	if err := ensureWorktree(r.Path, worktree, branch); err != nil {
 		return nil, err
 	}
 	baseSHA := ""
-	if out, err := exec.Command("git", "-C", r.Path, "rev-parse", "HEAD").Output(); err == nil {
+	if out, err := exec.Command("git", "-C", worktree, "rev-parse", "HEAD").Output(); err == nil {
 		baseSHA = strings.TrimSpace(string(out))
 	}
 
 	d := &state.Dispatch{
-		ID:          state.NewID(),
-		Feature:     feature,
-		Slug:        slug,
-		RepoPath:    r.Path,
-		RepoName:    r.Name,
-		Product:     r.Product,
-		Branch:      branch,
-		BaseSHA:     baseSHA,
-		Prompt:      prompt,
-		TmuxSession: tmux.UniqueName("disp-" + slug),
-		Status:      state.StatusLaunching,
-		CreatedAt:   time.Now(),
+		ID:           state.NewID(),
+		Feature:      feature,
+		Slug:         slug,
+		RepoPath:     r.Path,
+		RepoName:     r.Name,
+		Product:      r.Product,
+		Branch:       branch,
+		WorktreePath: worktree,
+		BaseSHA:      baseSHA,
+		Prompt:       prompt,
+		TmuxSession:  tmux.UniqueName("disp-" + slug),
+		Status:       state.StatusLaunching,
+		CreatedAt:    time.Now(),
 	}
 	if err := state.Save(d); err != nil {
 		return nil, err
@@ -62,7 +69,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	// inspection instead of vanishing.
 	cmd := fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude %s; exec ${SHELL:-/bin/sh}",
 		d.ID, shellQuote(prompt))
-	if err := tmux.NewSession(d.TmuxSession, r.Path, cmd); err != nil {
+	if err := tmux.NewSession(d.TmuxSession, worktree, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"
 		_ = state.Save(d)
@@ -71,19 +78,40 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	return d, nil
 }
 
-func ensureBranch(repoPath, branch string) error {
-	exists := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
-	var out []byte
-	var err error
-	if exists {
-		out, err = exec.Command("git", "-C", repoPath, "checkout", branch).CombinedOutput()
-	} else {
-		out, err = exec.Command("git", "-C", repoPath, "checkout", "-b", branch).CombinedOutput()
+// ensureWorktree adds a worktree for the branch at path, creating the branch
+// from the repo's current HEAD when it doesn't exist yet, and reusing a
+// worktree left behind by an earlier dispatch of the same feature.
+func ensureWorktree(repoPath, path, branch string) error {
+	if out, err := exec.Command("git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").Output(); err == nil {
+		if strings.TrimSpace(string(out)) == branch {
+			return nil
+		}
+		return fmt.Errorf("%s exists but is not a worktree on %s", path, branch)
 	}
-	if err != nil {
-		return fmt.Errorf("git checkout %s: %s", branch, strings.TrimSpace(string(out)))
+	// Recover bookkeeping for worktree dirs deleted behind git's back.
+	_ = exec.Command("git", "-C", repoPath, "worktree", "prune").Run()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	branchExists := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
+	args := []string{"-C", repoPath, "worktree", "add", path, branch}
+	if !branchExists {
+		args = []string{"-C", repoPath, "worktree", "add", "-b", branch, path}
+	}
+	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		return fmt.Errorf("git worktree add %s: %s", branch, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// CleanupWorktree removes a dispatch's worktree when git deems it safe (no
+// modified or untracked files); a dirty worktree is kept for inspection.
+// Reports whether the worktree was removed.
+func CleanupWorktree(repoPath, worktreePath string) bool {
+	if worktreePath == "" {
+		return false
+	}
+	return exec.Command("git", "-C", repoPath, "worktree", "remove", worktreePath).Run() == nil
 }
 
 func shellQuote(s string) string {

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -73,7 +73,7 @@ func TestCleanupWorktree(t *testing.T) {
 	if err := ensureWorktree(repo, wt, "feature/feat"); err != nil {
 		t.Fatal(err)
 	}
-	// Dirty worktree is kept.
+	// Dirty worktree is kept — killing a dispatcher must not discard work.
 	if err := os.WriteFile(filepath.Join(wt, "wip.txt"), []byte("wip"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -93,8 +93,13 @@ func TestCleanupWorktree(t *testing.T) {
 	if _, err := os.Stat(wt); !os.IsNotExist(err) {
 		t.Fatal("worktree directory still present")
 	}
-	if CleanupWorktree(repo, "") {
-		t.Fatal("empty path must be a no-op")
+	// "Gone" is the contract, so a second call and a dispatch that never had
+	// a worktree both report gone rather than a spurious "kept".
+	if !CleanupWorktree(repo, wt) {
+		t.Error("an already-removed worktree should report gone")
+	}
+	if !CleanupWorktree(repo, "") {
+		t.Error("a dispatch with no worktree should report gone")
 	}
 }
 

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1,10 +1,102 @@
 package dispatch
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	git := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", repo, "-c", "user.email=t@t", "-c", "user.name=t"}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+	git("init", "-b", "main")
+	git("commit", "--allow-empty", "-m", "base")
+	return repo
+}
+
+func worktreeBranch(t *testing.T, path string) string {
+	t.Helper()
+	out, err := exec.Command("git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse in %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestEnsureWorktree(t *testing.T) {
+	repo := initRepo(t)
+	wt := filepath.Join(t.TempDir(), "wt", "feat")
+
+	if err := ensureWorktree(repo, wt, "feature/feat"); err != nil {
+		t.Fatal(err)
+	}
+	if got := worktreeBranch(t, wt); got != "feature/feat" {
+		t.Fatalf("worktree on %q, want feature/feat", got)
+	}
+	// The repo's own checkout must be untouched.
+	if got := worktreeBranch(t, repo); got != "main" {
+		t.Fatalf("repo checkout moved to %q", got)
+	}
+	// Re-dispatch of the same feature reuses the worktree.
+	if err := ensureWorktree(repo, wt, "feature/feat"); err != nil {
+		t.Fatalf("reuse failed: %v", err)
+	}
+	// A path occupied by a different branch's worktree is refused.
+	if err := ensureWorktree(repo, wt, "feature/second"); err == nil {
+		t.Fatal("expected error for occupied path")
+	}
+	// An existing branch is checked out rather than recreated.
+	wt2 := filepath.Join(t.TempDir(), "feat-again")
+	if out, err := exec.Command("git", "-C", repo, "worktree", "remove", wt).CombinedOutput(); err != nil {
+		t.Fatalf("worktree remove: %s", out)
+	}
+	if err := ensureWorktree(repo, wt2, "feature/feat"); err != nil {
+		t.Fatalf("existing branch: %v", err)
+	}
+	if got := worktreeBranch(t, wt2); got != "feature/feat" {
+		t.Fatalf("worktree on %q, want feature/feat", got)
+	}
+}
+
+func TestCleanupWorktree(t *testing.T) {
+	repo := initRepo(t)
+	wt := filepath.Join(t.TempDir(), "feat")
+	if err := ensureWorktree(repo, wt, "feature/feat"); err != nil {
+		t.Fatal(err)
+	}
+	// Dirty worktree is kept.
+	if err := os.WriteFile(filepath.Join(wt, "wip.txt"), []byte("wip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if CleanupWorktree(repo, wt) {
+		t.Fatal("dirty worktree must not be removed")
+	}
+	if _, err := os.Stat(wt); err != nil {
+		t.Fatal("dirty worktree directory vanished")
+	}
+	// Clean worktree is removed.
+	if err := os.Remove(filepath.Join(wt, "wip.txt")); err != nil {
+		t.Fatal(err)
+	}
+	if !CleanupWorktree(repo, wt) {
+		t.Fatal("clean worktree should be removed")
+	}
+	if _, err := os.Stat(wt); !os.IsNotExist(err) {
+		t.Fatal("worktree directory still present")
+	}
+	if CleanupWorktree(repo, "") {
+		t.Fatal("empty path must be a no-op")
+	}
+}
 
 func TestSlugify(t *testing.T) {
 	cases := map[string]string{

--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -118,11 +118,18 @@ func resolve(dispatcherID, event string, in hookInput) *state.Dispatch {
 		}
 	}
 	// A freshly launched dispatch has no session id yet; bind the first
-	// SessionStart arriving from its repo. Records are sorted newest-first
-	// within a status, so the most recent launch wins.
+	// SessionStart arriving from its worktree (or repo, for records from
+	// before per-dispatch worktrees). Records are sorted newest-first within
+	// a status, so the most recent launch wins.
 	if event == "SessionStart" && in.Cwd != "" {
 		for _, d := range all {
-			if d.Status == state.StatusLaunching && samePath(d.RepoPath, in.Cwd) {
+			if d.Status != state.StatusLaunching {
+				continue
+			}
+			if d.WorktreePath != "" && samePath(d.WorktreePath, in.Cwd) {
+				return d
+			}
+			if d.WorktreePath == "" && samePath(d.RepoPath, in.Cwd) {
 				return d
 			}
 		}

--- a/internal/hookcmd/hookcmd_test.go
+++ b/internal/hookcmd/hookcmd_test.go
@@ -111,6 +111,17 @@ func TestResolve(t *testing.T) {
 	if d := resolve("", "SessionStart", hookInput{Cwd: "/repo/two"}); d == nil || d.ID != "id2" {
 		t.Error("SessionStart should bind launching dispatch by cwd")
 	}
+	worktreed := &state.Dispatch{ID: "id3", RepoPath: "/repo/three",
+		WorktreePath: "/wt/three", Status: state.StatusLaunching}
+	if err := state.Save(worktreed); err != nil {
+		t.Fatal(err)
+	}
+	if d := resolve("", "SessionStart", hookInput{Cwd: "/wt/three"}); d == nil || d.ID != "id3" {
+		t.Error("SessionStart should bind launching dispatch by worktree cwd")
+	}
+	if d := resolve("", "SessionStart", hookInput{Cwd: "/repo/three"}); d != nil {
+		t.Error("a worktree-backed dispatch must not bind by repo cwd")
+	}
 	if d := resolve("", "Stop", hookInput{Cwd: "/repo/two"}); d != nil {
 		t.Error("cwd binding must be SessionStart-only")
 	}

--- a/internal/repos/repos.go
+++ b/internal/repos/repos.go
@@ -1,5 +1,6 @@
 // Package repos discovers the git repositories the cockpit operates across.
-// Repos are the organising primitive — not worktrees.
+// Repos are the organising primitive; each dispatch then gets its own git
+// worktree of its repo so concurrent dispatches never share a checkout.
 package repos
 
 import (

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -52,13 +52,18 @@ func (s Status) Priority() int {
 }
 
 type Dispatch struct {
-	ID             string `json:"id"`
-	Feature        string `json:"feature"`
-	Slug           string `json:"slug"`
-	RepoPath       string `json:"repo_path"`
-	RepoName       string `json:"repo_name"`
-	Product        string `json:"product,omitempty"`
-	Branch         string `json:"branch"`
+	ID       string `json:"id"`
+	Feature  string `json:"feature"`
+	Slug     string `json:"slug"`
+	RepoPath string `json:"repo_path"`
+	RepoName string `json:"repo_name"`
+	Product  string `json:"product,omitempty"`
+	Branch   string `json:"branch"`
+	// WorktreePath is the dispatch's own checkout of Branch (a git worktree
+	// under WorktreesDir); the claude session runs there so concurrent
+	// dispatches never fight over the repo's working copy. RepoPath stays the
+	// main repo — refs, PRs, and commit provenance are read from there.
+	WorktreePath   string `json:"worktree_path,omitempty"`
 	Prompt         string `json:"prompt"`
 	TmuxSession    string `json:"tmux_session"`
 	SessionID      string `json:"session_id,omitempty"`
@@ -93,6 +98,9 @@ func Dir() string {
 }
 
 func DispatchesDir() string { return filepath.Join(Dir(), "dispatches") }
+
+// WorktreesDir holds per-dispatch git worktrees, worktrees/<repo>/<slug>.
+func WorktreesDir() string { return filepath.Join(Dir(), "worktrees") }
 
 func EnsureDirs() error { return os.MkdirAll(DispatchesDir(), 0o755) }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -227,7 +228,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, collectShip(m.repos)
 
 	case dispatchesMsg:
-		m.dispatches = msg
+		m.dispatches = groupByProduct(msg)
 		m.cursor = m.findSelected()
 		return m, nil
 
@@ -322,6 +323,15 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			_ = state.Save(d)
 			m.notice = fmt.Sprintf("killed %q", d.Feature)
+			if d.WorktreePath != "" {
+				if _, err := os.Stat(d.WorktreePath); err == nil {
+					if dispatch.CleanupWorktree(d.RepoPath, d.WorktreePath) {
+						m.notice += " · worktree removed"
+					} else {
+						m.notice += " · worktree kept (uncommitted changes)"
+					}
+				}
+			}
 			return m, loadDispatches
 		}
 	}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -323,14 +322,8 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			_ = state.Save(d)
 			m.notice = fmt.Sprintf("killed %q", d.Feature)
-			if d.WorktreePath != "" {
-				if _, err := os.Stat(d.WorktreePath); err == nil {
-					if dispatch.CleanupWorktree(d.RepoPath, d.WorktreePath) {
-						m.notice += " · worktree removed"
-					} else {
-						m.notice += " · worktree kept (uncommitted changes)"
-					}
-				}
+			if !dispatch.CleanupWorktree(d.RepoPath, d.WorktreePath) {
+				m.notice += " · worktree kept (uncommitted changes)"
 			}
 			return m, loadDispatches
 		}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -46,7 +46,7 @@ func newForm(rs []repos.Repo) *form {
 	prompt := textarea.New()
 	prompt.Placeholder = "Describe the work to dispatch…"
 
-	return &form{repos: rs, feature: feature, prompt: prompt}
+	return &form{repos: groupRepos(rs), feature: feature, prompt: prompt}
 }
 
 func (f *form) resize(width, height int) {

--- a/internal/ui/group.go
+++ b/internal/ui/group.go
@@ -1,0 +1,86 @@
+package ui
+
+import (
+	"sort"
+
+	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
+)
+
+// otherGroup labels dispatches and repos that no product claims.
+const otherGroup = "other"
+
+// groupByProduct reorders urgency-sorted dispatches into product sections.
+// Members keep their relative (urgency) order, groups are ordered by their
+// most urgent member, and the unnamed bucket sorts after named products on
+// ties. The cockpit list renders a section header wherever the product
+// changes, so grouping is purely an ordering concern.
+func groupByProduct(ds []*state.Dispatch) []*state.Dispatch {
+	type group struct {
+		name    string
+		best    int
+		members []*state.Dispatch
+	}
+	byName := map[string]*group{}
+	var groups []*group
+	for _, d := range ds {
+		g, ok := byName[d.Product]
+		if !ok {
+			g = &group{name: d.Product, best: d.Status.Priority()}
+			byName[d.Product] = g
+			groups = append(groups, g)
+		}
+		if p := d.Status.Priority(); p < g.best {
+			g.best = p
+		}
+		g.members = append(g.members, d)
+	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].best != groups[j].best {
+			return groups[i].best < groups[j].best
+		}
+		if (groups[i].name == "") != (groups[j].name == "") {
+			return groups[j].name == ""
+		}
+		return groups[i].name < groups[j].name
+	})
+	out := make([]*state.Dispatch, 0, len(ds))
+	for _, g := range groups {
+		out = append(out, g.members...)
+	}
+	return out
+}
+
+// groupRepos orders repos for the picker: named products alphabetically, the
+// unnamed bucket last, repos by name within each.
+func groupRepos(rs []repos.Repo) []repos.Repo {
+	out := append([]repos.Repo(nil), rs...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Product != out[j].Product {
+			if (out[i].Product == "") != (out[j].Product == "") {
+				return out[j].Product == ""
+			}
+			return out[i].Product < out[j].Product
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// anyProduct reports whether grouping headers are worth rendering at all — a
+// portfolio with no products configured stays a flat list.
+func anyProduct[T any](items []T, product func(T) string) bool {
+	for _, it := range items {
+		if product(it) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func groupLabel(product string) string {
+	if product == "" {
+		return otherGroup
+	}
+	return product
+}

--- a/internal/ui/group_test.go
+++ b/internal/ui/group_test.go
@@ -1,0 +1,68 @@
+package ui
+
+import (
+	"testing"
+
+	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
+)
+
+func TestGroupByProduct(t *testing.T) {
+	d := func(id, product string, s state.Status) *state.Dispatch {
+		return &state.Dispatch{ID: id, Product: product, Status: s}
+	}
+	// Input is urgency-sorted, as LoadAll delivers it.
+	in := []*state.Dispatch{
+		d("blocked-other", "", state.StatusBlocked),
+		d("needs-acme", "acme", state.StatusNeedsInput),
+		d("working-zeta", "zeta", state.StatusWorking),
+		d("working-acme", "acme", state.StatusWorking),
+		d("done-other", "", state.StatusDone),
+	}
+	got := groupByProduct(in)
+	want := []string{
+		// "other" holds the single most urgent dispatch, so it leads.
+		"blocked-other", "done-other",
+		"needs-acme", "working-acme",
+		"working-zeta",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d dispatches, want %d", len(got), len(want))
+	}
+	for i, id := range want {
+		if got[i].ID != id {
+			t.Errorf("position %d: got %s, want %s", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestGroupByProductNamedBeforeOtherOnTies(t *testing.T) {
+	in := []*state.Dispatch{
+		{ID: "a", Product: "", Status: state.StatusWorking},
+		{ID: "b", Product: "acme", Status: state.StatusWorking},
+	}
+	got := groupByProduct(in)
+	if got[0].ID != "b" || got[1].ID != "a" {
+		t.Errorf("named product should precede the unnamed bucket on equal urgency: %s, %s", got[0].ID, got[1].ID)
+	}
+}
+
+func TestGroupRepos(t *testing.T) {
+	in := []repos.Repo{
+		{Name: "zoo"},
+		{Name: "api", Product: "shop"},
+		{Name: "adm"},
+		{Name: "web", Product: "shop"},
+		{Name: "app", Product: "aura"},
+	}
+	got := groupRepos(in)
+	want := []string{"app", "api", "web", "adm", "zoo"}
+	for i, name := range want {
+		if got[i].Name != name {
+			t.Errorf("position %d: got %s, want %s", i, got[i].Name, name)
+		}
+	}
+	if in[0].Name != "zoo" {
+		t.Error("input slice must not be reordered in place")
+	}
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -9,6 +9,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
 	"claude-dispatcher/internal/transcript"
 )
@@ -189,7 +190,13 @@ func (m model) tableView(w int) string {
 	head := dimStyle.Render(fmt.Sprintf("  %-*s %-*s %-*s %*s",
 		featW, "FEATURE", repoW, "REPO", stateW, "STATE", ageW, "AGE"))
 	rows := []string{head}
+	grouped := anyProduct(m.dispatches, func(d *state.Dispatch) string { return d.Product })
+	prevProduct := "\x00" // sentinel: no group rendered yet
 	for i, d := range m.dispatches {
+		if grouped && d.Product != prevProduct {
+			prevProduct = d.Product
+			rows = append(rows, dimStyle.Render(sectionRule(groupLabel(d.Product), w)))
+		}
 		marker := "  "
 		if i == m.cursor {
 			marker = "▸ "
@@ -226,6 +233,7 @@ func (m model) detailView(w, h int) string {
 		kv("status", statusStyles[d.Status].Render(statusGlyph(d.Status)+" "+statusLabel(d.Status)), w),
 		kv("why", d.StatusReason, w),
 		kv("branch", d.Branch, w),
+		kv("worktree", orDash(d.WorktreePath), w),
 		kv("product", orDash(d.Product), w),
 		kv("tmux", d.TmuxSession, w),
 		kv("session", orDash(sid), w),
@@ -331,18 +339,18 @@ func (m model) formView() string {
 		b.WriteString(dimStyle.Render("filter: ") + f.filter + "▏\n\n")
 		visible := f.filtered()
 		shown := min(len(visible), 15)
+		grouped := anyProduct(visible[:shown], func(r repos.Repo) string { return r.Product })
+		prevProduct := "\x00" // sentinel: no group rendered yet
 		for i := 0; i < shown; i++ {
+			if grouped && visible[i].Product != prevProduct {
+				prevProduct = visible[i].Product
+				b.WriteString(dimStyle.Render(sectionRule(groupLabel(visible[i].Product), 40)) + "\n")
+			}
 			marker := "  "
 			line := visible[i].Name
-			if visible[i].Product != "" {
-				line += dimStyle.Render("  (" + visible[i].Product + ")")
-			}
 			if i == f.cursor {
 				marker = "▸ "
 				line = headerStyle.Render(visible[i].Name)
-				if visible[i].Product != "" {
-					line += dimStyle.Render("  (" + visible[i].Product + ")")
-				}
 			}
 			b.WriteString(marker + line + "\n")
 		}
@@ -367,6 +375,15 @@ func configPathLabel() string {
 		return "~" + strings.TrimPrefix(p, home)
 	}
 	return p
+}
+
+// sectionRule renders "── label ────…" padded with dashes to width.
+func sectionRule(label string, w int) string {
+	s := "── " + label + " "
+	if pad := w - len([]rune(s)); pad > 0 {
+		s += strings.Repeat("─", pad)
+	}
+	return s
 }
 
 func kv(k, v string, w int) string {


### PR DESCRIPTION
Targets `feature/version-2` rather than main, so #11 stays the single consolidating PR. Not pushed straight onto v2 because that branch has unpushed local work (`ff04bbc`, coverage wiring) — merge this when it suits you.

Implements the **multi-repo, multi-worktree, multi-product** model: three independent axes, one per concern.

**Worktree = per-dispatch isolation.** Each dispatch materialises `feature/<slug>` in its own git worktree under `~/.local/state/claude-dispatcher/worktrees/<repo>/<slug>` and runs its tmux session there; the repo's own checkout is never touched. This is not hypothetical — earlier today two sessions sharing this repo's checkout put a commit on the wrong branch, which took ref surgery to unpick.

- `SessionStart` hook attribution binds by worktree cwd, with repo cwd retained as the fallback for pre-worktree records.
- Kill reclaims the worktree in **both** cockpits — the v2 cockpit has its own kill path, so folding worktrees in without it would orphan a worktree per killed dispatcher.
- A worktree holding uncommitted changes is always kept, and the notice says so: killing a dispatcher must never discard unshipped work. `CleanupWorktree` reports whether the worktree is *gone* rather than whether this call removed it, so an already-absent path is not misreported as "kept".

**Product = grouping lens.** The default cockpit's list renders product sections ordered by their most urgent member ("other" last on ties), and the dispatch form's repo picker groups the same way. Portfolios with no products configured keep the flat list. This lands in `internal/ui`, which v2 leaves untouched and which is still the default cockpit — `internal/cockpit` remains behind the `v2` preview subcommand.

CLAUDE.md's decision log is updated to record the reversal of the original "multi-repo, not multi-worktree" call and why.

Verified: `go build`, `go vet`, `gofmt -l`, and `go test ./... -race -count=1` all clean, including the new `internal/cockpit` and `internal/usage` packages.