### PR TITLE
Show the build version, and nag when it is behind

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w -X claude-dispatcher/internal/version.Version={{.Version}}
 
 archives:
   # Unix stays tar.gz; Windows ships a .zip (native tooling and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@
 - `internal/ui` — Bubble Tea cockpit; responsive tiling breakpoints at 110
   and 170 columns (more panes on wide screens, never one ballooned view).
 - `internal/ship` — shipping stats (Claude-stamped = Co-Authored-By trailer).
+- `internal/version` — the build's version (stamped by goreleaser via
+  `-X claude-dispatcher/internal/version.Version`) and the cached, best-effort
+  check for a newer release that drives the cockpit's upgrade hint.
 
 ## Build
 `make build` / `make vet` / `make install` (binary to ~/.local/bin — the init

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/version"
 )
 
 // lensOrder is the 1..8 lens bar, in order. Digit keys select by index.
@@ -51,6 +52,10 @@ type model struct {
 	paletteCursor int
 
 	notice string
+
+	// upgradeTo is the newest published release tag when this build is behind
+	// it, "" when up to date, unknown, or running unstamped.
+	upgradeTo string
 
 	shipCursor int
 	resumeOpen bool
@@ -166,10 +171,12 @@ type (
 )
 
 func (m model) Init() tea.Cmd {
+	// The upgrade check is about the binary, not the portfolio, so it runs even
+	// on demo data — a config-less cockpit is still a real build.
 	if m.cfg == nil {
-		return nil // no config — run on demo seed data
+		return upgradeCheckCmd() // no config — run on demo seed data
 	}
-	return tea.Batch(loadSnapshotCmd(m.cfg), trackRefreshCmd(m.cfg), waitState(m.stateCh), refreshTick())
+	return tea.Batch(loadSnapshotCmd(m.cfg), trackRefreshCmd(m.cfg), waitState(m.stateCh), refreshTick(), upgradeCheckCmd())
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -189,7 +196,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(loadSnapshotCmd(m.cfg), waitState(m.stateCh))
 
 	case refreshTickMsg:
-		return m, tea.Batch(trackRefreshCmd(m.cfg), refreshTick())
+		// Re-checked on the poll so a cockpit left open for days still notices
+		// a release; the version package's own cache decides when that costs a
+		// network call.
+		return m, tea.Batch(trackRefreshCmd(m.cfg), refreshTick(), upgradeCheckCmd())
+
+	case upgradeMsg:
+		if version.IsOutdated(msg.latest) {
+			m.upgradeTo = msg.latest
+		}
+		return m, nil
 
 	case trackedMsg:
 		return m, loadSnapshotCmd(m.cfg)

--- a/internal/cockpit/upgrade.go
+++ b/internal/cockpit/upgrade.go
@@ -1,0 +1,38 @@
+package cockpit
+
+// upgrade.go keeps the bottom-right corner honest about which build is running
+// and whether it is behind the published one.
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/version"
+)
+
+// upgradeMsg carries the newest published release tag to the UI goroutine.
+type upgradeMsg struct{ latest string }
+
+// upgradeCheckCmd looks up the newest release off the UI goroutine. The lookup
+// is cache-gated inside the version package, so firing it on every poll costs a
+// file read rather than a network call. A dev build skips it entirely: there is
+// no released version an unstamped build can be behind.
+func upgradeCheckCmd() tea.Cmd {
+	if !version.IsRelease() {
+		return nil
+	}
+	return func() tea.Msg { return upgradeMsg{latest: version.Latest()} }
+}
+
+// versionForms is the bottom-right version, widest rendering first. The footer
+// takes the first one that fits, so a cramped terminal keeps the version number
+// and drops the upgrade command rather than losing both.
+func (m model) versionForms() []string {
+	if m.upgradeTo == "" {
+		return []string{fg(cFaint, version.Display())}
+	}
+	behind := fg(cAmber, version.Display()+" → "+version.Label(m.upgradeTo))
+	return []string{
+		behind + fg(cDim, " · "+version.UpgradeHint()),
+		behind,
+	}
+}

--- a/internal/cockpit/upgrade_test.go
+++ b/internal/cockpit/upgrade_test.go
@@ -1,0 +1,153 @@
+package cockpit
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	"claude-dispatcher/internal/version"
+)
+
+// stampVersion runs the model as a released build for the duration of a test.
+func stampVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := version.Version
+	version.Version = v
+	t.Cleanup(func() { version.Version = orig })
+}
+
+// footerOf renders the cockpit and returns its last line — the footer —
+// stripped of colour.
+func footerOf(m model) string {
+	lines := strings.Split(m.View(), "\n")
+	return ansi.Strip(lines[len(lines)-1])
+}
+
+// TestFooterCarriesTheVersion checks the version sits in the bottom-right
+// corner of every lens, at every width that has room for it — and that where
+// there is no room (a narrow terminal whose keybinding help already fills the
+// row) it drops out cleanly rather than clipping the help.
+func TestFooterCarriesTheVersion(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	for _, w := range smokeWidths {
+		for i := 1; i <= 8; i++ {
+			m := newModel()
+			m.width, m.height = w, 44
+			m = press(m, itoa(i))
+			footer := footerOf(m)
+			shown := strings.Contains(footer, "v2.1.1")
+			fits := dispWidth(m.footerHelp())+2+len("v2.1.1") <= w-2*pad
+
+			switch {
+			case fits && !shown:
+				t.Errorf("lens %d @%d: room for the version but the footer has none: %q", i, w, footer)
+			case !fits && shown:
+				t.Errorf("lens %d @%d: version squeezed into a footer with no room: %q", i, w, footer)
+			}
+			if shown {
+				if trailing := len(footer) - len(strings.TrimRight(footer, " ")); trailing > pad {
+					t.Errorf("lens %d @%d: version is not at the right edge (%d trailing spaces): %q",
+						i, w, trailing, footer)
+				}
+			}
+		}
+	}
+}
+
+// TestFooterNagsWhenTheBuildIsBehind checks the upgrade command appears beside
+// the version once a newer release is known.
+func TestFooterNagsWhenTheBuildIsBehind(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height = 190, 44
+	m.upgradeTo = "v2.2.0"
+
+	footer := footerOf(m)
+	if !strings.Contains(footer, "v2.1.1 → v2.2.0") {
+		t.Errorf("footer does not show the upgrade: %q", footer)
+	}
+	if !strings.Contains(footer, version.UpgradeHint()) {
+		t.Errorf("footer does not show %q: %q", version.UpgradeHint(), footer)
+	}
+}
+
+// TestFooterShedsTheUpgradeCommandBeforeTheVersion: on a terminal too narrow
+// for both, the version number survives and the command is what goes.
+func TestFooterShedsTheUpgradeCommandBeforeTheVersion(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.height = 44
+	m.upgradeTo = "v2.2.0"
+
+	// Wide enough for the help plus "v2.1.1 → v2.2.0", not for the command.
+	m.width = dispWidth(m.footerHelp()) + len("v2.1.1 → v2.2.0") + 2*pad + 4
+	footer := footerOf(m)
+	if !strings.Contains(footer, "v2.1.1 → v2.2.0") {
+		t.Errorf("narrow footer lost the version: %q", footer)
+	}
+	if strings.Contains(footer, version.UpgradeHint()) {
+		t.Errorf("narrow footer kept the upgrade command it had no room for: %q", footer)
+	}
+}
+
+// TestNoticeOutranksTheVersion: a notice says what just happened, the version
+// is ambient — when only one fits, the notice keeps the corner.
+func TestNoticeOutranksTheVersion(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.height = 44
+	m.notice = "killed webhook retries"
+	// Room for the help and the notice, but not for the version too.
+	m.width = dispWidth(m.footerHelp()) + dispWidth(m.notice) + 2*pad + 4
+
+	footer := footerOf(m)
+	if !strings.Contains(footer, m.notice) {
+		t.Errorf("notice squeezed out by the version: %q", footer)
+	}
+	if strings.Contains(footer, "v2.1.1") {
+		t.Errorf("version kept a corner it had no room for: %q", footer)
+	}
+
+	// Given room for both, they share the corner.
+	m.width = 190
+	footer = footerOf(m)
+	if !strings.Contains(footer, m.notice) || !strings.Contains(footer, "v2.1.1") {
+		t.Errorf("wide footer should carry both notice and version: %q", footer)
+	}
+}
+
+// TestDevBuildIsNeverNagged: an unstamped build shows what it is and never
+// checks for, or claims to be behind, a release.
+func TestDevBuildIsNeverNagged(t *testing.T) {
+	stampVersion(t, "dev")
+	if upgradeCheckCmd() != nil {
+		t.Error("a dev build should not check for upgrades")
+	}
+	m := newModel()
+	m.width, m.height = 190, 44
+	if footer := footerOf(m); !strings.Contains(footer, "dev") {
+		t.Errorf("dev build footer does not say so: %q", footer)
+	}
+}
+
+// TestUpgradeMsgOnlyAcceptsANewerRelease guards the nag itself: only a release
+// genuinely ahead of this build may set it.
+func TestUpgradeMsgOnlyAcceptsANewerRelease(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	cases := map[string]string{
+		"v2.2.0":  "v2.2.0", // ahead — nag
+		"v2.1.1":  "",       // same
+		"v2.0.0":  "",       // behind
+		"":        "",       // unknown (offline, or the check failed)
+		"nightly": "",       // unparseable
+	}
+	for latest, want := range cases {
+		m := newModel()
+		m.width, m.height = 190, 44
+		next, _ := m.Update(upgradeMsg{latest: latest})
+		if got := next.(model).upgradeTo; got != want {
+			t.Errorf("upgradeMsg{%q}: upgradeTo = %q, want %q", latest, got, want)
+		}
+	}
+}

