### PR TITLE
Redraw the cockpit on Ctrl-L

### DIFF
--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -242,6 +242,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// Ctrl-L: force a full clear + repaint, the universal "redraw" key —
+		// handy after a tmux attach or any terminal noise garbles the screen.
+		if msg.String() == "ctrl+l" {
+			return m, tea.ClearScreen
+		}
 		return m.handleKey(msg.String())
 	}
 	return m, nil

--- a/internal/cockpit/redraw_test.go
+++ b/internal/cockpit/redraw_test.go
@@ -1,0 +1,18 @@
+package cockpit
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Ctrl-L must return a redraw command (tea.ClearScreen), so a garbled screen
+// can be repainted.
+func TestCtrlLRedraw(t *testing.T) {
+	m := newModel()
+	m.width, m.height = 120, 40
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlL})
+	if cmd == nil {
+		t.Fatal("ctrl+l should return a redraw cmd, got nil")
+	}
+}


### PR DESCRIPTION
Ctrl-L was a no-op in the cockpit. It now forces a full clear + repaint (`tea.ClearScreen`) — the universal terminal redraw key, handy after a tmux attach or any terminal noise garbles the screen. Small test included.