### PR TITLE
Inherit the repo's trust so a dispatch can actually start

### DIFF
--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -41,6 +41,11 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	if err := ensureWorktree(r.Path, worktree, branch); err != nil {
 		return nil, err
 	}
+	// A fresh worktree is a folder Claude Code has never seen, and it blocks on
+	// its trust prompt before reading the prompt we launched it with. Inherit
+	// the repo's own trust decision so an unattended session can actually start.
+	InheritTrust(r.Path, worktree)
+
 	baseSHA := ""
 	if out, err := exec.Command("git", "-C", worktree, "rev-parse", "HEAD").Output(); err == nil {
 		baseSHA = strings.TrimSpace(string(out))

--- a/internal/dispatch/trust.go
+++ b/internal/dispatch/trust.go
@@ -1,0 +1,121 @@
+package dispatch
+
+// trust.go carries a repo's Claude Code trust decision across to the worktree a
+// dispatch runs in.
+//
+// Every dispatch materialises a brand-new directory, and Claude Code asks "do
+// you trust this folder?" the first time it starts in one. Nothing answers it —
+// the session is unattended by design — so claude sits on the prompt, the work
+// never begins, and the record still reports "working" because the lifecycle
+// hook fired on session start. Every dispatch silently did nothing.
+//
+// Trust is inherited, never invented: the worktree is marked trusted only when
+// the repo it was cut from already is. If the user has not vouched for the repo
+// then neither do we, and they answer the prompt once as they would anywhere
+// else. Failing to write is never fatal — a dispatch that shows a trust prompt
+// is worse than one that does not, but far better than no dispatch at all.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// claudeConfigPath is Claude Code's own config, where project trust lives.
+func claudeConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude.json")
+}
+
+// InheritTrust marks worktree as trusted when repo already is. It reports
+// whether the worktree will start without a trust prompt, so the caller can say
+// so rather than leaving the user to wonder why a session is idle.
+func InheritTrust(repoPath, worktree string) bool {
+	path := claudeConfigPath()
+	if path == "" || repoPath == "" || worktree == "" {
+		return false
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	// Decoded into a generic map on purpose: this file is Claude Code's, not
+	// ours, and it carries far more than trust. Round-tripping every key we do
+	// not understand is the only safe way to edit it.
+	var cfg map[string]json.RawMessage
+	if json.Unmarshal(raw, &cfg) != nil {
+		return false
+	}
+	var projects map[string]map[string]any
+	if p, ok := cfg["projects"]; ok {
+		if json.Unmarshal(p, &projects) != nil {
+			return false
+		}
+	}
+	if projects == nil {
+		projects = map[string]map[string]any{}
+	}
+
+	if trusted, _ := projects[worktree]["hasTrustDialogAccepted"].(bool); trusted {
+		return true // already inherited by an earlier dispatch of this feature
+	}
+	if trusted, _ := projects[repoPath]["hasTrustDialogAccepted"].(bool); !trusted {
+		return false // the repo itself is not trusted — do not invent it
+	}
+
+	// Clone the repo's own project entry rather than inventing one. Claude Code
+	// ignores a half-populated entry and asks anyway, and the repo's settings —
+	// its allowed tools, its MCP servers — are exactly what this worktree should
+	// run with, since it is the same codebase in a different directory.
+	entry := map[string]any{}
+	for k, v := range projects[repoPath] {
+		entry[k] = v
+	}
+	for k, v := range projects[worktree] {
+		entry[k] = v // anything already recorded for the worktree wins
+	}
+	entry["hasTrustDialogAccepted"] = true
+	// Onboarding is per-directory and has not happened here; claiming it has is
+	// what made Claude Code fall back to asking.
+	delete(entry, "hasCompletedProjectOnboarding")
+	entry["projectOnboardingSeenCount"] = 0
+	projects[worktree] = entry
+
+	encoded, err := json.Marshal(projects)
+	if err != nil {
+		return false
+	}
+	cfg["projects"] = encoded
+	out, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return false
+	}
+	return writeAtomic(path, out) == nil
+}
+
+// writeAtomic replaces path in one rename, so a crash mid-write cannot leave
+// Claude Code with a truncated config.
+func writeAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	f, err := os.CreateTemp(dir, ".claude-dispatcher-*.json")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	defer func() { _ = os.Remove(tmp) }()
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	if fi, err := os.Stat(path); err == nil {
+		_ = os.Chmod(tmp, fi.Mode())
+	}
+	return os.Rename(tmp, path)
+}

