### PR TITLE
Cut dispatch branches from the default branch, one live dispatch per feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,18 @@
     original "multi-repo, not multi-worktree" call, reversed the next day
     after two sessions collided in one working copy and a commit landed on
     the wrong branch.)
+    - The feature branch is cut from the repo's **default branch as the
+      remote sees it** (`origin/HEAD`, falling back to origin/main, then
+      local), after a best-effort fetch — never from the repo's HEAD. Git's
+      default would inherit whatever branch the human left checked out, so a
+      dispatch would silently start on top of an unmerged feature and carry
+      it into its own PR. Created `--no-track`, or `git push` would refuse a
+      branch whose upstream has a different name.
+    - **One live dispatch per feature name.** The name is the key: the
+      worktree path and the cockpit's record map are both keyed by it, so a
+      second concurrent dispatch of a live name would put two sessions in one
+      checkout. Launch refuses it; re-dispatching a *finished* feature is
+      still fine and reuses the worktree left behind.
   - *Product* is the grouping lens: the cockpit list and the dispatch form's
     repo picker group by the `[products]` config, most urgent group first;
     unmapped repos fall under "other". No separate group concept.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -4,6 +4,7 @@
 package dispatch
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -35,6 +36,10 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	slug := Slugify(feature)
 	if slug == "" {
 		return nil, fmt.Errorf("feature name %q produces an empty slug", feature)
+	}
+	if live := liveDispatch(slug); live != nil {
+		return nil, fmt.Errorf("%q is already live in %s (session %s) — kill it, or dispatch under a different feature name",
+			live.Feature, live.RepoName, live.TmuxSession)
 	}
 	branch := "feature/" + slug
 	worktree := filepath.Join(state.WorktreesDir(), r.Name, slug)
@@ -78,8 +83,76 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	return d, nil
 }
 
+// liveDispatch returns a dispatch of the same slug whose session is still
+// running, or nil.
+//
+// The feature name is the key throughout: the worktree path is
+// worktrees/<repo>/<slug>, and the cockpit maps a feature name to one record.
+// So a second concurrent dispatch of a name already in flight would put two
+// claude sessions in a single checkout — the exact collision per-dispatch
+// worktrees exist to prevent — and shadow one record with the other in the
+// cockpit. Re-dispatching a feature whose session has ended is still fine, and
+// deliberately reuses the worktree left behind.
+//
+// The live tmux session, not the record's status, is the test: a record can be
+// left stale by a crash, but a running session is ground truth.
+func liveDispatch(slug string) *state.Dispatch {
+	for _, d := range state.LoadAll() {
+		if d.Slug == slug && d.TmuxSession != "" && sessionAlive(d.TmuxSession) {
+			return d
+		}
+	}
+	return nil
+}
+
+// sessionAlive is a seam: tests swap it rather than stand up real sessions.
+var sessionAlive = supervisor.HasSession
+
+// fetchTimeout bounds the pre-dispatch fetch. Refreshing the base is a
+// courtesy; a slow or unreachable remote must never stall a launch.
+const fetchTimeout = 20 * time.Second
+
+// baseRef resolves the start point for a new feature branch: the repo's
+// default branch, as the remote sees it.
+//
+// Letting git default the start point to the repo's HEAD — what `worktree add
+// -b` does with no explicit base — silently cuts the branch from whatever the
+// human left checked out, so a dispatch starts on top of an unrelated unmerged
+// feature and its PR carries that work onto main. Naming origin/<default>
+// rather than the local branch also keeps a stale local main out of the base.
+func baseRef(repoPath string) string {
+	// Best effort: a fresh origin/<default> beats a stale one, but offline is
+	// not a launch failure. GIT_TERMINAL_PROMPT=0 stops a credential prompt
+	// from holding the fetch open until the timeout expires.
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	fetch := exec.CommandContext(ctx, "git", "-C", repoPath, "fetch", "--quiet", "origin")
+	fetch.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	_ = fetch.Run()
+
+	// origin/HEAD names the remote's default branch, but it is absent from
+	// --single-branch clones and from repos cloned before git recorded it, so
+	// fall through the conventional names — and finally to the local checkout,
+	// for a repo with no remote at all.
+	if out, err := exec.Command("git", "-C", repoPath, "symbolic-ref", "--short", "--quiet",
+		"refs/remotes/origin/HEAD").Output(); err == nil {
+		if ref := strings.TrimSpace(string(out)); ref != "" {
+			return ref
+		}
+	}
+	for _, cand := range []string{
+		"refs/remotes/origin/main", "refs/remotes/origin/master",
+		"refs/heads/main", "refs/heads/master",
+	} {
+		if exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", cand).Run() == nil {
+			return cand
+		}
+	}
+	return "HEAD"
+}
+
 // ensureWorktree adds a worktree for the branch at path, creating the branch
