### PR TITLE
Package the dispatcher as a Nix flake, and point the hook at a path that survives an upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 claude-dispatcher
 *.log
 dist/
+
+# nix build output symlinks.
+result
+result-*
 coverage.out
 coverage.xml
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,45 @@ Or from source (needs Go):
 make install               # builds to ~/.local/bin/claude-dispatcher
 ```
 
+Via Nix — try it, or install it into your profile:
+
+```sh
+nix run github:Innovology/claude-dispatcher            # no install
+nix profile install github:Innovology/claude-dispatcher
+```
+
+Declaratively, the way you would pin any other flake-packaged tool. Add the
+input:
+
+```nix
+inputs.claude-dispatcher.url = "github:Innovology/claude-dispatcher";
+```
+
+then take the package in a NixOS module:
+
+```nix
+{ pkgs, inputs, ... }:
+{
+  environment.systemPackages = [
+    inputs.claude-dispatcher.packages.${pkgs.stdenv.hostPlatform.system}.default
+  ];
+}
+```
+
+or in home-manager (`home.packages`), or apply `overlays.default` and use
+`pkgs.claude-dispatcher`. `inputs.nixpkgs.follows` is safe but not required:
+`go.mod` asks for Go 1.26.5, so a nixpkgs older than that would fail to build.
+
+The binary is wrapped with `git` and `tmux` on its PATH — as a fallback, so
+your own copies still win — which leaves `claude` and `gh` yours to provide.
+`init` records the profile path it was invoked through (`~/.nix-profile/bin/…`,
+`/run/current-system/sw/bin/…`), not the `/nix/store` path behind it, so the
+hook survives upgrades and you do not have to re-run it after every rebuild.
+
+`nix develop` gives the full toolchain — Go, `golangci-lint`, `goreleaser`,
+`tmux` — for working on the dispatcher itself; `nix flake check` runs the test
+suite and the `gofmt` gate.
+
 `~/.local/bin` must be on your PATH ahead of Homebrew's, or a `brew`-installed copy keeps winning:
 
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786247143,
+        "narHash": "sha256-8S3Kcxs7D4UtxJxSJZz0m14CGhuW0MxfrIwJxeGWGnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "279b4a8275f032c566576b3f181fa0f27197f588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "Terminal dispatch cockpit for Claude Code sessions across many repositories";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (pkgs: rec {
+        claude-dispatcher = pkgs.callPackage ./nix/package.nix { };
+        default = claude-dispatcher;
+      });
+
+      overlays.default = final: _prev: {
+        claude-dispatcher = final.callPackage ./nix/package.nix { };
+      };
+
+      devShells = forAllSystems (pkgs: {
+        default = pkgs.mkShell {
+          packages = [
+            pkgs.go
+            pkgs.gopls
+            pkgs.gotools
+            pkgs.golangci-lint
+            pkgs.goreleaser
+            pkgs.gnumake
+            # The cockpit's own runtime dependencies, so `make run` works from
+            # inside the shell.
+            pkgs.git
+            pkgs.tmux
+          ];
+        };
+      });
+
+      checks = forAllSystems (
+        pkgs:
+        let
+          package = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        in
+        {
+          # `go test ./...` already runs as the package's check phase.
+          inherit package;
+
+          gofmt = pkgs.runCommand "claude-dispatcher-gofmt" { nativeBuildInputs = [ pkgs.go ]; } ''
+            unformatted=$(cd ${package.src} && gofmt -l .)
+            if [ -n "$unformatted" ]; then
+              echo "gofmt needed:" >&2
+              echo "$unformatted" >&2
+              exit 1
+            fi
+            touch $out
+          '';
+        }
+      );
+
+      formatter = forAllSystems (pkgs: pkgs.nixfmt);
+    };
+}

--- a/internal/initcmd/initcmd.go
+++ b/internal/initcmd/initcmd.go
@@ -78,16 +78,57 @@ func hookSpecs() []hookSpec {
 
 const hookMarker = "claude-dispatcher hook"
 
+const nixStore = "/nix/store/"
+
+// hookExe returns the path to bake into the hook command.
+//
+// os.Executable answers with the real file — on Linux /proc/self/exe is
+// already resolved — which for a Nix install is /nix/store/<hash>-…: a path
+// that changes with every upgrade and disappears at the next garbage
+// collection, leaving a hook that silently never fires again. Homebrew has the
+// same shape, one Cellar version deep. The durable name is the one the human
+// invoked through (/run/current-system/sw/bin/…, ~/.nix-profile/bin/…, the
+// brew shim, ~/.local/bin/…), so prefer that — but only once it is proven to
+// resolve to this very binary. PATH may hold a second, older copy (the
+// brew-vs-~/.local/bin trap in the README); a hook aimed at the wrong build
+// would be worse than one pinned to the right one.
+func hookExe(exe, argv0 string, lookPath, eval func(string) (string, error)) string {
+	cand := argv0
+	if !strings.ContainsRune(cand, filepath.Separator) {
+		found, err := lookPath(cand)
+		if err != nil {
+			return exe
+		}
+		cand = found
+	}
+	cand, err := filepath.Abs(cand)
+	if err != nil {
+		return exe
+	}
+	if resolved, err := eval(cand); err != nil || resolved != exe {
+		return exe
+	}
+	return cand
+}
+
 func installHook() error {
 	exe, err := os.Executable()
 	if err != nil {
 		return err
 	}
-	exe, _ = filepath.EvalSymlinks(exe)
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
 	if strings.Contains(exe, "go-build") {
 		fmt.Println("\n! running via `go run` — install a real binary first (make install), then re-run init,")
 		fmt.Println("  otherwise the hook would point at a temporary build path.")
 		return nil
+	}
+	exe = hookExe(exe, os.Args[0], exec.LookPath, filepath.EvalSymlinks)
+	if strings.HasPrefix(exe, nixStore) {
+		fmt.Println("\n! this build was run straight out of /nix/store, so the hook can only point at")
+		fmt.Println("  this exact build — it stops firing at the next garbage collection. Install it")
+		fmt.Println("  into a profile (nix profile install / systemPackages) and re-run init.")
 	}
 
 	settingsPath := filepath.Join(claudeConfigDir(), "settings.json")

--- a/internal/initcmd/initcmd_test.go
+++ b/internal/initcmd/initcmd_test.go
@@ -1,0 +1,102 @@
+package initcmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// binAndLink builds the shape every packaged install has: the real binary at
+// one path, and a stable name on PATH pointing at it.
+func binAndLink(t *testing.T) (real, link string) {
+	t.Helper()
+	dir := t.TempDir()
+	// t.TempDir can itself sit behind a symlink (/var → /private/var on
+	// macOS); resolve it so the comparisons below are about our links only.
+	dir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolving temp dir: %v", err)
+	}
+	real = filepath.Join(dir, "abcdef-claude-dispatcher-2.3.1", "claude-dispatcher")
+	if err := os.MkdirAll(filepath.Dir(real), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(real, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	link = filepath.Join(dir, "bin", "claude-dispatcher")
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	return real, link
+}
+
+func found(path string) func(string) (string, error) {
+	return func(string) (string, error) { return path, nil }
+}
+
+// The whole point: a Nix or Homebrew install is reached through a stable
+// symlink, and the hook has to record that rather than the versioned path it
+// resolves to, which the next upgrade replaces.
+func TestHookExePrefersTheStableName(t *testing.T) {
+	real, link := binAndLink(t)
+
+	got := hookExe(real, "claude-dispatcher", found(link), filepath.EvalSymlinks)
+
+	if got != link {
+		t.Fatalf("hookExe = %q, want the stable link %q", got, link)
+	}
+}
+
+// PATH may hold a second, older copy of the dispatcher — the brew versus
+// ~/.local/bin trap. Recording it would aim the hook at a different build, so
+// a candidate that does not resolve to this binary is refused.
+func TestHookExeRefusesADifferentCopyOnPath(t *testing.T) {
+	real, _ := binAndLink(t)
+	other, _ := binAndLink(t)
+
+	got := hookExe(real, "claude-dispatcher", found(other), filepath.EvalSymlinks)
+
+	if got != real {
+		t.Fatalf("hookExe = %q, want the running binary %q", got, real)
+	}
+}
+
+func TestHookExeFallsBackWhenPathLookupFails(t *testing.T) {
+	real, _ := binAndLink(t)
+	lookPath := func(string) (string, error) { return "", errors.New("not found") }
+
+	got := hookExe(real, "claude-dispatcher", lookPath, filepath.EvalSymlinks)
+
+	if got != real {
+		t.Fatalf("hookExe = %q, want the running binary %q", got, real)
+	}
+}
+
+// Invoked by path rather than by name: no PATH lookup happens, but the same
+// proof is required before the given path is trusted.
+func TestHookExeAcceptsAnExplicitPath(t *testing.T) {
+	real, link := binAndLink(t)
+	never := func(string) (string, error) { t.Fatal("PATH lookup for an explicit path"); return "", nil }
+
+	got := hookExe(real, link, never, filepath.EvalSymlinks)
+
+	if got != link {
+		t.Fatalf("hookExe = %q, want %q", got, link)
+	}
+}
+
+func TestHookExeKeepsTheBinaryWhenNothingResolves(t *testing.T) {
+	real, _ := binAndLink(t)
+	gone := filepath.Join(t.TempDir(), "bin", "claude-dispatcher")
+
+	got := hookExe(real, gone, found(gone), filepath.EvalSymlinks)
+
+	if got != real {
+		t.Fatalf("hookExe = %q, want the running binary %q", got, real)
+	}
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  buildGoModule,
+  makeWrapper,
+  git,
+  tmux,
+  # Releases are stamped by goreleaser from the git tag; a flake build of an
+  # arbitrary commit is honestly a dev build, exactly like `make install`.
+  # Override to stamp one: `pkgs.claude-dispatcher.override { version = "2.3.1"; }`.
+  version ? "dev",
+}:
+
+buildGoModule {
+  pname = "claude-dispatcher";
+  inherit version;
+
+  # Only the Go sources decide the build, so editing the README or the
+  # workflows does not invalidate the derivation.
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../go.mod
+      ../go.sum
+      (lib.fileset.fileFilter (f: f.hasExt "go") ../.)
+    ];
+  };
+
+  vendorHash = "sha256-pCqhzNxhspm/Q3WcK5pUaJgizabfqCuANhyDsAFjUug=";
+
+  env.CGO_ENABLED = "0";
+
+  # -trimpath is already buildGoModule's default; -s -w matches .goreleaser.yml.
+  ldflags = [
+    "-s"
+    "-w"
+    "-X"
+    "claude-dispatcher/internal/version.Version=${version}"
+  ];
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  # The dispatch and ship tests shell out to git; nothing in the suite needs
+  # tmux (the supervisor tests only assert the backend's name).
+  nativeCheckInputs = [ git ];
+
+  # git and tmux are hard runtime dependencies — tmux is the process
+  # supervisor, git cuts the per-dispatch branch and worktree. --suffix, not
+  # --prefix, so a user's own git still wins on PATH. `claude` and `gh` stay
+  # the user's to provide: the point of the cockpit is to drive the Claude
+  # Code install they already run.
+  postInstall = ''
+    wrapProgram $out/bin/claude-dispatcher \
+      --suffix PATH : ${
+        lib.makeBinPath [
+          git
+          tmux
+        ]
+      }
+  '';
+
+  meta = {
+    description = "Terminal dispatch cockpit for Claude Code sessions across many repositories";
+    homepage = "https://github.com/Innovology/claude-dispatcher";
+    license = lib.licenses.mit;
+    mainProgram = "claude-dispatcher";
+    # The tmux supervisor is unix-only; the Windows build has its own backend
+    # but nix does not target it.
+    platforms = lib.platforms.unix;
+  };
+}


### PR DESCRIPTION
Two commits, already on the branch. Verified against current `main`: merges cleanly, builds, `golangci-lint` 0 issues, `go test ./...` passes.

## 1. A flake

`flake.nix`, `nix/package.nix` and `flake.lock`, covering `x86_64`/`aarch64` on Linux and Darwin, plus a README section. Installable like any other tool.

## 2. The hook survives upgrades — and this one matters beyond Nix

`init` recorded `os.Executable()`, which on Linux resolves through `/proc/self/exe` to the real file. For a Nix install that is `/nix/store/<hash>-…` — a path that **changes on every upgrade and disappears at the next garbage collection**. The hook then calls a build the system no longer has, and every dispatch sits on "launching" forever.

Homebrew has the same shape one Cellar version deep, so this was always a latent "remember to re-run `init`" trap; the README even warns about the related brew-vs-`~/.local/bin` PATH problem.

It now prefers the **stable name** — the profile or shim your PATH reaches the binary through — but only once that name is proven to resolve to *this very binary*. PATH may hold a second, older copy, and a hook aimed at the wrong build would be worse than one pinned to the right one. Running straight out of the store, where no such name exists, says so rather than writing a path that will quietly rot.

Also fixes a real bug on the way: a failed `EvalSymlinks` had its error discarded and the empty result kept, which would have written `" hook SessionStart"` into `settings.json`.

Five tests cover it: prefers the stable name, refuses a different copy on PATH, falls back when lookup fails, accepts an explicit path, and keeps the binary when nothing resolves.

## Release

`release:minor` — new packaging plus a fix, nothing breaking.