### PR TITLE
Measure velocity from the repositories, not only from what we dispatched

### DIFF
--- a/internal/cockpit/collect_products.go
+++ b/internal/cockpit/collect_products.go
@@ -112,6 +112,9 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 	// per repo; openPRs is empty when the search fails, which reads as "no
 	// open PRs" only after gh has actually answered.
 	openPRs, _ := gh.OpenPRs()
+	// Merged PRs are a fact about the repository whoever opened them, which is
+	// how work done outside the dispatcher still registers.
+	mergedByRepo, _ := gh.MergedPRs(7)
 
 	ghCache := map[string]repoGHData{}
 	repoGHFor := func(name string) repoGHData {
@@ -241,17 +244,40 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 		if med, ok := prodMedian(leads); ok {
 			leadStr, leadDur = prodDur(med), med
 		}
+		// What the repositories themselves say, independent of any dispatch.
+		commits7d, merged7d, deploys7d := 0, 0, 0
+		for _, name := range names {
+			r, ok := discByName[name]
+			if !ok {
+				continue
+			}
+			if n, ok := stqCommitsSince(r.Path, 7); ok {
+				commits7d += n
+			}
+			merged7d += len(mergedByRepo[name])
+			if ghUp {
+				override := ""
+				if cfg != nil {
+					override = cfg.DeployWorkflows[name]
+				}
+				deploys7d += gh.DeployStatus(r.Path, override).Successes
+			}
+		}
+
 		s.products = append(s.products, product{
-			name:     p,
-			repos:    prodRepoCount(len(names)),
-			forge:    prodForge(names, discByName, ctx),
-			inflight: inflight,
-			needs:    needs,
-			review:   review,
-			live:     live,
-			spark:    prodSpark(dailyLive),
-			lead:     leadStr,
-			leadDur:  leadDur,
+			name:      p,
+			commits7d: commits7d,
+			merged7d:  merged7d,
+			deploys7d: deploys7d,
+			repos:     prodRepoCount(len(names)),
+			forge:     prodForge(names, discByName, ctx),
+			inflight:  inflight,
+			needs:     needs,
+			review:    review,
+			live:      live,
+			spark:     prodSpark(dailyLive),
+			lead:      leadStr,
+			leadDur:   leadDur,
 		})
 
 		// ---- note + stats --------------------------------------------------

--- a/internal/cockpit/collect_stale.go
+++ b/internal/cockpit/collect_stale.go
@@ -132,3 +132,22 @@ func stqAge(t time.Time) string {
 		return strconv.Itoa(int(d/(24*time.Hour))) + "d"
 	}
 }