-// from the repo's current HEAD when it doesn't exist yet, and reusing a
+// from the repo's default branch when it doesn't exist yet, and reusing a
 // worktree left behind by an earlier dispatch of the same feature.
 func ensureWorktree(repoPath, path, branch string) error {
 	if out, err := exec.Command("git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD").Output(); err == nil {
@@ -94,11 +167,17 @@ func ensureWorktree(repoPath, path, branch string) error {
 		return err
 	}
 	branchExists := exec.Command("git", "-C", repoPath, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch).Run() == nil
-	args := []string{"-C", repoPath, "worktree", "add", path, branch}
 	if !branchExists {
-		args = []string{"-C", repoPath, "worktree", "add", "-b", branch, path}
+		// Created as its own step so the base is explicit. --no-track because
+		// the base is normally a remote-tracking ref, and inheriting it as
+		// upstream would make a later plain `git push` refuse: push.default
+		// simple rejects a branch whose upstream carries a different name.
+		base := baseRef(repoPath)
+		if out, err := exec.Command("git", "-C", repoPath, "branch", "--no-track", branch, base).CombinedOutput(); err != nil {
+			return fmt.Errorf("git branch %s from %s: %s", branch, base, strings.TrimSpace(string(out)))
+		}
 	}
-	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+	if out, err := exec.Command("git", "-C", repoPath, "worktree", "add", path, branch).CombinedOutput(); err != nil {
 		return fmt.Errorf("git worktree add %s: %s", branch, strings.TrimSpace(string(out)))
 	}
 	return nil

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"claude-dispatcher/internal/repos"
+	"claude-dispatcher/internal/state"
 )
 
 func initRepo(t *testing.T) string {
@@ -69,6 +72,76 @@ func TestEnsureWorktree(t *testing.T) {
 	}
 }
 
+// A dispatch must start from the repo's default branch, never from whatever
+// the human happens to have checked out — otherwise it inherits an unrelated
+// unmerged feature and carries it into its own PR.
+func TestEnsureWorktreeBranchesFromDefaultNotHEAD(t *testing.T) {
+	repo := initRepo(t)
+	git := func(args ...string) {
+		t.Helper()
+		full := append([]string{"-C", repo, "-c", "user.email=t@t", "-c", "user.name=t"}, args...)
+		if out, err := exec.Command("git", full...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+	// The human is mid-feature in the repo's own checkout.
+	git("checkout", "-b", "feature/human-wip")
+	git("commit", "--allow-empty", "-m", "human WIP")
+
+	wt := filepath.Join(t.TempDir(), "feat")
+	if err := ensureWorktree(repo, wt, "feature/feat"); err != nil {
+		t.Fatal(err)
+	}
+	out, err := exec.Command("git", "-C", wt, "log", "--format=%s", "main..HEAD").Output()
+	if err != nil {
+		t.Fatalf("log in worktree: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != "" {
+		t.Errorf("dispatch branch carries commits not on main: %q", got)
+	}
+	// The human's checkout is left exactly where they had it.
+	if got := worktreeBranch(t, repo); got != "feature/human-wip" {
+		t.Errorf("repo checkout moved to %q", got)
+	}
+}
+
+// baseRef prefers the remote's view of the default branch, so a local main
+// that has fallen behind origin is not used as the base.
+func TestBaseRefPrefersRemoteDefault(t *testing.T) {
+	repo := initRepo(t)
+	// No remote at all: fall back to the local default branch.
+	if got := baseRef(repo); got != "refs/heads/main" {
+		t.Errorf("baseRef with no remote = %q, want refs/heads/main", got)
+	}
+	// With a remote-tracking ref present, prefer it over the local branch.
+	if out, err := exec.Command("git", "-C", repo, "update-ref",
+		"refs/remotes/origin/main", "refs/heads/main").CombinedOutput(); err != nil {
+		t.Fatalf("update-ref: %s", out)
+	}
+	if got := baseRef(repo); got != "refs/remotes/origin/main" {
+		t.Errorf("baseRef = %q, want refs/remotes/origin/main", got)
+	}
+}
+
+// A new feature branch must not inherit the base as its upstream: with a
+// remote-tracking base, push.default=simple would refuse to push it.
+func TestEnsureWorktreeLeavesBranchUntracked(t *testing.T) {
+	repo := initRepo(t)
+	if out, err := exec.Command("git", "-C", repo, "update-ref",
+		"refs/remotes/origin/main", "refs/heads/main").CombinedOutput(); err != nil {
+		t.Fatalf("update-ref: %s", out)
+	}
+	wt := filepath.Join(t.TempDir(), "feat")
+	if err := ensureWorktree(repo, wt, "feature/feat"); err != nil {
+		t.Fatal(err)
+	}
+	err := exec.Command("git", "-C", repo, "rev-parse", "--verify", "--quiet",
+		"feature/feat@{upstream}").Run()
+	if err == nil {
+		t.Error("feature branch inherited an upstream from its base")
+	}
+}
+
 func TestCleanupWorktree(t *testing.T) {
 	repo := initRepo(t)
 	wt := filepath.Join(t.TempDir(), "feat")
@@ -102,6 +175,43 @@ func TestCleanupWorktree(t *testing.T) {
 	}
 	if !CleanupWorktree(repo, "") {
 		t.Error("a dispatch with no worktree should report gone")
+	}
+}
+
+// Two live dispatches of one feature would share worktrees/<repo>/<slug> —
+// two claude sessions in a single checkout, the collision worktrees exist to
+// prevent — so the second is refused while the first is still running.
+func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	repo := initRepo(t)
+
+	rec := &state.Dispatch{
+		ID: state.NewID(), Feature: "Payment Retry", Slug: "payment-retry",
+		RepoPath: repo, RepoName: "acme", Branch: "feature/payment-retry",
+		TmuxSession: "disp-payment-retry", Status: state.StatusWorking,
+	}
+	if err := state.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	alive := map[string]bool{"disp-payment-retry": true}
+	restore := sessionAlive
+	sessionAlive = func(name string) bool { return alive[name] }
+	defer func() { sessionAlive = restore }()
+
+	_, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go")
+	if err == nil {
+		t.Fatal("expected a duplicate of a live feature to be refused")
+	}
+	if !strings.Contains(err.Error(), "already live") {
+		t.Errorf("unhelpful error: %v", err)
+	}
+
+	// Once the session has ended, the feature can be dispatched again — that
+	// path deliberately reuses the worktree left behind.
+	alive["disp-payment-retry"] = false
+	if got := liveDispatch("payment-retry"); got != nil {
+		t.Errorf("dead session still reported live: %#v", got)
 	}
 }
 


### PR DESCRIPTION
Per-dispatch worktrees stopped dispatches fighting over one working copy, but two collisions survived them. Both are fixed here, each with a test that fails against the previous behaviour.

## Dispatch branches were cut from whatever the human had checked out

`ensureWorktree` ran `git worktree add -b <branch> <path>` with **no start point**, so git used the repo checkout's HEAD.

This branch was itself an instance. It was dispatched while the main checkout sat on `feature/product-assignment`, so it arrived carrying that feature's commit:

```
$ git log --oneline origin/main..HEAD
4d29b20 Assign repos to products from the cockpit   ← another feature's work
```

Had product-assignment still been open, the PR from this branch would have carried it onto main. That is the "commit landed on the wrong branch" failure the worktrees were introduced to end — worktrees fixed the *working-copy* collision, not the *history* one.

Compounding it, the base could be stale even when correct: local `main` was three commits behind `origin/main`.

**Fix.** Resolve an explicit base — `origin/HEAD`, falling back through `origin/main`, `origin/master`, then local — after a best-effort `fetch` (20s timeout, `GIT_TERMINAL_PROMPT=0`, offline is never a launch failure). Branch creation moves into its own `git branch --no-track` step: the base is normally a remote-tracking ref, and inheriting it as upstream would make a later plain `git push` refuse, since `push.default=simple` rejects a branch whose upstream carries a different name.

## Two live dispatches of one feature shared a worktree

The worktree path is `worktrees/<repo>/<slug>` — not uniquified, though the tmux session name already was (`supervisor.UniqueName`), so the same-name case had been anticipated for tmux and missed for the checkout. `ensureWorktree` finds the path already on that branch and reuses it, putting two interactive `claude` sessions in one directory. The original collision, reproduced.

The reuse itself is intended — it resumes a feature whose session has ended. The bug is that it could not tell a leftover worktree from one in active use.

**Fix.** `Launch` refuses a duplicate while the first session is alive, naming the session to kill. The feature name is the key throughout — the cockpit's record map is keyed by it too, so a duplicate live name also silently shadowed one record with the other. Re-dispatching a *finished* feature still reuses the worktree left behind, unchanged.

Liveness is read from the running tmux session rather than the record's status, which a crash can leave stale.

## Checked and cleared

`internal/gh`, `internal/track`, `collect_floor.go` and `collect_stale_queue.go` all run git/gh against `RepoPath`, but only read. `shipCmd` sets `cmd.Dir = rec.RepoPath` for `gh pr merge`, which never touches the working tree. No other collision paths.

## Notes

- This branch is rebased onto `origin/main` to drop the `4d29b20` contamination described above.
- The nine pre-worktree dispatch records (6–7 Aug, `worktree_path: ""`) are the historical collisions; they are unaffected by this change, and `CleanupWorktree` already treats them as "gone".
