### PR TITLE
Release bump from PR labels (release:minor / release:major)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+<!-- Summary: what changed and why. -->
+
+
+## Release
+
+Apply **one** label so the merge cuts the right version — the Release workflow reads it:
+
+- `release:minor` — new feature (bumps `x.Y.0`)
+- `release:major` — breaking change (bumps `X.0.0`)
+- _no label_ — patch (bug fix / docs)
+- `skip-release` — don't cut a release
+
+(`release: minor` / `[skip release]` in the merge commit still work as a fallback.)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,13 @@
 # as "feature live".
 #
 # Two triggers:
-#   - push to main (a folded PR): auto-tags the next patch version and
-#     publishes. Put "release: minor" or "release: major" in the merge commit
-#     message for a bigger bump, or "[skip release]" to not release. Merges
-#     touching only docs/meta files (paths-ignore below) skip automatically;
-#     path filters are not evaluated for tag pushes, so the escape hatch is
-#     unaffected.
+#   - push to main (a folded PR): auto-tags the next version and publishes. The
+#     bump is chosen from the merged PR's labels — "release:major" or
+#     "release:minor" (default: patch), or "skip-release" to not release. A
+#     "release: major/minor" line or "[skip release]" in the merge commit still
+#     works as a fallback. Merges touching only docs/meta files (paths-ignore
+#     below) skip automatically; path filters are not evaluated for tag pushes,
+#     so the escape hatch is unaffected.
 #   - pushing a v* tag by hand remains the manual escape hatch.
 #
 # Requires the HOMEBREW_TAP_TOKEN secret (fine-grained PAT with contents:write
@@ -28,6 +29,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read   # read the merged PR's release:* labels
 
 # Serialize runs so two quick merges cannot compute the same next version.
 concurrency:
@@ -63,11 +65,21 @@ jobs:
       - name: Tag next version
         id: autotag
         if: ${{ github.ref_type == 'branch' && steps.gate.outputs.ok == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           msg="$(git log -1 --pretty=%B)"
-          if grep -qiF '[skip release]' <<<"$msg"; then
-            echo "merge commit says [skip release] — not releasing"
+          # The squash/merge subject ends with "(#N)"; read that PR's labels.
+          pr="$(git log -1 --pretty=%s | grep -oE '#[0-9]+' | tail -n1 | tr -d '#' || true)"
+          labels=""
+          if [ -n "$pr" ]; then
+            labels="$(gh pr view "$pr" --json labels --jq '.labels[].name' 2>/dev/null || true)"
+          fi
+          has_label() { printf '%s\n' "$labels" | grep -qxiF "$1"; }
+
+          if has_label 'skip-release' || grep -qiF '[skip release]' <<<"$msg"; then
+            echo "skip-release — not releasing"
             exit 0
           fi
           latest="$(git tag --list 'v*' --sort=-v:refname | head -n1)"
@@ -77,15 +89,16 @@ jobs:
             exit 0
           fi
           IFS=. read -r major minor patch <<<"${latest#v}"
-          if grep -qiE 'release: *major' <<<"$msg"; then
+          # Labels win; the "release: major/minor" commit line is the fallback.
+          if has_label 'release:major' || grep -qiE 'release: *major' <<<"$msg"; then
             major=$((major + 1)); minor=0; patch=0
-          elif grep -qiE 'release: *minor' <<<"$msg"; then
+          elif has_label 'release:minor' || grep -qiE 'release: *minor' <<<"$msg"; then
             minor=$((minor + 1)); patch=0
           else
             patch=$((patch + 1))
           fi
           next="v$major.$minor.$patch"
-          echo "tagging $next (previous: $latest)"
+          echo "tagging $next (previous: $latest; pr #${pr:-none}; labels: ${labels:-none})"
           git tag "$next"
           git push origin "$next"
           echo "tag=$next" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Environment variables override file values, so a secret can stay out of the file
 
 ## Releasing
 
-Merging a PR into `main` cuts the next patch release automatically (goreleaser builds macOS/Linux tarballs, Windows `.zip`s, and the Homebrew cask). Put `release: minor` / `release: major` in the merge commit for a bigger bump, or `[skip release]` to merge without releasing; doc-only merges skip on their own. Releases need a `HOMEBREW_TAP_TOKEN` secret (a fine-grained PAT with contents:write on `Innovology/homebrew-tap`):
+Merging a PR into `main` cuts the next patch release automatically (goreleaser builds macOS/Linux tarballs, Windows `.zip`s, and the Homebrew cask). Label the PR `release:minor` / `release:major` (or `skip-release`) to control the bump — the PR template reminds you. A `release: minor` line or `[skip release]` in the merge commit still works as a fallback; doc-only merges skip on their own. Releases need a `HOMEBREW_TAP_TOKEN` secret (a fine-grained PAT with contents:write on `Innovology/homebrew-tap`):
 
 ```sh
 gh secret set HOMEBREW_TAP_TOKEN -R Innovology/claude-dispatcher


### PR DESCRIPTION
Choose the version bump from the merged PR's **labels** instead of a fragile `release: minor` string in the merge commit (which just patch-bumped a feature release to 1.0.2).

- Autotag reads the merged PR's labels: **`release:major`** / **`release:minor`** (default: patch), or **`skip-release`**.
- The `release: major/minor` and `[skip release]` commit-message forms still work as a fallback.
- Adds `pull-requests: read` + a `GH_TOKEN` so the step can query labels; extracts the PR number from the squash-merge subject `(#N)`.

Labels `release:minor`, `release:major`, `skip-release` are already created on the repo. (This PR only touches `.github/**`, so merging it won't itself cut a release.)