### PR TITLE
Name a dispatch after its branch, and cap the slug that names three things

### DIFF
--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -172,16 +172,14 @@ func (m model) dxPicked() (dxRepoRow, bool) {
 
 // ---- the branch --------------------------------------------------------------
 
-// dxBranchWords caps how many slug words the branch keeps, so a whole sentence
-// of a feature name still produces a branch a human can type. 0 means no cap.
+// dxBranchWords caps how many slug words the branch preview keeps.
 //
-// It is 0, not the design's 5. The preview is only true if Launch applies the
-// same cap, and Launch's slug also names the worktree directory and the tmux
-// session — capping it here alone would mislabel three things at once, and
-// capping it in internal/dispatch would rename branches for every dispatch path
-// in the product, which is a change this design does not ask for. A truthful
-// long branch beats a tidy wrong one; raise this the day Launch caps too.
-const dxBranchWords = 0
+// It tracks dispatch.SlugWords deliberately: the preview is only true if Launch
+// applies the same cap, and Launch's slug also names the worktree directory and
+// the tmux session. It used to be 0 — an uncapped, truthful-but-unusable branch
+// — because capping here alone would have mislabelled three things at once.
+// Launch caps now, so this can.
+const dxBranchWords = dispatchpkg.SlugWords
 
 // dxSlugWords slugifies s and keeps at most max slug words.
 //
@@ -365,7 +363,7 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 		m.notice = "nothing matches — widen the filter"
 		return m, nil
 	}
-	feature := strings.TrimSpace(m.dxWhat)
+	feature := dxFeatureName(m.dxWhat)
 	if feature == "" {
 		m.dxField = dxWhatF
 		m.notice = "say what it should do"
@@ -655,4 +653,20 @@ func dxRepoLine(inner int, r dxRepoRow, on bool) string {
 		segs = append(segs, c("", dxGapW, ""), cr(r.last, 10, cFaint))
 	}
 	return flG(blank(indent) + row(width, bg, segs...))
+}
+
+// dxFeatureName is the name the dispatch is filed under: the branch's own words,
+// read back as a phrase.
+//
+// WHAT used to become the feature name whole, so a pasted paragraph produced a
+// 75-word name, a 91-character slug and a 96-character tmux session. Naming the
+// feature from the same capped slug the branch uses keeps all four in agreement
+// — name, branch, worktree and session — and nothing is lost: the full sentence
+// is the first line of the prompt (see dxPrompt).
+func dxFeatureName(what string) string {
+	slug := dispatchpkg.Slugify(strings.TrimSpace(what))
+	if slug == "" {
+		return ""
+	}
+	return strings.ReplaceAll(slug, "-", " ")
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -23,7 +23,43 @@ var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
 // Slugify turns a feature name into a branch/session-safe slug.
 func Slugify(feature string) string {
 	s := slugRe.ReplaceAllString(strings.ToLower(feature), "-")
-	return strings.Trim(s, "-")
+	return capSlug(strings.Trim(s, "-"))
+}
+
+// SlugWords is how many words a slug keeps. The slug names three things at
+// once — the branch, the worktree directory and the tmux session — so an
+// uncapped one produced `feature/several-improvements-here-use-the-claude-
+// design-mcp-https-api-anthropic-com` and a 96-character session name, because
+// whatever was typed as the feature name went in whole.
+//
+// Five words is enough to tell two features apart at a glance and short enough
+// to type. The full name still lives on the record and is what every screen
+// shows; only the slug is abbreviated.
+const SlugWords = 5
+
+// slugMaxLen bounds the result even when five words are each very long, so a
+// path component stays comfortably inside what every filesystem accepts.
+const slugMaxLen = 60
+
+// capSlug keeps at most SlugWords words and slugMaxLen characters, never
+// splitting a word unless a single word exceeds the limit on its own.
+func capSlug(s string) string {
+	if s == "" {
+		return ""
+	}
+	words := strings.Split(s, "-")
+	if len(words) > SlugWords {
+		words = words[:SlugWords]
+	}
+	out := strings.Join(words, "-")
+	for len(out) > slugMaxLen && len(words) > 1 {
+		words = words[:len(words)-1]
+		out = strings.Join(words, "-")
+	}
+	if len(out) > slugMaxLen {
+		out = strings.Trim(out[:slugMaxLen], "-")
+	}
+	return out
 }
 
 // Launch materialises feature/<slug> in its own git worktree under the state

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -253,3 +253,45 @@ func TestSlugifyStripsNonASCII(t *testing.T) {
 		t.Errorf("expected non-ascii stripped, got %q", got)
 	}
 }
