### PR TITLE
Stop the dispatch form swallowing the key that opens it

### DIFF
--- a/internal/cockpit/cq_keys.go
+++ b/internal/cockpit/cq_keys.go
@@ -197,7 +197,14 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 		// keys still reach their handlers. The moment there is a filter or a
 		// sentence they are letters again — `w` belongs in a sentence more often
 		// than it means "working".
-		navKey := isLensDigit(k) || k == ":" || k == "w"
+		//
+		// `d` is in that set because it is the key that OPENS this form, and the
+		// footer advertises it. Swallowing it typed a letter into the repo
+		// filter instead: press d twice, or press it at all with a clear queue
+		// (where the form is already up), and the repo list silently narrowed to
+		// the repos containing "d" while nothing appeared to happen. Falling
+		// through re-opens the form, which on an untouched one is a no-op.
+		navKey := isLensDigit(k) || k == ":" || k == "w" || k == "d"
 		if m.dxTouched() || !navKey {
 			mm, cmd := m.dxKey(k)
 			return mm, cmd, true

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -458,3 +458,42 @@ func TestCQIncludesReviewItems(t *testing.T) {
 		t.Errorf("review item offers no merge act: keys %v", keys)
 	}
 }
+
+// TestDispatchKeyIsIdempotent guards the key the footer advertises as "d
+// dispatch". The form's untouched-fall-through set left `d` out, so pressing it
+// while the form was already up typed a letter into the repo filter. With a
+// clear queue the form is up by default, which made `d` look broken outright:
+// the repo list narrowed to the repos containing "d" and nothing else happened.
+func TestDispatchKeyIsIdempotent(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	cqItems = nil // a clear queue: the form owns the keyboard from the start
+
+	m := newModel()
+	m.lens = "floor"
+	if !m.cqPromptOn() {
+		t.Fatal("precondition: a clear queue should leave the prompt up")
+	}
+
+	mm, _, handled := m.updateFloorQueue("d")
+	if !handled {
+		t.Fatal("d should be handled on the triage lens")
+	}
+	if mm.dxFilter != "" {
+		t.Errorf("d typed itself into the repo filter: dxFilter = %q", mm.dxFilter)
+	}
+	if !mm.cqDispatch {
+		t.Error("d should leave the dispatch form open")
+	}
+
+	// Once something IS typed, d is a letter again — you must be able to filter
+	// for a repo whose name contains one.
+	m2 := newModel()
+	m2.lens = "floor"
+	m2.cqDispatch, m2.dxFilter = true, "clau"
+	m2.key = runes("d")
+	mm2, _, _ := m2.updateFloorQueue(runes("d").String())
+	if mm2.dxFilter != "claud" {
+		t.Errorf("a touched form should take d as text, got %q", mm2.dxFilter)
+	}
+}


### PR DESCRIPTION
**`d` appeared not to work.** It does open the dispatch form — but only from the item view, and only once.

The form's untouched-fall-through set listed `1-8`, `:` and `w`, but not `d`. So with the form already up, `d` was just a letter: it typed itself into the WHERE filter and silently narrowed the repo list to everything containing a "d".

Reproduced against a real portfolio:

| | |
|---|---|
| `d` from the queue | opens the form ✅ |
| `d` again, form open | filter becomes `d` — **47 of 57 repos** ❌ |
| `esc`, then `d` | opens again ✅ |

And **with a clear queue the form is up from the start**, so `d` never appears to do anything at all — you press the key the footer names, the list quietly changes, and nothing you asked for happens. That is the case most people would hit.

## Fix

`d` falls through like the other navigation keys. Re-opening an already-open form is a no-op on an untouched one, so pressing it twice is harmless. The moment anything is typed it is a letter again — exactly the rule `w` follows — because you still need to filter for a repo with a `d` in its name.

## Verified

Live, on the clear-queue case: three `d` presses leave the form untouched (`8 repos · type to filter`, no stray filter), and typing `bluefin` still narrows to 2 of 8. Regression test covers both halves — that `d` does not type itself when untouched, and that it still does once the filter has content.

`make build`, `go vet`, `golangci-lint` (0 issues), `gofmt` and `go test ./...` all pass, including `-shuffle=on`.

## Release

No label — a bug fix, so this cuts a patch.