### PR TITLE
Split usage by model family, so Fable 5 stops hiding in "other"

### DIFF
--- a/internal/cockpit/collect_usage.go
+++ b/internal/cockpit/collect_usage.go
@@ -8,6 +8,8 @@ package cockpit
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"claude-dispatcher/internal/state"
@@ -66,14 +68,15 @@ func collectUsage(ctx *collectCtx, s *snapshot) {
 
 	// ---- by model (this week) -----------------------------------------------
 	notes := map[string]string{
+		"fable":  "the top tier — hardest and longest-horizon work",
+		"mythos": "the top tier — hardest and longest-horizon work",
 		"opus":   "blocked, urgent and long-context work",
 		"sonnet": "the default for feature work",
 		"haiku":  "pr writing, changelogs, quick passes",
-		"other":  "other models",
 	}
 	wk := sum.Weekly
 	models := []usageModel{}
-	for _, name := range []string{"opus", "sonnet", "haiku", "other"} {
+	for _, name := range usgModelOrder(wk.ByModel) {
 		tok := wk.ByModel[name]
 		if tok == 0 {
 			continue
@@ -104,9 +107,16 @@ func collectUsage(ctx *collectCtx, s *snapshot) {
 	// ---- advice / what would change it --------------------------------------
 	advice := []usageAdviceItem{}
 	if wk.Total > 0 {
-		if op := wk.ByModel["opus"]; op > 0 {
+		// The premium tiers together, not opus alone — fable/mythos price above
+		// opus, so counting only opus understates what the week actually cost.
+		premium := 0
+		for _, name := range usgPremium {
+			premium += wk.ByModel[name]
+		}
+		if premium > 0 {
 			advice = append(advice, usageAdviceItem{
-				text: fmt.Sprintf("opus is %d%% of the week's tokens — the expensive share", 100*op/wk.Total), color: cAmber,
+				text: fmt.Sprintf("%s is %d%% of the week's tokens — the expensive share",
+					usgJoin(usgPresent(wk.ByModel, usgPremium)), 100*premium/wk.Total), color: cAmber,
 			})
 		}
 		advice = append(advice, usageAdviceItem{
@@ -120,6 +130,58 @@ func collectUsage(ctx *collectCtx, s *snapshot) {
 		})
 	}
 	s.usageAdvice = advice
+}
+
+// usgPremium are the tiers that price above the rest — the "expensive share".
+var usgPremium = []string{"fable", "mythos", "opus"}
+
+// usgModelOrder lists the models to render: the known families in tier order
+// first, then anything unrecognised, heaviest first. An unknown model shows
+// under its own id rather than being swept into a nameless "other" row.
+func usgModelOrder(byModel map[string]int) []string {
+	known := map[string]bool{}
+	for _, f := range usage.Families {
+		known[f] = true
+	}
+	order := append([]string{}, usage.Families...)
+
+	rest := []string{}
+	for name := range byModel {
+		if !known[name] {
+			rest = append(rest, name)
+		}
+	}
+	sort.Slice(rest, func(i, j int) bool {
+		if byModel[rest[i]] != byModel[rest[j]] {
+			return byModel[rest[i]] > byModel[rest[j]]
+		}
+		return rest[i] < rest[j]
+	})
+	return append(order, rest...)
+}
+
+// usgPresent keeps only the names that drew tokens this week.
+func usgPresent(byModel map[string]int, names []string) []string {
+	out := []string{}
+	for _, n := range names {
+		if byModel[n] > 0 {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// usgJoin renders a name list as prose: "fable", "fable and opus",
+// "fable, mythos and opus".
+func usgJoin(names []string) string {
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + " and " + names[len(names)-1]
+	}
 }
 
 // usgAgo formats a rough age like "3h", "2d".

--- a/internal/cockpit/usage.go
+++ b/internal/cockpit/usage.go
@@ -113,7 +113,7 @@ func (m model) usageRight(w int) []string {
 	for _, md := range usageModels {
 		out = append(out, "")
 		col := cGreen
-		if md.name == "opus" {
+		if usgIsPremium(md.name) {
 			col = cAmber
 		}
 		lead := fg(cWhite, padTo(md.name, 9, alignLeft)) + "  " +
@@ -150,6 +150,17 @@ func (m model) usageRight(w int) []string {
 }
 
 // ---- usage-local helpers ----------------------------------------------------
+
+// usgIsPremium reports whether a model row is one of the expensive tiers, which
+// the by-model bars draw in amber rather than green.
+func usgIsPremium(name string) bool {
+	for _, p := range usgPremium {
+		if name == p {
+			return true
+		}
+	}
+	return false
+}
 
 // usageFill lays left flush-left and right flush-right within width w, the
 // terminal analogue of the design's margin-left:auto.

--- a/internal/usage/bucket_test.go
+++ b/internal/usage/bucket_test.go
@@ -1,0 +1,29 @@
+package usage
+
+import "testing"
+
+// Fable 5 is its own model family, not an Opus version — it used to fall into a
+// nameless "other" row while accounting for ~40% of a week's tokens. Every Opus
+// version, meanwhile, must land on the single "opus" row: the by-model split is
+// by family, not by point release.
+func TestBucketByFamilyNotVersion(t *testing.T) {
+	for _, c := range []struct{ model, want string }{
+		{"claude-fable-5", "fable"},
+		{"claude-mythos-5", "mythos"},
+		{"claude-mythos-preview", "mythos"},
+		{"claude-opus-5", "opus"},
+		{"claude-opus-4-8", "opus"},
+		{"claude-opus-4-6", "opus"},
+		{"claude-sonnet-5", "sonnet"},
+		{"sonnet", "sonnet"},
+		{"claude-haiku-4-5-20251001", "haiku"},
+		// Unknown models keep their own id rather than vanishing into "other".
+		{"claude-gizmo-6-20260401", "gizmo-6"},
+		{"<synthetic>", "<synthetic>"},
+		{"", "unknown"},
+	} {
+		if got := bucket(c.model); got != c.want {
+			t.Errorf("bucket(%q) = %q, want %q", c.model, got, c.want)
+		}
+	}
+}

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -40,7 +40,7 @@ const (
 // Stat is one window's consumption and its learned cap.
 type Stat struct {
 	Total     int            // tokens consumed in the window
-	ByModel   map[string]int // bucketed model → tokens (opus/sonnet/haiku/other)
+	ByModel   map[string]int // model family → tokens (see bucket: Families, else the id)
 	Sessions  int            // distinct sessions contributing
 	Cap       int            // learned cap; 0 = still learning
 	CapSource string         // "limit" (from a 429) | "observed" (ratcheted high-water) | ""
@@ -87,19 +87,45 @@ type store struct {
 	LastLimitUnix  int64  `json:"last_limit_unix"`
 }
 
-// bucket maps a raw model id to opus/sonnet/haiku/other.
+// Families are the model families we know by name, most expensive first. The
+// cockpit renders them in this order; anything else keeps its own id (see
+// bucket), so a new model never disappears into an unlabelled "other" row.
+var Families = []string{"fable", "mythos", "opus", "sonnet", "haiku"}
+
+// bucket maps a raw model id to its family. An id from no known family is NOT
+// folded into a catch-all: it keeps its own name (minus the "claude-" prefix
+// and any date suffix), because "other models" tells you nothing when a whole
+// new tier — Fable 5 was 40% of a week — lands in it.
 func bucket(model string) string {
-	m := strings.ToLower(model)
-	switch {
-	case strings.Contains(m, "opus"):
-		return "opus"
-	case strings.Contains(m, "haiku"):
-		return "haiku"
-	case strings.Contains(m, "sonnet"):
-		return "sonnet"
-	default:
-		return "other"
+	m := strings.ToLower(strings.TrimSpace(model))
+	for _, f := range Families {
+		if strings.Contains(m, f) {
+			return f
+		}
 	}
+	return trimModelID(m)
+}
+
+// trimModelID shortens a raw id for display: "claude-gizmo-6-20260401" → "gizmo-6".
+func trimModelID(m string) string {
+	if m == "" {
+		return "unknown"
+	}
+	m = strings.TrimPrefix(m, "claude-")
+	// Drop a trailing 8-digit date stamp ("-20251001"), which is noise in a label.
+	if i := strings.LastIndex(m, "-"); i > 0 && len(m)-i == 9 && isDigits(m[i+1:]) {
+		m = m[:i]
+	}
+	return m
+}
+
+func isDigits(s string) bool {
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return len(s) > 0
 }
 
 func claudeDir() string {


### PR DESCRIPTION
## The bug

The USAGE lens showed **"other models"** for 40% of the week's tokens.

It was not an Opus point release landing in the wrong bucket. `bucket()` matched
on substrings, so `claude-opus-5`, `claude-opus-4-8` and `claude-opus-4-6` all
already collapsed onto the single `opus` row — which is what we want, since the
split is by family, not by point release.

The culprit was `claude-fable-5`. Fable 5 is a **separate model family** (the top
tier, priced above Opus), and it matched none of the three names `bucket()` knew,
so it fell through to the catch-all:

```
claude-opus-4-8            67.1M tok   → opus
claude-fable-5             60.9M tok   → "other"   ← 40% of the week, unlabelled
claude-opus-5              21.5M tok   → opus
claude-haiku-4-5-20251001   0.7M tok   → haiku
claude-sonnet-5             0.7M tok   → sonnet
claude-opus-4-6             0.1M tok   → opus
```

## The fix

Name `fable` and `mythos` — and **drop the catch-all entirely**. An unrecognised
id now keeps its own name (`claude-gizmo-6-20260401` → `gizmo-6`) instead of
disappearing into an unlabelled bar, so the next new tier gets a labelled row the
day it first runs rather than becoming a thing to investigate.

The *"expensive share"* advice line counted `opus` alone, which understated the
week once a tier priced above opus was in play; it now sums the premium tiers and
names them. The amber bar colour follows the same set.

## Verification

`make vet`, `go build ./...` and the `internal/usage` + `internal/cockpit` suites
all pass, with a new `bucket_test.go` pinning the family-not-version rule
(including the unknown-id and empty-string paths).

Against real transcripts, the mystery row is gone — everything is now classified:

```
weekly total 151,977,755 tok
  opus     89,722,392  59%
  fable    60,911,964  40%
  haiku       674,350   0%
  sonnet      669,049   0%
```