--- a/internal/dispatch/trust_test.go
+++ b/internal/dispatch/trust_test.go
@@ -1,0 +1,143 @@
+package dispatch
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeClaudeConfig lays down a ~/.claude.json with the given projects plus a
+// key we do not understand, so the round-trip is exercised.
+func writeClaudeConfig(t *testing.T, projects map[string]any) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := map[string]any{
+		"projects":         projects,
+		"someOtherSetting": "must survive",
+		"numberOfStartups": 41,
+		"tipsHistory":      map[string]any{"a": 1},
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), b, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return home
+}
+
+func readProjects(t *testing.T, home string) map[string]map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(home, ".claude.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg struct {
+		Projects map[string]map[string]any `json:"projects"`
+	}
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("config is no longer valid JSON: %v", err)
+	}
+	return cfg.Projects
+}
+
+// The whole point: a worktree of a trusted repo starts without a prompt.
+func TestInheritTrustFromATrustedRepo(t *testing.T) {
+	home := writeClaudeConfig(t, map[string]any{
+		"/repos/shop": map[string]any{"hasTrustDialogAccepted": true, "allowedTools": []string{"Bash"}},
+	})
+	if !InheritTrust("/repos/shop", "/state/worktrees/shop/csv-export") {
+		t.Fatal("a worktree of a trusted repo should inherit trust")
+	}
+	got := readProjects(t, home)
+	if v, _ := got["/state/worktrees/shop/csv-export"]["hasTrustDialogAccepted"].(bool); !v {
+		t.Errorf("worktree not marked trusted: %+v", got)
+	}
+	// The repo's own entry, and its other settings, must be untouched.
+	if v, _ := got["/repos/shop"]["hasTrustDialogAccepted"].(bool); !v {
+		t.Error("the repo's own trust was disturbed")
+	}
+	if got["/repos/shop"]["allowedTools"] == nil {
+		t.Error("unrelated project settings were dropped")
+	}
+}
+
+// Trust is inherited, never invented.
+func TestInheritTrustRefusesWhenTheRepoIsNotTrusted(t *testing.T) {
+	home := writeClaudeConfig(t, map[string]any{
+		"/repos/shop": map[string]any{"hasTrustDialogAccepted": false},
+	})
+	if InheritTrust("/repos/shop", "/state/worktrees/shop/x") {
+		t.Error("an untrusted repo must not confer trust on its worktree")
+	}
+	if _, ok := readProjects(t, home)["/state/worktrees/shop/x"]; ok {
+		t.Error("nothing should have been written for the worktree")
+	}
+
+	// A repo Claude Code has never seen is equally not a licence.
+	if InheritTrust("/repos/never-opened", "/state/worktrees/never/x") {
+		t.Error("an unknown repo must not confer trust")
+	}
+}
+
+// The config belongs to Claude Code; every key we do not understand round-trips.
+func TestInheritTrustPreservesTheRestOfTheConfig(t *testing.T) {
+	home := writeClaudeConfig(t, map[string]any{
+		"/repos/shop": map[string]any{"hasTrustDialogAccepted": true},
+	})
+	InheritTrust("/repos/shop", "/state/worktrees/shop/y")
+
+	b, _ := os.ReadFile(filepath.Join(home, ".claude.json"))
+	var cfg map[string]any
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		t.Fatalf("config no longer parses: %v", err)
+	}
+	if cfg["someOtherSetting"] != "must survive" {
+		t.Errorf("unknown top-level keys were lost: %v", cfg["someOtherSetting"])
+	}
+	if cfg["tipsHistory"] == nil {
+		t.Error("tipsHistory was dropped")
+	}
+}
+
+// A missing or unreadable config is not fatal — the dispatch still goes out, it
+// just shows a trust prompt.
+func TestInheritTrustDegradesQuietly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no .claude.json at all
+	if InheritTrust("/repos/shop", "/state/worktrees/shop/z") {
+		t.Error("with no config there is nothing to inherit")
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if InheritTrust("/repos/shop", "/state/worktrees/shop/z") {
+		t.Error("a corrupt config must not be treated as trust")
+	}
+	// And it must be left exactly as found, not half-rewritten.
+	if b, _ := os.ReadFile(filepath.Join(home, ".claude.json")); string(b) != "{not json" {
+		t.Errorf("a config we could not parse was modified: %q", b)
+	}
+}
+
+// Re-dispatching the same feature must not double-write or flip anything back.
+func TestInheritTrustIsIdempotent(t *testing.T) {
+	home := writeClaudeConfig(t, map[string]any{
+		"/repos/shop": map[string]any{"hasTrustDialogAccepted": true},
+	})
+	wt := "/state/worktrees/shop/again"
+	if !InheritTrust("/repos/shop", wt) {
+		t.Fatal("first call should inherit")
+	}
+	if !InheritTrust("/repos/shop", wt) {
+		t.Fatal("second call should report the worktree is already trusted")
+	}
+	if v, _ := readProjects(t, home)[wt]["hasTrustDialogAccepted"].(bool); !v {
+		t.Error("trust was lost on the second pass")
+	}
+}


### PR DESCRIPTION
**Dispatching has been silently doing nothing.**

Every dispatch materialises a brand-new worktree directory, and Claude Code asks *"do you trust this folder?"* the first time it starts in one. Nothing answers it — the session is unattended by design — so `claude` sits on the prompt forever. The prompt is never read, no work happens, and the record still reports `working · processing your prompt`, because the lifecycle hook fired on session start.

Caught it by looking inside a stuck session:

```
 ❯ 1. Yes, I trust this folder
   2. No, exit
```

and confirming the sessions were alive but running `zsh`, not `claude`.

## The fix

The worktree inherits the repo's own entry from `~/.claude.json`. **Trust is inherited, never invented** — if the repo is not already trusted, neither is the worktree, and you answer once as you would anywhere else.

Cloning the *whole* entry rather than writing `hasTrustDialogAccepted` alone was found the hard way: a half-populated entry is ignored and Claude Code asks regardless. It also means the worktree runs with the repo's allowed tools and MCP servers, which is right — it is the same codebase in a different directory.

The config belongs to Claude Code, so it is round-tripped whole: unknown keys survive, the write is atomic (temp + rename), and every failure path is quiet. A dispatch that shows a trust prompt is worse than one that does not; a dispatch that does not happen at all is worse than both.

## Verification

Tests cover inheriting from a trusted repo, refusing an untrusted or unknown one, preserving unrelated config, degrading quietly on a missing or corrupt file, and idempotency on re-dispatch.

Verified end to end against a real trusted repo and a fresh directory: **claude starts with no trust prompt**. The probe entry was removed afterwards and the config left exactly as found.

## Release

No label — a bug fix, so this cuts a patch.