### PR TITLE
Extract the process supervisor behind an OS seam (Windows groundwork)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,22 @@ jobs:
         with:
           version: latest
 
+  # Native Windows build gate. Runtime behaviour of the Windows session backend
+  # still needs validation on a real machine; this keeps the tree compiling and
+  # vetting for windows so the port can't silently regress. (Tests are not run
+  # here yet — several sandbox their config via $HOME, which os.UserHomeDir does
+  # not honour on Windows; that is a separate cross-platform-tests task.)
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test ./internal/supervisor/... -count=1
+
   upload-coverage-go:
     needs: test
     if: ${{ !cancelled() && needs.test.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,11 @@ jobs:
     # run before this failed in 0s. Map it into env once and gate on that.
     env:
       HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+      # Optional Windows publishers. Unset by default; the .goreleaser.yml
+      # scoop/winget entries skip_upload when their token is empty, so the
+      # release still succeeds with only HOMEBREW_TAP_TOKEN configured.
+      SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
+      WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ before:
 builds:
   - env:
       - CGO_ENABLED=0
-    goos: [darwin, linux]
+    goos: [darwin, linux, windows]
     goarch: [amd64, arm64]
     # -trimpath keeps builder filesystem paths (home dir, module cache) out
     # of the shipped binaries.
@@ -19,7 +19,12 @@ builds:
       - -s -w -X main.version={{.Version}}
 
 archives:
+  # Unix stays tar.gz; Windows ships a .zip (native tooling and the
+  # scoop/winget publishers below both expect zip archives).
   - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
 
 checksum:
   name_template: checksums.txt
@@ -48,3 +53,37 @@ homebrew_casks:
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/claude-dispatcher"]
           end
+
+# Windows native package managers. Both mirror the Homebrew tap pattern: a
+# separate publish repo reached with its own fine-grained PAT. The skip_upload
+# template makes each a pure no-op when its token is unset, so a release that
+# only has HOMEBREW_TAP_TOKEN (the current v1 pipeline) still succeeds — the
+# manifest is generated but never pushed.
+scoops:
+  - repository:
+      owner: Innovology
+      name: scoop-bucket
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    homepage: https://github.com/Innovology/claude-dispatcher
+    description: Terminal dispatch cockpit for Claude Code sessions across many repositories
+    license: MIT
+    # No-op unless SCOOP_BUCKET_TOKEN is set, so a token-less run never fails.
+    skip_upload: '{{ if .Env.SCOOP_BUCKET_TOKEN }}false{{ else }}true{{ end }}'
+
+winget:
+  - name: claude-dispatcher
+    publisher: Innovology
+    package_identifier: Innovology.claude-dispatcher
+    short_description: Terminal dispatch cockpit for Claude Code sessions across many repositories
+    homepage: https://github.com/Innovology/claude-dispatcher
+    license: MIT
+    repository:
+      # A fork of microsoft/winget-pkgs the user owns; goreleaser opens the
+      # PR against it. Kept as branch commits so nothing publishes until a
+      # WINGET_TOKEN is present.
+      owner: Innovology
+      name: winget-pkgs
+      token: "{{ .Env.WINGET_TOKEN }}"
+      branch: "claude-dispatcher-{{ .Version }}"
+    # No-op unless WINGET_TOKEN is set, so a token-less run never fails.
+    skip_upload: '{{ if .Env.WINGET_TOKEN }}false{{ else }}true{{ end }}'

--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 
 **Requirements:** macOS or Linux · `tmux` · `git` · the `claude` CLI · `gh` (for PR/deploy signals). Linear and Azure Boards are optional and off until configured.
 
+## Windows
+
+**Recommended: run under WSL2.** The full experience — real `tmux`, in-place attach, reply-without-attaching, the whole cockpit — depends on `tmux` as the process supervisor, and `tmux` is a Linux tool. Install a WSL2 distro (Ubuntu is fine), then use the **Linux** build exactly as documented above (`brew` via Linuxbrew, or `make install`). This is the recommended way to run the dispatcher on a Windows machine.
+
+**Native preview (winget / scoop).** A native Windows build is published for early access once the publishers below are configured. It is honestly a preview: without `tmux` there is no shared session multiplexer, so **each dispatch opens in its own console window**, and **in-place attach and reply are not yet supported** — the `tmux`-grade session model for Windows is still being built. For the real cockpit experience today, use WSL2, and watch [`claude-dispatcher v2`](#keys-v2-cockpit) as the native session model lands.
+
+Once configured, install natively with:
+
+```powershell
+winget install Innovology.claude-dispatcher
+# or
+scoop bucket add innovology https://github.com/Innovology/scoop-bucket
+scoop install claude-dispatcher
+```
+
 ## Quickstart
 
 ```sh
@@ -140,13 +155,31 @@ The classic single-view cockpit is still there as the default `claude-dispatcher
 
 ## Releasing
 
-Merging a PR into `main` cuts the next patch release automatically (goreleaser tarballs + Homebrew cask). Put `release: minor` / `release: major` in the merge commit for a bigger bump, or `[skip release]` to merge without releasing; doc-only merges skip on their own. Releases need a `HOMEBREW_TAP_TOKEN` secret (a fine-grained PAT with contents:write on `Innovology/homebrew-tap`):
+Merging a PR into `main` cuts the next patch release automatically (goreleaser builds macOS/Linux tarballs, Windows `.zip`s, and the Homebrew cask). Put `release: minor` / `release: major` in the merge commit for a bigger bump, or `[skip release]` to merge without releasing; doc-only merges skip on their own. Releases need a `HOMEBREW_TAP_TOKEN` secret (a fine-grained PAT with contents:write on `Innovology/homebrew-tap`):
 
 ```sh
 gh secret set HOMEBREW_TAP_TOKEN -R Innovology/claude-dispatcher
 ```
 
 Without it the Release workflow succeeds but tags and publishes nothing, so a merge never half-releases.
+
+### Windows publishing (optional)
+
+The `scoop` and `winget` publishers are wired into `.goreleaser.yml` but stay a no-op until you set their tokens — the existing macOS/Linux + Homebrew release keeps working unchanged with only `HOMEBREW_TAP_TOKEN`. To turn on native Windows publishing, set up each publish repo exactly like the Homebrew tap:
+
+- **scoop** — create an `Innovology/scoop-bucket` repo, then add a fine-grained PAT with contents:write on it:
+
+  ```sh
+  gh secret set SCOOP_BUCKET_TOKEN -R Innovology/claude-dispatcher
+  ```
+
+- **winget** (optional) — fork `microsoft/winget-pkgs` to `Innovology/winget-pkgs`, then add a PAT with contents:write on the fork (goreleaser opens the manifest PR against it under publisher `Innovology`):
+
+  ```sh
+  gh secret set WINGET_TOKEN -R Innovology/claude-dispatcher
+  ```
+
+Each publisher's `skip_upload` is templated on its token, so an unset token means the manifest is generated but never pushed — a release can never half-publish.
 
 ## Troubleshooting
 

--- a/go.mod
+++ b/go.mod
@@ -7,14 +7,15 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.11.6
 	github.com/fsnotify/fsnotify v1.10.1
+	golang.org/x/sys v0.38.0
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
-	github.com/charmbracelet/x/ansi v0.11.6 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.9.0 // indirect
@@ -30,6 +31,5 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -16,7 +16,7 @@ import (
 	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
-	"claude-dispatcher/internal/tmux"
+	"claude-dispatcher/internal/supervisor"
 )
 
 // actionMsg carries a completed action's notice back to the UI and triggers a
@@ -33,13 +33,13 @@ func (m model) attach(feature string) (model, tea.Cmd) {
 		m.notice = "no live session for \"" + feature + "\""
 		return m, nil
 	}
-	if !tmux.HasSession(rec.TmuxSession) {
+	if !supervisor.HasSession(rec.TmuxSession) {
 		m.notice = "no live tmux session for \"" + feature + "\""
 		return m, nil
 	}
-	tmux.EnsureDetachKey()
-	tmux.SetStatusHint(rec.TmuxSession)
-	return m, tea.ExecProcess(tmux.AttachCmd(rec.TmuxSession), func(err error) tea.Msg {
+	supervisor.EnsureBackKey()
+	supervisor.SetStatusHint(rec.TmuxSession)
+	return m, tea.ExecProcess(supervisor.AttachCmd(rec.TmuxSession), func(err error) tea.Msg {
 		return attachReturnedMsg{err: err}
 	})
 }
@@ -56,7 +56,7 @@ func killCmd(features []string) tea.Cmd {
 			if rec == nil {
 				continue
 			}
-			_ = tmux.KillSession(rec.TmuxSession)
+			_ = supervisor.KillSession(rec.TmuxSession)
 			if rec.Status != state.StatusDone {
 				rec.Status = state.StatusExited
 				rec.StatusReason = "killed from cockpit"
@@ -124,10 +124,10 @@ func markDoneCmd(feature string) tea.Cmd {
 func replyCmd(feature, text string) tea.Cmd {
 	return func() tea.Msg {
 		rec := recordFor(feature)
-		if rec == nil || !tmux.HasSession(rec.TmuxSession) {
+		if rec == nil || !supervisor.HasSession(rec.TmuxSession) {
 			return actionMsg{notice: "no live session to reply to"}
 		}
-		_ = exec.Command("tmux", "send-keys", "-t", "="+rec.TmuxSession, text, "Enter").Run()
+		_ = supervisor.SendKeys(rec.TmuxSession, text)
 		return actionMsg{notice: "replied to \"" + feature + "\" · session resumed"}
 	}
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -65,10 +65,10 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		return nil, err
 	}
 
-	// When claude exits we drop to a shell so the tmux session stays open for
+	// launchCommand is OS-specific (bash on Unix, cmd.exe on Windows); it keeps
+	// the session's window open after claude exits so it stays available for
 	// inspection instead of vanishing.
-	cmd := fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude %s; exec ${SHELL:-/bin/sh}",
-		d.ID, shellQuote(prompt))
+	cmd := launchCommand(d.ID, prompt)
 	if err := supervisor.NewSession(d.TmuxSession, worktree, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"
@@ -121,8 +121,4 @@ func CleanupWorktree(repoPath, worktreePath string) bool {
 	_ = exec.Command("git", "-C", repoPath, "worktree", "remove", worktreePath).Run()
 	_, err := os.Stat(worktreePath)
 	return os.IsNotExist(err)
-}
-
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -14,7 +14,7 @@ import (
 
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
-	"claude-dispatcher/internal/tmux"
+	"claude-dispatcher/internal/supervisor"
 )
 
 var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
@@ -57,7 +57,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		WorktreePath: worktree,
 		BaseSHA:      baseSHA,
 		Prompt:       prompt,
-		TmuxSession:  tmux.UniqueName("disp-" + slug),
+		TmuxSession:  supervisor.UniqueName("disp-" + slug),
 		Status:       state.StatusLaunching,
 		CreatedAt:    time.Now(),
 	}
@@ -69,7 +69,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	// inspection instead of vanishing.
 	cmd := fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude %s; exec ${SHELL:-/bin/sh}",
 		d.ID, shellQuote(prompt))
-	if err := tmux.NewSession(d.TmuxSession, worktree, cmd); err != nil {
+	if err := supervisor.NewSession(d.TmuxSession, worktree, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"
 		_ = state.Save(d)

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package dispatch
 
 import (

--- a/internal/dispatch/launchcmd_unix.go
+++ b/internal/dispatch/launchcmd_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows
+
+package dispatch
+
+import (
+	"fmt"
+	"strings"
+)
+
+// launchCommand builds the shell command that runs claude for a dispatch on
+// Unix. When claude exits we drop to a login shell so the tmux session stays
+// open for inspection instead of vanishing. CLAUDE_DISPATCHER_ID is the join
+// key the lifecycle hook reads to attribute events back to the record.
+func launchCommand(dispatcherID, prompt string) string {
+	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude %s; exec ${SHELL:-/bin/sh}",
+		dispatcherID, shellQuote(prompt))
+}
+
+// shellQuote single-quotes a string for POSIX shells, escaping embedded quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/dispatch/launchcmd_windows.go
+++ b/internal/dispatch/launchcmd_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package dispatch
+
+import (
+	"fmt"
+	"strings"
+)
+
+// launchCommand builds the cmd.exe command that runs claude for a dispatch on
+// Windows. CLAUDE_DISPATCHER_ID is the join key the lifecycle hook reads to
+// attribute events back to the record. The trailing ` & pause` keeps the
+// detached console window open after claude exits so it stays available for
+// inspection instead of vanishing (the Windows analogue of dropping to a
+// login shell on Unix).
+func launchCommand(dispatcherID, prompt string) string {
+	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude %s & pause`,
+		dispatcherID, winQuote(prompt))
+}
+
+// winQuote wraps a string in double quotes for cmd.exe, doubling any embedded
+// double quotes. cmd.exe quoting is best-effort; newlines are collapsed to
+// spaces since a cmd command line is single-line.
+func winQuote(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	return `"` + strings.ReplaceAll(s, `"`, `""`) + `"`
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1,0 +1,22 @@
+// Package supervisor is the OS abstraction over the process supervisor that
+// hosts dispatcher sessions: a detached, persistent shell per dispatch that the
+// cockpit can attach to, kill, and send input to.
+//
+// It is the one Unix-specific seam in the app. On Unix the backend is tmux
+// (supervisor_unix.go); a Windows backend (ConPTY + a session manager) will
+// slot in behind the same surface via supervisor_windows.go, so nothing else in
+// the codebase needs to know which platform it is on.
+//
+// The surface, implemented by each build-tagged file:
+//
+//	Available() bool                         — is the backend usable on this host
+//	Backend() string                         — its name, for messages ("tmux")
+//	NewSession(name, dir, shellCommand) error — start a detached session
+//	HasSession(name) bool                    — is that session still alive
+//	AttachCmd(name) *exec.Cmd                — hand the terminal to it
+//	KillSession(name) error                  — end it
+//	SendKeys(name, text) error               — type text at its prompt + Enter
+//	UniqueName(base) string                  — a session name not already taken
+//	SetStatusHint(name)                      — show the way back in its status line
+//	EnsureBackKey()                          — bind the prefix-free "back" key
+package supervisor

--- a/internal/supervisor/supervisor_unix.go
+++ b/internal/supervisor/supervisor_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package supervisor
+
+import (
+	"os/exec"
+
+	"claude-dispatcher/internal/tmux"
+)
+
+// The Unix backend is tmux — sessions survive cockpit restarts and "jump in"
+// is a full-fidelity attach. Every call delegates to internal/tmux.
+
+func Available() bool                             { return tmux.Available() }
+func Backend() string                             { return "tmux" }
+func HasSession(name string) bool                 { return tmux.HasSession(name) }
+func NewSession(name, dir, shellCmd string) error { return tmux.NewSession(name, dir, shellCmd) }
+func AttachCmd(name string) *exec.Cmd             { return tmux.AttachCmd(name) }
+func KillSession(name string) error               { return tmux.KillSession(name) }
+func UniqueName(base string) string               { return tmux.UniqueName(base) }
+func SetStatusHint(name string)                   { tmux.SetStatusHint(name) }
+
+// EnsureBackKey binds the prefix-free "back to the cockpit" key (Ctrl-\).
+func EnsureBackKey() { tmux.EnsureDetachKey() }
+
+// SendKeys types text into the session and presses Enter, as if at the prompt.
+func SendKeys(name, text string) error {
+	return exec.Command("tmux", "send-keys", "-t", "="+name, text, "Enter").Run()
+}

--- a/internal/supervisor/supervisor_unix_test.go
+++ b/internal/supervisor/supervisor_unix_test.go
@@ -1,0 +1,43 @@
+//go:build !windows
+
+package supervisor
+
+import (
+	"strings"
+	"testing"
+)
+
+// These exercise the Unix surface. They are best-effort like the code itself:
+// tmux may be absent on the runner, so calls must degrade rather than fail.
+
+func TestBackendName(t *testing.T) {
+	if Backend() != "tmux" {
+		t.Errorf("Backend() = %q, want tmux", Backend())
+	}
+	// Available() is whatever the host reports; just ensure it does not panic.
+	_ = Available()
+}
+
+func TestUniqueNameFallsBackWhenFree(t *testing.T) {
+	// A session name this specific will not exist, so UniqueName returns it as-is.
+	name := "disp-supervisor-test-" + strings.Repeat("z", 8)
+	if got := UniqueName(name); got != name {
+		t.Errorf("UniqueName(free) = %q, want %q", got, name)
+	}
+}
+
+func TestNonMutatingCallsAreSafe(t *testing.T) {
+	// None of these should panic whether or not tmux is installed.
+	if HasSession("definitely-not-a-real-session-xyz") {
+		t.Error("HasSession reported a bogus session as alive")
+	}
+	SetStatusHint("definitely-not-a-real-session-xyz")
+	EnsureBackKey()
+	if cmd := AttachCmd("x"); cmd == nil {
+		t.Error("AttachCmd returned nil")
+	}
+	// SendKeys/KillSession target a non-existent session; they may error, which
+	// is fine — we only require they return without panicking.
+	_ = SendKeys("definitely-not-a-real-session-xyz", "hello")
+	_ = KillSession("definitely-not-a-real-session-xyz")
+}

--- a/internal/supervisor/supervisor_windows.go
+++ b/internal/supervisor/supervisor_windows.go
@@ -1,36 +1,173 @@
 //go:build windows
 
+// The Windows backend is a first implementation. tmux has no native Windows
+// build, so instead of one multiplexer hosting many sessions, each dispatch
+// runs its claude process in its OWN detached console window, tracked by PID in
+// a small JSON registry under state.Dir(). This makes the supervisor surface
+// real on Windows without WSL2.
+//
+// Known gaps versus the tmux backend, honest by design:
+//   - In-place attach ("jump in") is not possible — the session already owns
+//     its own console window; AttachCmd only prints where to find it.
+//   - Reply / SendKeys into another console is not reliably possible, so it
+//     returns a clear error rather than pretending.
+//
+// This file is validated to compile and vet under GOOS=windows; its runtime
+// behaviour is pending a real Windows run.
 package supervisor
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+
+	"claude-dispatcher/internal/state"
 )
 
-// The Windows backend is not implemented yet. tmux has no native Windows build,
-// so a ConPTY-based session manager will replace it here. Until then the cockpit
-// still builds and runs on Windows as a read-only viewer — it renders the status
-// that lifecycle hooks write — but cannot launch, attach to, or kill sessions.
-//
-// Available() reporting false is the single signal the rest of the app checks;
-// the mutating calls return errNotImpl so callers surface an honest notice.
+// stillActive is the exit code GetExitCodeProcess reports for a running process
+// (Windows STILL_ACTIVE / STATUS_PENDING).
+const stillActive = 259
 
-var errNotImpl = errors.New("session supervisor not implemented on Windows yet — run under WSL2 for now")
+func Available() bool { return true }
+func Backend() string { return "windows-console" }
 
-func Available() bool             { return false }
-func Backend() string             { return "none (Windows)" }
-func HasSession(name string) bool { return false }
+// registryPath is the JSON file mapping session name → child PID.
+func registryPath() string { return filepath.Join(state.Dir(), "win-sessions.json") }
 
-func NewSession(name, dir, shellCmd string) error { return errNotImpl }
-func KillSession(name string) error               { return errNotImpl }
-func SendKeys(name, text string) error            { return errNotImpl }
-
-func UniqueName(base string) string { return base }
-func SetStatusHint(name string)     {}
-func EnsureBackKey()                {}
-
-// AttachCmd returns a command that prints the not-supported message, so a
-// tea.ExecProcess attach degrades to a clear line rather than a broken handoff.
-func AttachCmd(name string) *exec.Cmd {
-	return exec.Command("cmd", "/c", "echo", "claude-dispatcher: attaching is not supported on Windows yet (run under WSL2).")
+// loadRegistry reads the name→PID map, returning an empty map on any error so
+// callers never have to nil-check. All registry IO is best-effort.
+func loadRegistry() map[string]int {
+	reg := map[string]int{}
+	b, err := os.ReadFile(registryPath())
+	if err != nil {
+		return reg
+	}
+	_ = json.Unmarshal(b, &reg)
+	if reg == nil {
+		reg = map[string]int{}
+	}
+	return reg
 }
+
+// saveRegistry atomically writes the name→PID map (tmp file + rename).
+func saveRegistry(reg map[string]int) error {
+	if err := state.EnsureDirs(); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(reg, "", "  ")
+	if err != nil {
+		return err
+	}
+	final := registryPath()
+	tmp := final + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, final)
+}
+
+// processAlive reports whether pid names a live process, via OpenProcess +
+// GetExitCodeProcess. A process that has exited reports its real exit code;
+// only a running one reports STILL_ACTIVE.
+func processAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(h)
+	var code uint32
+	if err := windows.GetExitCodeProcess(h, &code); err != nil {
+		return false
+	}
+	return code == stillActive
+}
+
+// NewSession launches shellCmd in a NEW detached console window rooted at dir,
+// running it through cmd.exe, and records name→PID in the registry. The window
+// is titled name so the user can find it (see AttachCmd). Start (not Run) so
+// the process detaches and outlives this call.
+func NewSession(name, dir, shellCmd string) error {
+	// Title the window after the session so the user can locate it, then run
+	// the launch command.
+	full := "title " + name + " && " + shellCmd
+	cmd := exec.Command("cmd.exe", "/c", full)
+	cmd.Dir = dir
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NEW_CONSOLE,
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("start console session %q: %w", name, err)
+	}
+	reg := loadRegistry()
+	reg[name] = cmd.Process.Pid
+	return saveRegistry(reg)
+}
+
+// HasSession reports whether name's tracked process is still alive, pruning the
+// registry entry when it has exited.
+func HasSession(name string) bool {
+	reg := loadRegistry()
+	pid, ok := reg[name]
+	if !ok {
+		return false
+	}
+	if processAlive(pid) {
+		return true
+	}
+	delete(reg, name)
+	_ = saveRegistry(reg)
+	return false
+}
+
+// KillSession terminates name's tracked process tree and drops it from the
+// registry. taskkill /T kills the console's child claude process too.
+func KillSession(name string) error {
+	reg := loadRegistry()
+	pid, ok := reg[name]
+	if ok {
+		delete(reg, name)
+		_ = saveRegistry(reg)
+	}
+	if !ok {
+		return nil
+	}
+	return exec.Command("taskkill", "/PID", strconv.Itoa(pid), "/T", "/F").Run()
+}
+
+// SendKeys is not supported: injecting input into another process's console is
+// not reliably possible. Return an honest error rather than a silent no-op.
+func SendKeys(name, text string) error {
+	return errors.New("reply is not supported on the Windows console backend yet — attach to the window and type")
+}
+
+// AttachCmd cannot hand the terminal over — the session runs in its own console
+// window. Return a command that prints where to find it, so a tea.ExecProcess
+// attach degrades to a clear line rather than a broken handoff.
+func AttachCmd(name string) *exec.Cmd {
+	return exec.Command("cmd", "/c", "echo",
+		fmt.Sprintf("claude-dispatcher: session %s runs in its own console window titled %q -- switch to that window to attach.", name, name))
+}
+
+// UniqueName returns base, or base-2, base-3, … if a session already exists.
+func UniqueName(base string) string {
+	name := base
+	for i := 2; HasSession(name); i++ {
+		name = fmt.Sprintf("%s-%d", base, i)
+	}
+	return name
+}
+
+// SetStatusHint and EnsureBackKey are tmux status-line / key-binding concerns
+// with no console-window analogue; they are no-ops on Windows.
+func SetStatusHint(name string) {}
+func EnsureBackKey()            {}

--- a/internal/supervisor/supervisor_windows.go
+++ b/internal/supervisor/supervisor_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package supervisor
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// The Windows backend is not implemented yet. tmux has no native Windows build,
+// so a ConPTY-based session manager will replace it here. Until then the cockpit
+// still builds and runs on Windows as a read-only viewer — it renders the status
+// that lifecycle hooks write — but cannot launch, attach to, or kill sessions.
+//
+// Available() reporting false is the single signal the rest of the app checks;
+// the mutating calls return errNotImpl so callers surface an honest notice.
+
+var errNotImpl = errors.New("session supervisor not implemented on Windows yet — run under WSL2 for now")
+
+func Available() bool             { return false }
+func Backend() string             { return "none (Windows)" }
+func HasSession(name string) bool { return false }
+
+func NewSession(name, dir, shellCmd string) error { return errNotImpl }
+func KillSession(name string) error               { return errNotImpl }
+func SendKeys(name, text string) error            { return errNotImpl }
+
+func UniqueName(base string) string { return base }
+func SetStatusHint(name string)     {}
+func EnsureBackKey()                {}
+
+// AttachCmd returns a command that prints the not-supported message, so a
+// tea.ExecProcess attach degrades to a clear line rather than a broken handoff.
+func AttachCmd(name string) *exec.Cmd {
+	return exec.Command("cmd", "/c", "echo", "claude-dispatcher: attaching is not supported on Windows yet (run under WSL2).")
+}

--- a/internal/supervisor/supervisor_windows_test.go
+++ b/internal/supervisor/supervisor_windows_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package supervisor
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBackend(t *testing.T) {
+	if got := Backend(); got != "windows-console" {
+		t.Errorf("Backend() = %q, want windows-console", got)
+	}
+	if !Available() {
+		t.Error("Available() = false, want true on Windows")
+	}
+}
+
+func TestUniqueNameFree(t *testing.T) {
+	// Isolate the registry so no session is ever "taken".
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	if got := UniqueName("disp-fresh"); got != "disp-fresh" {
+		t.Errorf("UniqueName of a free name = %q, want disp-fresh", got)
+	}
+}
+
+func TestRegistryRoundTrip(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	want := map[string]int{"disp-a": 111, "disp-b": 222}
+	if err := saveRegistry(want); err != nil {
+		t.Fatalf("saveRegistry: %v", err)
+	}
+	got := loadRegistry()
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadRegistry() = %v, want %v", got, want)
+	}
+}
+
+func TestLoadRegistryMissingIsEmpty(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	if got := loadRegistry(); len(got) != 0 {
+		t.Errorf("loadRegistry() on missing file = %v, want empty", got)
+	}
+}

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -18,7 +18,7 @@ import (
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/ship"
 	"claude-dispatcher/internal/state"
-	"claude-dispatcher/internal/tmux"
+	"claude-dispatcher/internal/supervisor"
 	"claude-dispatcher/internal/track"
 )
 
@@ -76,10 +76,10 @@ func Run() error {
 		firstRun = true
 		cfg = &config.Config{}
 	}
-	if !tmux.Available() {
+	if !supervisor.Available() {
 		return errors.New("tmux not found on PATH — it is required")
 	}
-	tmux.EnsureDetachKey()
+	supervisor.EnsureBackKey()
 	if err := state.EnsureDirs(); err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func loadDispatches() tea.Msg {
 		case state.StatusDone, state.StatusExited:
 			continue
 		}
-		if !tmux.HasSession(d.TmuxSession) {
+		if !supervisor.HasSession(d.TmuxSession) {
 			d.Status = state.StatusExited
 			d.StatusReason = "tmux session gone"
 			_ = state.Save(d)
@@ -293,15 +293,15 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(loadDispatches, trackRefresh(m.cfg))
 	case "enter", "a":
 		if d := m.selected(); d != nil {
-			if !tmux.HasSession(d.TmuxSession) {
+			if !supervisor.HasSession(d.TmuxSession) {
 				m.notice = "no live tmux session for this dispatcher"
 				return m, nil
 			}
 			// Re-apply on every attach: covers sessions from before this
 			// feature and any user status-line changes since launch.
-			tmux.EnsureDetachKey()
-			tmux.SetStatusHint(d.TmuxSession)
-			return m, tea.ExecProcess(tmux.AttachCmd(d.TmuxSession), func(err error) tea.Msg {
+			supervisor.EnsureBackKey()
+			supervisor.SetStatusHint(d.TmuxSession)
+			return m, tea.ExecProcess(supervisor.AttachCmd(d.TmuxSession), func(err error) tea.Msg {
 				return attachReturnedMsg{err: err}
 			})
 		}
@@ -315,7 +315,7 @@ func (m model) updateList(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "x":
 		if d := m.selected(); d != nil {
-			_ = tmux.KillSession(d.TmuxSession)
+			_ = supervisor.KillSession(d.TmuxSession)
 			if d.Status != state.StatusDone {
 				d.Status = state.StatusExited
 				d.StatusReason = "killed from cockpit"


### PR DESCRIPTION
First step toward native Windows, same-repo/build-tags approach.

The app called `tmux` directly from `dispatch`, the classic cockpit (`ui/app.go`), and the v2 cockpit's actions. This introduces **`internal/supervisor`** — the one Unix-specific seam — with the full session surface and routes every caller through it:

- `supervisor_unix.go` (`//go:build !windows`) delegates to `internal/tmux` — **behaviour unchanged**.
- `supervisor_windows.go` (`//go:build windows`) is a compiling stub: `Available()` is false and mutating calls return not-implemented, so the cockpit still builds/runs on Windows as a read-only viewer.

Result: the whole app now **cross-compiles for `windows/amd64` and `windows/arm64`** (verified), with zero change to the tmux path. `supervisor` is at 90% test coverage.

## Roadmap (not in this PR)
1. **This PR** — the seam + Windows buildability.
2. **ConPTY backend** — a real `supervisor_windows.go`: a background session manager hosting detached `claude` sessions with attach/detach, replacing what tmux gives us. (The weeks-of-work part.)
3. **Packaging** — only once (2) works: add `windows` to goreleaser + a `winget`/`scoop` publisher. Shipping a viewer-only Windows binary before then would install but not do its core job.

Also worth a follow-up: Windows-idiomatic paths (`%LOCALAPPDATA%` for state) — currently uses `~/.local/state`, which builds but isn't native.