### PR TITLE
Products lens: an honest count, the keys, and a cursor you can see

### DIFF
--- a/internal/cockpit/cluster_view.go
+++ b/internal/cockpit/cluster_view.go
@@ -14,14 +14,21 @@ func (m model) viewCluster(w, h int) string {
 	leftInner := maxi(leftW-2*pad, 1)
 	rightInner := maxi(rightW-2*pad, 1)
 
-	left := productsPane(m.clLeft(leftInner), leftW)
+	left := productsPane(m.clLeft(leftInner, h), leftW)
 	right := productsPane(m.clRight(rightInner, h), rightW)
 	hh := mini(maxi(strings.Count(left, "\n"), strings.Count(right, "\n"))+1, maxi(h, 1))
 	return clampLines(hjoin(padBlockTo(left, hh), vrule(hh, cRule), padBlockTo(right, hh)), h)
 }
 
 // clLeft is the repo table: mark, name, forge, current product, out, last.
-func (m model) clLeft(cw int) []string {
+//
+// h is the body height, and the rows scroll within it. The list used to render
+// every repo and let clampLines cut the overflow, which meant that on any
+// portfolio taller than the terminal the cursor walked off the bottom and
+// stayed there: j kept working, the selection kept moving, and none of it was
+// visible. A repo list you cannot see the cursor in is not one you can assign
+// from.
+func (m model) clLeft(cw, h int) []string {
 	rows := m.clRepos()
 	sel := clampCursor(m.clRepo, len(rows))
 
@@ -55,7 +62,11 @@ func (m model) clLeft(cw int) []string {
 	if len(rows) == 0 {
 		return append(out, "", fg(cFaint, "no repos found — check your scan roots with ,"))
 	}
-	for i, r := range rows {
+	// Leave a line for the "showing x of y" footer so it cannot itself be the
+	// row that gets clipped.
+	start, end := window(sel, len(rows), maxi(h-len(out)-1, 1))
+	for i := start; i < end; i++ {
+		r := rows[i]
 		bg, mark, nameColor := cTransparent, " ", cFg
 		if m.clMarked[r.name] {
 			mark = "◆"
@@ -78,6 +89,11 @@ func (m model) clLeft(cw int) []string {
 			cr(itoa(r.out), 8, cFaint),
 			cr(r.last, 8, cFaint),
 		))
+	}
+	// Only when the list is actually scrolling: on a portfolio that fits, a
+	// position counter is noise.
+	if end-start < len(rows) {
+		out = append(out, fg(cFaint, itoa(sel+1)+" of "+itoa(len(rows))))
 	}
 	return out
 }

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -30,6 +30,13 @@ var helpSections = []struct {
 		{":", "command palette"},
 		{"?", "this help"},
 	}},
+	{section: "products · lens 2", keys: []struct{ k, d string }{
+		{"a", "assign repos to products"},
+		{"n", "new product — names it and moves the marked repos in"},
+		{"space", "mark a repo · enter moves every marked one"},
+		{"tab", "between the repo list and the products"},
+		{"u / U", "take repos back out of a product · start over"},
+	}},
 	{section: "the other lenses", keys: []struct{ k, d string }{
 		{"j / k", "up and down the list"},
 		{"→ / ←", "into the detail pane and back"},

--- a/internal/cockpit/products_polish_test.go
+++ b/internal/cockpit/products_polish_test.go
@@ -1,0 +1,113 @@
+package cockpit
+
+// products_polish_test.go pins the four small things the products lens and its
+// assignment editor were missing: an honest product count in the header, the
+// keys advertised in the footer and the help sheet, and a repo list whose
+// cursor stays on screen.
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// The header counts what the user has grouped. "unassigned" is the bucket every
+// unmapped repo falls into, so counting it made a fresh install — nothing
+// grouped, nothing to group by — report "1 product".
+func TestPortfolioLineDoesNotCountTheUnassignedBucket(t *testing.T) {
+	saved := captureVars()
+	t.Cleanup(func() { restoreVars(saved) })
+
+	m := newModel()
+	products = []product{{name: clUnassigned, repos: "4 repos"}}
+	if got := m.portfolioLine(); strings.Contains(got, "product") {
+		t.Errorf("nothing grouped, yet the header claims a product: %q", got)
+	}
+
+	products = []product{{name: "acme", repos: "2 repos"}, {name: clUnassigned, repos: "2 repos"}}
+	if got := m.portfolioLine(); !strings.Contains(got, "1 product") {
+		t.Errorf("one real product: got %q, want it to say 1 product", got)
+	}
+
+	products = []product{{name: "acme"}, {name: "orbit"}, {name: clUnassigned}}
+	if got := m.portfolioLine(); !strings.Contains(got, "2 products") {
+		t.Errorf("two real products: got %q", got)
+	}
+}
+
+// a and n are the only way to make a product without hand-editing TOML, so the
+// lens has to say so — the footer is the only thing on screen that can.
+func TestProductsFooterAdvertisesTheAssignKeys(t *testing.T) {
+	m := newModel()
+	m.lens = "products"
+	got := m.footerHelp()
+	for _, want := range []string{"a assign", "n new product"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("products footer is missing %q: %q", want, got)
+		}
+	}
+}
+
+// The help sheet is where a user goes when the footer has scrolled past. Every
+// key the editor answers to should be findable there.
+func TestHelpSheetDocumentsTheAssignKeys(t *testing.T) {
+	m := newModel()
+	m.width, m.height = 150, 44
+	out := m.viewHelp(m.width, m.height)
+	for _, want := range []string{"products", "assign repos to products", "new product", "tab"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help sheet is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The list scrolls with the cursor. It used to render every repo and let
+// clampLines cut the overflow, so on a portfolio taller than the terminal the
+// selection walked off the bottom and became invisible.
+func TestClLeftKeepsTheCursorOnScreen(t *testing.T) {
+	saved := captureVars()
+	t.Cleanup(func() { restoreVars(saved) })
+
+	// Zero-padded: clRepos sorts by name, so "repo-9" would otherwise sit at
+	// index 59 and the assertions below would be testing the sort, not the
+	// scrolling.
+	var refs []repoRef
+	for i := 0; i < 60; i++ {
+		refs = append(refs, repoRef{name: fmt.Sprintf("repo-%02d", i), forge: "gh", last: "1d"})
+	}
+	reposByProduct = map[string][]repoRef{clUnassigned: refs}
+
+	m := newModel()
+	m.clOpen, m.clPane = true, "repos"
+
+	const h = 20
+	for _, sel := range []int{0, 30, 59} {
+		m.clRepo = sel
+		lines := m.clLeft(70, h)
+		if len(lines) > h {
+			t.Errorf("cursor %d: pane is %d lines, exceeds the %d available", sel, len(lines), h)
+		}
+		want := fmt.Sprintf("repo-%02d", sel)
+		found := false
+		for _, ln := range lines {
+			// The selected row is the one carrying the cursor marker.
+			if strings.Contains(ln, want) && strings.Contains(ln, "▸") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("cursor %d (%s) is not on screen:\n%s", sel, want, strings.Join(lines, "\n"))
+		}
+	}
+
+	// A scrolling list says where you are in it; one that fits does not.
+	if got := strings.Join(m.clLeft(70, h), "\n"); !strings.Contains(got, "60 of 60") {
+		t.Errorf("expected a position counter while scrolling:\n%s", got)
+	}
+	reposByProduct = map[string][]repoRef{clUnassigned: refs[:3]}
+	m.clRepo = 0
+	if got := strings.Join(m.clLeft(70, h), "\n"); strings.Contains(got, " of 3") {
+		t.Errorf("a list that fits should not count itself:\n%s", got)
+	}
+}

--- a/internal/cockpit/view.go
+++ b/internal/cockpit/view.go
@@ -10,7 +10,7 @@ import (
 const pad = 2 // left/right page gutter, in columns (the design's 24px)
 
 var footerByLens = map[string]string{
-	"products":  "j/k move · enter open product · : palette · 1 triage",
+	"products":  "j/k move · enter open product · a assign repos · n new product · 1 triage",
 	"product":   "R review · T team · S shipped · j/k move · enter open · d dispatch a reviewer · 1 triage",
 	"queue":     "a add · e edit · x drop · ctrl+d dispatch all · 1 triage",
 	"backlog":   "j/k move · space pick · enter dispatch · ctrl+d dispatch picked · s source · 1 triage",
@@ -223,8 +223,18 @@ func (m model) portfolioLine() string {
 	if out > 0 {
 		parts = append(parts, itoa(out)+" out")
 	}
-	if n := len(products); n > 0 {
-		parts = append(parts, itoa(n)+" "+plural(n, "product", "products"))
+	// "unassigned" is the bucket collectProducts folds every unmapped repo into,
+	// not a product. Counting it made a portfolio with nothing grouped claim
+	// "1 product" — the one reading a user is most likely to check against, on
+	// the install where it is least likely to be true.
+	prods := 0
+	for _, p := range products {
+		if p.name != clUnassigned {
+			prods++
+		}
+	}
+	if prods > 0 {
+		parts = append(parts, itoa(prods)+" "+plural(prods, "product", "products"))
 	}
 	if n := m.repoCount(); n > 0 {
 		parts = append(parts, itoa(n)+" "+plural(n, "repo", "repos"))


### PR DESCRIPTION
Four small gaps left by #21. None is worth its own PR; together they are the difference between the assignment editor being discoverable and usable, and not.

Found while comparing a duplicate branch against #21 (that branch is closed — #23).

## The header counted the unassigned bucket as a product

`unassigned` is what `collectProducts` folds every unmapped repo into, not something the user made. Counting it meant a fresh install — nothing grouped, nothing to group by — reported **"1 product"**, in the one reading a user is most likely to check their config against.

## Nothing on screen named the keys

`a` and `n` are the only way to make a product without hand-editing TOML. The products footer advertised `: palette`; the help sheet (`?`) had no products section at all. Both now list what the editor answers to — `a`, `n`, `space`, `tab`, `u`/`U`.

## The cursor could leave the screen

`clLeft` rendered every repo row and let `clampLines` cut the overflow. On any portfolio taller than the terminal the selection walked off the bottom and stayed there: `j` kept working, `clRepo` kept incrementing, and none of it was visible — so you were marking and assigning repos you could not see.

It now windows on the cursor (the same `window()` helper the dispatch form uses) and shows "N of M" only while the list is actually scrolling — on a portfolio that fits, a position counter is noise.

## Verification

`go build`, `go vet`, `golangci-lint run`, `go test ./... -race -count=1` all pass.

The windowing test was checked against the pre-fix `clLeft` and fails there, so it is pinning the bug rather than describing the fix.

## Release

`release:patch` — fixes and affordances, no new capability.