+
+// TestSlugifyCaps guards the names a dispatch creates. The slug names three
+// things at once — the branch, the worktree directory and the tmux session —
+// and it used to take whatever was typed as the feature name whole. Real
+// records ended up with 91-character slugs and 96-character session names,
+// because the dispatch prompt fed the entire typed sentence in as the name.
+func TestSlugifyCaps(t *testing.T) {
+	long := "several improvements here: Use the claude_design MCP (https://api.anthropic.com/v1/design/mcp, auth via /design-login) to import this project"
+	got := Slugify(long)
+
+	if n := len(strings.Split(got, "-")); n > SlugWords {
+		t.Errorf("slug kept %d words, want at most %d: %q", n, SlugWords, got)
+	}
+	if len(got) > 60 {
+		t.Errorf("slug is %d chars, too long for a path component: %q", len(got), got)
+	}
+	if strings.HasPrefix(got, "-") || strings.HasSuffix(got, "-") {
+		t.Errorf("slug has a dangling separator: %q", got)
+	}
+
+	// Short names are untouched — the cap must not mangle the ordinary case.
+	for _, s := range []string{"retry backoff", "csv export", "seat limits"} {
+		if got := Slugify(s); got != strings.ReplaceAll(s, " ", "-") {
+			t.Errorf("Slugify(%q) = %q, want it unchanged", s, got)
+		}
+	}
+
+	// A single enormous word still has to fit.
+	if got := Slugify(strings.Repeat("x", 200)); len(got) > 60 {
+		t.Errorf("one long word not bounded: %d chars", len(got))
+	}
+
+	// Slugifying twice is the same as once — the cockpit names the feature from
+	// the slug, and Launch slugifies that name again.
+	if a, b := Slugify(long), Slugify(strings.ReplaceAll(Slugify(long), "-", " ")); a != b {
+		t.Errorf("not idempotent: %q vs %q", a, b)
+	}
+
+	if Slugify("") != "" || Slugify("!!!") != "" {
+		t.Error("an unnameable feature should still produce an empty slug")
+	}
+}


### PR DESCRIPTION
Whatever you typed as the feature name went through whole. The slug it produces names **three** things — the branch, the worktree directory and the tmux session — so a pasted paragraph gave a 91-character slug and a 96-character session name. Real records on this machine carry:

```
feature/several-improvements-here-use-the-claude-design-mcp-https-api-anthropic-com
```

## The fix

`Slugify` keeps **five words and sixty characters**, applied in `internal/dispatch` — the one place that makes all three names agree. Short names are untouched.

The dispatch form now names the feature from that same slug, read back as a phrase, instead of from the whole WHAT field. Name, branch, worktree and session finally say the same thing, and **nothing is lost** — the full sentence is still the first line of the prompt.

| typed | name | branch / session |
|---|---|---|
| `several improvements here: Use the claude_design MCP (https://…` | `several improvements here use the` | `feature/several-improvements-here-use-the` |
| `P0: Full test suite regression on main — frontend and backend` | `p0 full test suite regression` | `feature/p0-full-test-suite-regression` |
| `retry failed charges with backoff` | *unchanged* | `feature/retry-failed-charges-with-backoff` |

## And the preview stops lying

`dxBranchWords` was `0`, with a comment saying capping the preview alone would mislabel three things at once and that it should be raised *"the day Launch caps too"*. Launch caps now, so it tracks `dispatch.SlugWords`. Verified live — pasting a paragraph into WHAT previews `feature/use-the-claude-design-mcp`.

## Verification

Tests cover the cap, that short names are untouched, that a single 200-character word still fits, that dangling separators never survive, and that slugifying is **idempotent** — which matters because the cockpit names the feature from the slug and `Launch` slugifies that name again.

`make build`, `go vet`, `golangci-lint` (0 issues), `go test ./...` and `-shuffle=on` all pass.

## One behavioural note

An in-flight dispatch whose feature name is long already has a worktree at the old path. Re-dispatching that feature after this lands will cut a new, shorter branch and worktree rather than reusing the old one. Nothing is destroyed — the old worktree stays until you kill it.

## Release

No label — a bug fix, so this cuts a patch.