--- a/internal/cockpit/view.go
+++ b/internal/cockpit/view.go
@@ -100,7 +100,26 @@ func (m model) footerView() string {
 	if m.undo != "" {
 		notice += "  ·  u to undo"
 	}
-	right := fg(cAmber, notice)
+	right := ""
+	if notice != "" {
+		right = fg(cAmber, notice)
+	}
+
+	// The build version shares the bottom-right corner with the notice. They
+	// compete for the same space, so the version yields first — a notice is
+	// about what just happened, the version is ambient — and yields in stages,
+	// shedding the upgrade command before the version number itself.
+	inner := m.width - 2*pad
+	for _, v := range m.versionForms() {
+		cand := v
+		if right != "" {
+			cand = right + fg(cFaint, "  ·  ") + v
+		}
+		if dispWidth(left)+2+dispWidth(cand) <= inner {
+			right = cand
+			break
+		}
+	}
 	return spread(left, right, m.width)
 }
 

--- a/internal/version/latest.go
+++ b/internal/version/latest.go
@@ -1,0 +1,116 @@
+package version
+
+// latest.go answers "is there a newer release?" without turning the cockpit
+// into GitHub chatter.
+//
+// The answer changes a few times a week at most, while the cockpit polls every
+// minute, so the reply is cached on disk under the state dir and refetched only
+// once the cache is older than checkTTL. The call is unauthenticated (the repo
+// is public), short-timeout and best-effort: offline, rate-limited or firewalled
+// all degrade to "no signal" — the cockpit then shows the version with no
+// upgrade hint, never an error.
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"claude-dispatcher/internal/state"
+)
+
+const (
+	checkTTL     = 6 * time.Hour
+	fetchTimeout = 4 * time.Second
+)
+
+// releasesURL is a var so the tests can point it at an httptest server.
+var releasesURL = "https://api.github.com/repos/Innovology/claude-dispatcher/releases/latest"
+
+// Latest returns the newest published release tag, or "" when it is not known
+// (never checked, offline, or the check failed). It reads and writes a file and
+// may make a network call, so callers must run it off the UI goroutine.
+func Latest() string {
+	cached, ok := readCache()
+	if ok && time.Since(cached.CheckedAt) < checkTTL {
+		return cached.Latest
+	}
+	tag := fetchLatest()
+	if tag == "" {
+		// A failed call teaches nothing new: keep whatever was last known, but
+		// still stamp the check so a broken network is retried on the TTL
+		// rather than on every poll.
+		tag = cached.Latest
+	}
+	writeCache(checkCache{Latest: tag, CheckedAt: time.Now()})
+	return tag
+}
+
+type checkCache struct {
+	Latest    string    `json:"latest"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+func cachePath() string { return filepath.Join(state.Dir(), "version-check.json") }
+
+func readCache() (checkCache, bool) {
+	b, err := os.ReadFile(cachePath())
+	if err != nil {
+		return checkCache{}, false
+	}
+	var c checkCache
+	if json.Unmarshal(b, &c) != nil {
+		return checkCache{}, false
+	}
+	return c, true
+}
+
+// writeCache is best-effort and atomic (tmp + rename), like every other file
+// this tool owns: a half-written cache must never be read back as an answer.
+func writeCache(c checkCache) {
+	b, err := json.Marshal(c)
+	if err != nil || os.MkdirAll(state.Dir(), 0o755) != nil {
+		return
+	}
+	tmp := cachePath() + ".tmp"
+	if os.WriteFile(tmp, b, 0o644) != nil {
+		return
+	}
+	if os.Rename(tmp, cachePath()) != nil {
+		_ = os.Remove(tmp)
+	}
+}
+
+// fetchLatest asks GitHub for the newest release tag. The /releases/latest
+// endpoint already excludes drafts and pre-releases, so nothing unpublished can
+// ever prompt an upgrade.
+func fetchLatest() string {
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, releasesURL, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	// GitHub rejects requests without a User-Agent.
+	req.Header.Set("User-Agent", "claude-dispatcher/"+Version)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	var rel struct {
+		TagName string `json:"tag_name"`
+	}
+	if json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&rel) != nil {
+		return ""
+	}
+	return strings.TrimSpace(rel.TagName)
+}

--- a/internal/version/latest_test.go
+++ b/internal/version/latest_test.go
@@ -1,0 +1,112 @@
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// serveTag stands in for the GitHub releases endpoint and counts how often it
+// is asked, which is what the cache exists to keep small.
+func serveTag(t *testing.T, tag string, status int) *int32 {
+	t.Helper()
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		if status != http.StatusOK {
+			w.WriteHeader(status)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"tag_name": tag})
+	}))
+	t.Cleanup(srv.Close)
+
+	orig := releasesURL
+	releasesURL = srv.URL
+	t.Cleanup(func() { releasesURL = orig })
+	return &hits
+}
+
+// seedCache writes the on-disk answer as if it had been fetched `age` ago.
+func seedCache(t *testing.T, tag string, age time.Duration) {
+	t.Helper()
+	writeCache(checkCache{Latest: tag, CheckedAt: time.Now().Add(-age)})
+}
+
+func TestLatestFetchesThenServesFromCache(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "v2.5.0", http.StatusOK)
+
+	if got := Latest(); got != "v2.5.0" {
+		t.Fatalf("first Latest() = %q, want v2.5.0", got)
+	}
+	if got := Latest(); got != "v2.5.0" {
+		t.Fatalf("second Latest() = %q, want v2.5.0", got)
+	}
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1 — the cache is not holding", n)
+	}
+}
+
+func TestLatestRefetchesOnceTheCacheIsStale(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "v3.0.0", http.StatusOK)
+	seedCache(t, "v2.5.0", checkTTL+time.Minute)
+
+	if got := Latest(); got != "v3.0.0" {
+		t.Fatalf("Latest() = %q, want the refetched v3.0.0", got)
+	}
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1", n)
+	}
+}
+
+func TestLatestKeepsTheLastKnownAnswerWhenTheCheckFails(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "", http.StatusInternalServerError)
+	seedCache(t, "v2.5.0", checkTTL+time.Minute)
+
+	if got := Latest(); got != "v2.5.0" {
+		t.Fatalf("Latest() = %q, want the last known v2.5.0", got)
+	}
+	// The failed check is still stamped, so a broken network is retried on the
+	// TTL rather than on every poll.
+	if got := Latest(); got != "v2.5.0" {
+		t.Fatalf("second Latest() = %q, want v2.5.0", got)
+	}
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1 — a failure is not being backed off", n)
+	}
+}
+
+func TestLatestIsEmptyWhenNothingIsKnown(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	serveTag(t, "", http.StatusNotFound)
+
+	if got := Latest(); got != "" {
+		t.Fatalf("Latest() = %q, want \"\" — an unknown answer must not nag", got)
+	}
+	if IsOutdated(Latest()) {
+		t.Fatal("an unknown latest reported the build as outdated")
+	}
+}
+
+func TestReadCacheIgnoresGarbage(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "v4.0.0", http.StatusOK)
+	writeCache(checkCache{Latest: "v1.0.0", CheckedAt: time.Now()})
+	if err := os.WriteFile(cachePath(), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := Latest(); got != "v4.0.0" {
+		t.Fatalf("Latest() = %q, want v4.0.0 — a corrupt cache should be refetched", got)
+	}
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1", n)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,101 @@
+// Package version reports which build of claude-dispatcher is running and,
+// best-effort, whether a newer one has been published.
+//
+// Version is stamped at release time by goreleaser (see .goreleaser.yml), so a
+// plain `go build` reports "dev" — and a dev build is never told to upgrade,
+// because there is no released version it can meaningfully be behind.
+package version
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Version is the running build's version. Goreleaser's {{.Version}} is the tag
+// with the leading "v" stripped ("2.1.1"), so both forms are accepted
+// everywhere and normalised for display.
+var Version = "dev"
+
+// Display is the running build as shown to the human: "v2.1.1", or "dev".
+func Display() string { return Label(Version) }
+
+// Label normalises a version string to its display form — "2.1.1" and "v2.1.1"
+// both render "v2.1.1". Anything unparseable (a dev build) is shown untouched
+// rather than dressed up as a release.
+func Label(v string) string {
+	if _, ok := parse(v); !ok {
+		return v
+	}
+	return "v" + strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// IsRelease reports whether this build carries a stamped version. Only a
+// release build can be out of date, so only a release build ever checks.
+func IsRelease() bool {
+	_, ok := parse(Version)
+	return ok
+}
+
+// IsOutdated reports whether latest is a newer release than the running build.
+// Anything it cannot parse — a dev build, an empty or malformed latest —
+// answers false: a version it does not understand must never nag the user.
+func IsOutdated(latest string) bool { return newer(Version, latest) }
+
+// UpgradeHint is the command that upgrades this build in place. macOS and
+// Linux ship through the Homebrew tap, Windows through the scoop bucket.
+func UpgradeHint() string {
+	if runtime.GOOS == "windows" {
+		return "scoop update claude-dispatcher"
+	}
+	return "brew upgrade claude-dispatcher"
+}
+
+// semver is a version parsed far enough to order two of them.
+type semver struct {
+	nums [3]int
+	pre  string // pre-release tag; "" for a final release
+}
+
+// parse reads "v2.1.1", "2.1.1", "2.2.0-rc1" or "2.2.0-rc1+abc123". ok=false
+// for anything else, including "dev".
+func parse(s string) (semver, bool) {
+	s = strings.TrimPrefix(strings.TrimSpace(s), "v")
+	// Build metadata is not ordered; the pre-release tag is, so keep it.
+	if i := strings.IndexByte(s, '+'); i >= 0 {
+		s = s[:i]
+	}
+	var v semver
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		v.pre, s = s[i+1:], s[:i]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return semver{}, false
+	}
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil || n < 0 {
+			return semver{}, false
+		}
+		v.nums[i] = n
+	}
+	return v, true
+}
+
+// newer reports whether latest is ahead of cur.
+func newer(cur, latest string) bool {
+	c, okc := parse(cur)
+	l, okl := parse(latest)
+	if !okc || !okl {
+		return false
+	}
+	for i := range c.nums {
+		if l.nums[i] != c.nums[i] {
+			return l.nums[i] > c.nums[i]
+		}
+	}
+	// Same x.y.z: a pre-release is behind the final release of that version
+	// (2.2.0-rc1 → 2.2.0), never the other way round.
+	return c.pre != "" && l.pre == ""
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,95 @@
+package version
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLabel(t *testing.T) {
+	cases := map[string]string{
+		"2.1.1":      "v2.1.1",
+		"v2.1.1":     "v2.1.1",
+		" 2.1.1 ":    "v2.1.1",
+		"2.2.0-rc1":  "v2.2.0-rc1",
+		"dev":        "dev",
+		"":           "",
+		"not.a.vers": "not.a.vers",
+	}
+	for in, want := range cases {
+		if got := Label(in); got != want {
+			t.Errorf("Label(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		cur, latest string
+		want        bool
+	}{
+		{"2.1.1", "2.1.2", true},
+		{"2.1.1", "2.2.0", true},
+		{"2.1.1", "3.0.0", true},
+		{"2.1.1", "v2.1.2", true}, // tags arrive with the v, builds without
+		{"v2.1.1", "2.1.2", true},
+		{"2.1.1", "2.1.1", false},
+		{"2.1.2", "2.1.1", false}, // ahead of the release, e.g. a local build
+		{"2.10.0", "2.9.0", false},
+		{"2.9.0", "2.10.0", true},
+		// A pre-release is behind the final release of the same version, and a
+		// final release is never behind its own pre-release.
+		{"2.2.0-rc1", "2.2.0", true},
+		{"2.2.0", "2.2.0-rc1", false},
+		{"2.2.0-rc1", "2.2.0-rc2", false}, // rc ordering is not modelled
+		// Nothing unparseable may ever produce an upgrade nag.
+		{"dev", "2.1.1", false},
+		{"2.1.1", "", false},
+		{"2.1.1", "nightly", false},
+		{"", "", false},
+		{"2.1", "2.2", false},
+		{"2.1.1.1", "2.1.2.1", false},
+	}
+	for _, c := range cases {
+		if got := newer(c.cur, c.latest); got != c.want {
+			t.Errorf("newer(%q, %q) = %v, want %v", c.cur, c.latest, got, c.want)
+		}
+	}
+}
+
+func TestIsReleaseAndDisplay(t *testing.T) {
+	orig := Version
+	defer func() { Version = orig }()
+
+	Version = "dev"
+	if IsRelease() {
+		t.Error("dev build reported as a release")
+	}
+	if got := Display(); got != "dev" {
+		t.Errorf("Display() = %q, want %q", got, "dev")
+	}
+	if IsOutdated("99.0.0") {
+		t.Error("dev build reported as outdated — it has no release to be behind")
+	}
+
+	Version = "2.1.1"
+	if !IsRelease() {
+		t.Error("stamped build not reported as a release")
+	}
+	if got := Display(); got != "v2.1.1" {
+		t.Errorf("Display() = %q, want %q", got, "v2.1.1")
+	}
+	if !IsOutdated("v2.2.0") {
+		t.Error("2.1.1 should be outdated against v2.2.0")
+	}
+	if IsOutdated("v2.1.1") {
+		t.Error("2.1.1 should not be outdated against itself")
+	}
+}
+
+func TestUpgradeHintNamesTheBinary(t *testing.T) {
+	// Whichever package manager the platform ships through, the hint has to be
+	// a runnable command naming this tool.
+	if got := UpgradeHint(); !strings.Contains(got, "claude-dispatcher") {
+		t.Errorf("UpgradeHint() = %q, want a command naming claude-dispatcher", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,10 +13,8 @@ import (
 	"claude-dispatcher/internal/cockpit"
 	"claude-dispatcher/internal/hookcmd"
 	"claude-dispatcher/internal/initcmd"
+	"claude-dispatcher/internal/version"
 )
-
-// version is stamped by the release build via -ldflags.
-var version = "dev"
 
 const usage = `claude-dispatcher — dispatch cockpit for Claude Code sessions
 
@@ -53,7 +51,7 @@ func main() {
 		// Never fail loudly: a hook error must not disturb the Claude session.
 		os.Exit(hookcmd.Run(args[1:]))
 	case "version", "--version", "-v":
-		fmt.Println("claude-dispatcher", version)
+		fmt.Println("claude-dispatcher", version.Display())
 	case "help", "-h", "--help":
 		fmt.Print(usage)
 	default:


### PR DESCRIPTION
The cockpit never said which build it was, so "is this fixed in my copy?" had no answer short of running `claude-dispatcher version` in another terminal.

The version now sits in the bottom-right of the footer. When a newer release exists it becomes the upgrade hint:

```
type the work · enter dispatch · w running · esc clear · 1…8 sections    v1.0.0 → v2.1.1 · brew upgrade claude-dispatcher
type the work · enter dispatch · w running · esc clear · 1…8 sections                                              v2.1.1
```

Both captured from a real tmux terminal against the live GitHub API — a build stamped `1.0.0`, and one stamped at the current release.

## `internal/version`

One source of truth for the build's version. The goreleaser stamp moves from `main.version` to `claude-dispatcher/internal/version.Version`, so the cockpit reads it without threading it through `Run()`. Verified: a stamped build prints `v1.0.0`, a plain `go build` prints `dev`, and `goreleaser check` passes.

The upgrade check asks GitHub's `/releases/latest` unauthenticated (the repo is public) behind a **6h on-disk cache** in the state dir. This matters: the cockpit polls every 60s, which without a cache is ~60 API calls/hour against a 60/hour unauthenticated limit — enough to exhaust it and then report nothing. Each poll is now a file read.

Every failure mode — offline, rate-limited, non-200, unparseable version — degrades to showing the version with no hint. Never an error, and never a wrong nag: a version string the comparison cannot parse can only answer "not outdated". A dev build skips the network call entirely, since there is no release it can meaningfully be behind.

## Footer behaviour

The version and the notice compete for the same corner, so the version yields in stages: full hint → bare `v2.1.1 → v2.2.0` → gone. A notice is about what just happened and outranks the ambient version. At 80 columns the keybinding help already fills the row, so the version drops out rather than clipping the help — matching how `spread` already treats notices.

## Judgement calls

- **Windows gets `scoop update claude-dispatcher`.** This repo actively ships a scoop bucket and winget manifest and has a Windows CI gate, so a brew hint would be dead advice there. macOS and Linux get `brew upgrade claude-dispatcher`.
- **`make install` still does not stamp**, so local builds show `dev` and never nag. Stamping from `git describe` would produce `2.1.1-3-gabc1234`, which semver reads as a *pre-release* of 2.1.1 — a local build one commit ahead of the tag would be told to upgrade backwards. Stamping only on an exact tag match is a follow-up if wanted.

## Checks

`make check` green: build, vet, gofmt, golangci-lint (0 issues), full `-race` suite. 15 new tests cover semver ordering (including the pre-release edge and every unparseable input), the cache's TTL / failure-backoff / corrupt-file paths, and the footer's fit ladder at all three width tiers.

Labelled `release:minor` — this adds a user-visible feature.