+
+// stqCommitsSince counts commits on the repo's current branch in the last
+// `days`, whoever made them.
+//
+// Every other figure in the cockpit is derived from its own dispatch records,
+// so a repo the human works in directly reads as idle. It is not: this is the
+// signal that says so, and it costs one local git call with no API budget.
+func stqCommitsSince(repoPath string, days int) (int, bool) {
+	out, err := exec.Command("git", "-C", repoPath, "rev-list", "--count",
+		"--since="+itoa(days)+".days.ago", "HEAD").Output()
+	if err != nil {
+		return 0, false
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/cockpit/collect_velocity.go
+++ b/internal/cockpit/collect_velocity.go
@@ -354,10 +354,31 @@ func collectVelocity(ctx *collectCtx, s *snapshot) {
 		waitV = velHumanDur(med)
 		waitNote = fmt.Sprintf("median of %d hand-backs to you", len(dwell.waits))
 	}
+	// What the repositories say, summed across products — these count work done
+	// outside the dispatcher too, which every other figure on this lens misses.
+	deploys, merged, commits := 0, 0, 0
+	for _, p := range s.products {
+		deploys += p.deploys7d
+		merged += p.merged7d
+		commits += p.commits7d
+	}
+	deployV, deployNote := "—", "no deploy workflow found"
+	if deploys > 0 {
+		deployV, deployNote = itoa(deploys), "successful deploy runs, last 7 days"
+	}
+	mergedV, mergedNote := "—", "nothing merged in the last 7 days"
+	if merged > 0 {
+		mergedNote = "merged in the last 7 days"
+		mergedV = itoa(merged)
+		if commits > 0 {
+			mergedNote += " · " + itoa(commits) + " " + plural(commits, "commit", "commits")
+		}
+	}
+
 	s.doraFactory = []doraMetric{
-		{key: "first-pass rate", v: "—", unit: "", band: "medium", note: "claims accepted without rework"},
+		{key: "deployments", v: deployV, unit: "", band: "medium", note: deployNote},
+		{key: "prs merged", v: mergedV, unit: "", band: "medium", note: mergedNote},
 		{key: "waiting on you", v: waitV, unit: "", band: "medium", note: waitNote},
-		{key: "turns per feature", v: "—", unit: "", band: "medium", note: "no turn data"},
 		{key: "work in progress", v: itoa(inFlight), unit: "", band: "medium", spark: velSpark(sparkVals), note: "dispatchers not yet live"},
 	}
 

--- a/internal/cockpit/derive_bands_test.go
+++ b/internal/cockpit/derive_bands_test.go
@@ -7,6 +7,7 @@ package cockpit
 // portfolio.
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -103,5 +104,41 @@ func TestCQPhaseFromTranscript(t *testing.T) {
 func TestFanOutIsBounded(t *testing.T) {
 	if n := fanOut(); n < 4 || n > 12 {
 		t.Errorf("fanOut = %d, want it clamped to [4,12] so a big portfolio cannot spawn hundreds of processes", n)
+	}
+}
+
+// TestVelUnseenLinesNamesWhatTheRankingCannotSee guards the gap this lens had:
+// lead time is measured from dispatch records, so a product the human commits
+// to directly has none and used to drop out of the ranking silently. A partial
+// ranking presented as a whole one is a claim about products it never measured.
+func TestVelUnseenLinesNamesWhatTheRankingCannotSee(t *testing.T) {
+	got := strings.Join(velUnseenLines([]product{
+		{name: "Soundbooth", merged7d: 3, commits7d: 41},
+		{name: "Spine", commits7d: 7},
+		{name: "VERA", merged7d: 1},
+	}, 120), " ")
+
+	for _, want := range []string{"Soundbooth", "3 merged", "41 commits", "Spine", "7 commits", "VERA", "1 merged"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in: %s", want, got)
+		}
+	}
+	if !strings.Contains(got, "nothing dispatched through here") {
+		t.Errorf("should say why they are unranked: %s", got)
+	}
+
+	// A product with no activity at all is not "unseen", it is idle — the caller
+	// filters those out, so nothing is claimed about them either way.
+	if velUnseenLines(nil, 120) != nil {
+		t.Error("no unseen products should render no line")
+	}
+
+	// Long lists are summarised rather than run off the pane.
+	many := make([]product, 6)
+	for i := range many {
+		many[i] = product{name: "p" + itoa(i), commits7d: 1}
+	}
+	if s := strings.Join(velUnseenLines(many, 120), " "); !strings.Contains(s, "3 more") {
+		t.Errorf("should summarise the tail: %s", s)
 	}
 }

--- a/internal/cockpit/types.go
+++ b/internal/cockpit/types.go
@@ -61,6 +61,15 @@ type product struct {
 	// time, and ranking on the formatted string silently puts "48m" above
 	// "2d 4h"; the duration is the sortable truth, the string is for the eye.
 	leadDur time.Duration
+	// commits7d and merged7d are what the repositories say, not what the
+	// dispatcher started: commits on each repo's branch and pull requests merged
+	// in the last week, whoever did them. A product the human works in directly
+	// has no dispatch records and would otherwise read as idle.
+	commits7d int
+	merged7d  int
+	// deploys7d counts successful runs of each repo's deploy workflow — the
+	// deployments that actually happened.
+	deploys7d int
 }
 
 type repoRef struct {

--- a/internal/cockpit/velocity.go
+++ b/internal/cockpit/velocity.go
@@ -236,30 +236,41 @@ func (m model) velRight(iw int) []string {
 // comparison rather than a bare number — a ratio against a one-repo product is
 // too fragile to state.
 //
-// Only products that can be ranked take part: one with no repos has no lead
-// time to have, and one where nothing has reached live has none yet. When
-// nothing survives that filter the block says which of the two it is instead of
-// picking a winner out of an empty set.
+// Lead time is measured from dispatch records, so it only sees work the cockpit
+// started. A product the human commits to directly has no lead time to rank and
+// used to drop out of the comparison silently, which read as "nothing to say"
+// when the truth was "we cannot see it from here". Those products are now named
+// with what the repositories do show — commits and merges — so the reader knows
+// the ranking is partial rather than complete.
 func velLaggardBlock(iw int) []string {
 	out := []string{"", fg(cRule, strings.Repeat("─", iw)), ""}
 
-	var ranked []product
+	var ranked, unseen []product
 	for _, p := range products {
-		if p.repos == prodRepoCount(0) || p.leadDur <= 0 {
+		if p.repos == prodRepoCount(0) {
 			continue
 		}
-		ranked = append(ranked, p)
+		if p.leadDur > 0 {
+			ranked = append(ranked, p)
+			continue
+		}
+		// No dispatch has reached live here, but the repos may still be moving.
+		if p.commits7d > 0 || p.merged7d > 0 {
+			unseen = append(unseen, p)
+		}
 	}
 
+	out = append(out, line("slowest product", iw, cDim, ""))
+
 	if len(ranked) == 0 {
-		out = append(out, line("velocity per product", iw, cDim, ""))
 		msg := "No products yet — assign repos to products on 2 and this measures each one."
 		if len(products) > 0 {
-			msg = "No product has had a feature reach live yet — this measures dispatch → live, per product."
+			msg = "No product has had a dispatch reach live yet — this measures dispatch → live, per product."
 		}
 		for _, l := range velWrap(msg, iw, 3) {
 			out = append(out, line(l, iw, cFaint, ""))
 		}
+		out = append(out, velUnseenLines(unseen, iw)...)
 		return append(out, "")
 	}
 
@@ -281,9 +292,41 @@ func velLaggardBlock(iw int) []string {
 	} else {
 		slow += " · slowest of " + itoa(len(ranked)) + " products · " + best.name + " ships in " + best.lead
 	}
-	out = append(out, line("slowest product", iw, cDim, ""))
 	out = append(out, line(slow, iw, cAmber, ""))
+	out = append(out, velUnseenLines(unseen, iw)...)
 	return append(out, "")
+}
+
+// velUnseenLines names the products the ranking could not include because the
+// cockpit dispatched none of their work, and says what their repos did anyway.
+// Leaving them out entirely would present a partial ranking as a whole one.
+func velUnseenLines(unseen []product, iw int) []string {
+	if len(unseen) == 0 {
+		return nil
+	}
+	var parts []string
+	for i, p := range unseen {
+		if i == 3 {
+			parts = append(parts, "and "+itoa(len(unseen)-3)+" more")
+			break
+		}
+		what := ""
+		switch {
+		case p.merged7d > 0 && p.commits7d > 0:
+			what = itoa(p.merged7d) + " merged · " + itoa(p.commits7d) + " commits"
+		case p.merged7d > 0:
+			what = itoa(p.merged7d) + " merged"
+		default:
+			what = itoa(p.commits7d) + " commits"
+		}
+		parts = append(parts, p.name+" ("+what+")")
+	}
+	var out []string
+	for _, l := range velWrap("not ranked — moving, but nothing dispatched through here: "+
+		strings.Join(parts, ", "), iw, 3) {
+		out = append(out, line(l, iw, cFaint, ""))
+	}
+	return out
 }
 
 // velTilesBlock lays out metric tiles two-across (one-across when the column

--- a/internal/gh/gh.go
+++ b/internal/gh/gh.go
@@ -148,6 +148,10 @@ type DeployPipeline struct {
 	Conclusion string // success | failure | cancelled | "" while running
 	At         time.Time
 	RunsToday  int
+	// Successes is how many runs of this workflow succeeded in the window the
+	// caller asked about — the deployments that actually happened, as opposed
+	// to the dispatches the cockpit happens to have started.
+	Successes int
 }
 
 // DeployStatus reports the repo's deploy workflow and its latest run, using the
@@ -184,13 +188,17 @@ func DeployStatus(repoPath, override string) DeployPipeline {
 			return DeployPipeline{Name: target}
 		}
 		p := DeployPipeline{Name: target}
-		cutoff := time.Now().Add(-24 * time.Hour)
+		day := time.Now().Add(-24 * time.Hour)
+		week := time.Now().AddDate(0, 0, -7)
 		for i, r := range rows {
 			if i == 0 {
 				p.Status, p.Conclusion, p.At = r.Status, r.Conclusion, r.CreatedAt
 			}
-			if r.CreatedAt.After(cutoff) {
+			if r.CreatedAt.After(day) {
 				p.RunsToday++
+			}
+			if r.Conclusion == "success" && r.CreatedAt.After(week) {
+				p.Successes++
 			}
 		}
 		return p

--- a/internal/gh/search.go
+++ b/internal/gh/search.go
@@ -135,3 +135,55 @@ func OpenPRs() (map[string][]OpenPR, bool) {
 	})
 	return r.byRepo, r.ok
 }
+
+// MergedPRs returns pull requests merged in the last `days`, keyed by bare repo
+// name. One search, cached — the same shape as OpenPRs.
+//
+// The cockpit's other counts come from its own dispatch records, which only see
+// work it started. A merged PR is a fact about the repository regardless of who
+// or what opened it, so this is how a product the human works in directly still
+// registers as moving.
+func MergedPRs(days int) (map[string][]OpenPR, bool) {
+	type result struct {
+		byRepo map[string][]OpenPR
+		ok     bool
+	}
+	if days <= 0 {
+		days = 7
+	}
+	since := time.Now().AddDate(0, 0, -days).Format("2006-01-02")
+	r := memo("search:prs:merged:"+since, SearchTTL, func() result {
+		if !Available() {
+			return result{}
+		}
+		out, err := exec.Command("gh", "search", "prs",
+			"--merged", "--merged-at", ">="+since, "--involves", "@me",
+			"--limit", "100",
+			"--json", "repository,number,title,author,createdAt").Output()
+		if err != nil {
+			return result{}
+		}
+		var rows []struct {
+			Repository repoField `json:"repository"`
+			Number     int       `json:"number"`
+			Title      string    `json:"title"`
+			Author     struct {
+				Login string `json:"login"`
+			} `json:"author"`
+			CreatedAt time.Time `json:"createdAt"`
+		}
+		if json.Unmarshal(out, &rows) != nil {
+			return result{}
+		}
+		byRepo := map[string][]OpenPR{}
+		for _, row := range rows {
+			name := row.Repository.shortName()
+			byRepo[name] = append(byRepo[name], OpenPR{
+				Number: row.Number, Title: row.Title,
+				Author: row.Author.Login, CreatedAt: row.CreatedAt,
+			})
+		}
+		return result{byRepo: byRepo, ok: true}
+	})
+	return r.byRepo, r.ok
+}


### PR DESCRIPTION
Every figure on the velocity lens came from the cockpit's own dispatch records, so work done directly in a repo was invisible to it. On this machine that is **most** of the work:

| | dispatcher's count | what the repos say |
|---|---|---|
| deployments, last 7 days | 9 "live" | **18** successful deploy runs |
| PRs merged, last 7 days | not measured | **38** (70 commits) |
| products rankable | 4 | of 10 |

## The slowest-product ranking had the sharper version of it

Lead time is dispatch→live, so a product nobody dispatched through has none — and those products were dropped from the comparison **in silence**. Six of ten here. The read-out looked complete when it had seen four.

Products that are moving but unrankable are now named, with what their repos actually show, so a partial ranking says so:

```
slowest product
AURA · lead 4d 0h · slowest of 4 products · Soundbooth ships in 2h 57m
not ranked — moving, but nothing dispatched through here: Cortiva (2 merged · 2 commits),
PlayerPulse (1 merged), unassigned (1 merged · 3 commits)
```

## Two dead tiles become real ones

`first-pass rate` and `turns per feature` had been `—` since they were written, with no data behind either. They are replaced by **deployments** and **prs merged**, both counted from the forge. The two DORA incident tiles stay `—`, because there genuinely is no incident data and inventing one would be worse.

## New signals

- **`gh.MergedPRs`** — one cached search, same shape as the existing open-PR one. A merged PR is a fact about the repository regardless of who opened it.
- **`DeployPipeline.Successes`** — deploy runs that actually succeeded in the window, from the workflow the "done means live" tracker already detects, so the two cannot disagree.
- **`stqCommitsSince`** — a local `git rev-list --count --since`, which costs no API budget and sees every commit whoever made it.

## Verification

`make build`, `go vet`, `golangci-lint` (0 issues), `go test ./...` and `-shuffle=on` all pass. Tests cover the unseen-product line: that it names each product and what it did, explains why it is unranked, renders nothing when there is nothing to say, and summarises a long tail rather than running off the pane.

Driven live against the real portfolio at 176×44 — the capture above is from that run.

## Release

`release:minor` — new measurements, nothing breaking.