### PR TITLE
Drop the w key from triage

### DIFF
--- a/internal/cockpit/cq_keys.go
+++ b/internal/cockpit/cq_keys.go
@@ -208,7 +208,7 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 		// flight (where the form is already up), and the repo list silently
 		// narrowed to the repos containing "d" while nothing appeared to happen.
 		// Falling through re-opens the form, which on an untouched one is a no-op.
-		navKey := isLensDigit(k) || k == ":" || k == "w" || k == "d"
+		navKey := isLensDigit(k) || k == ":" || k == "d"
 		if m.dxTouched() || !navKey {
 			mm, cmd := m.dxKey(k)
 			return mm, cmd, true
@@ -226,16 +226,6 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 		return m.fleetTo(len(m.fleetRows()) - 1), nil, true
 	case "f":
 		return m.fleetSetFilter(fleetNextFilter(m.fleetFilter())), nil, true
-	case "w":
-		// `w` is the shortcut to the filter people actually reach for, and the
-		// way back out of the dispatch form — which is what the form's own
-		// footer advertises. The form is only ever untouched here (see the
-		// navKey set above), so closing it discards nothing typed.
-		m = m.dxReset()
-		if m.fleetFilter() == "running" {
-			return m.fleetSetFilter(fleetFilters[0]), nil, true
-		}
-		return m.fleetSetFilter("running"), nil, true
 	case "d":
 		return m.dxOpen(""), nil, true
 	}

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -254,30 +254,13 @@ func TestFleetFilterCycles(t *testing.T) {
 	}
 }
 
-// `w` is the shortcut to the running rows and back — it no longer opens a view
-// of its own, which is why cqUnattendedLine says "shows only those".
-func TestFleetWTogglesTheRunningFilter(t *testing.T) {
-	m := cqModel(t)
-	m = press(m, "w")
-	if m.fleetFilter() != "running" || fleetFeatures(m) != "three" {
-		t.Fatalf("w = %q / %s", m.fleetFilter(), fleetFeatures(m))
-	}
-	m = press(m, "w")
-	if m.fleetFilter() != "all" {
-		t.Errorf("w again should come back, got %q", m.fleetFilter())
-	}
-	if !strings.Contains(cqUnattendedLine(), "w shows only those") {
-		t.Errorf("the unattended line advertises a key that no longer does that: %q", cqUnattendedLine())
-	}
-}
-
 // A filter that matches nothing must show the table saying so. Gating the empty
 // state on the filtered count — as the design does — dropped the human into the
 // dispatch form instead, where that line can never appear.
 func TestFleetEmptyFilterStaysOnTheTable(t *testing.T) {
 	m := cqModel(t)
 	fleet = fleet[:2] // queue rows only
-	m = press(m, "w") // …filtered to running
+	m = m.fleetSetFilter("running")
 	if len(m.fleetRows()) != 0 {
 		t.Fatalf("precondition: %d rows match", len(m.fleetRows()))
 	}
@@ -299,11 +282,10 @@ func TestCQFormFallThrough(t *testing.T) {
 		t.Fatalf("d should open an empty form, auto on: %v %v %v", m.cqDispatch, m.dxTouched(), m.dxAuto)
 	}
 
-	// Untouched: w leaves the form for the running rows, which is what the
-	// form's own footer advertises.
-	m = press(m, "w")
-	if m.cqDispatch || m.fleetFilter() != "running" {
-		t.Fatalf("w should leave an untouched form for the running rows: %v %q", m.cqDispatch, m.fleetFilter())
+	// Untouched: a lens digit still navigates rather than typing itself.
+	m2 := press(m, "3")
+	if m2.lens != "backlog" {
+		t.Fatalf("a digit should leave an untouched form, lens = %q", m2.lens)
 	}
 
 	// Once anything is typed, those same keys are letters again. The form opens
@@ -427,9 +409,14 @@ func TestCQFooterHelpFollowsTheCursor(t *testing.T) {
 	}
 
 	md := press(m, "d")
-	// An untouched form still advertises the exits it still has.
-	if got := md.footerHelp(); !strings.Contains(got, "w running") {
-		t.Errorf("untouched-form help = %q", got)
+	// An untouched form advertises the exits it still has. `w` used to be one
+	// of them; it is gone, so the footer must not name it.
+	formHelp := md.footerHelp()
+	if !strings.Contains(formHelp, "esc cancel") || !strings.Contains(formHelp, "1…6 sections") {
+		t.Errorf("untouched-form help = %q", formHelp)
+	}
+	if strings.Contains(formHelp, "w running") {
+		t.Errorf("footer still advertises the removed w key: %q", formHelp)
 	}
 	// A touched one drops them — they are letters now — and offers ctrl+d,
 	// which is the key that actually submits (ctrl+⏎ is not reportable).

--- a/internal/cockpit/cqrows.go
+++ b/internal/cockpit/cqrows.go
@@ -248,7 +248,9 @@ func cqUnattendedLine() string {
 	}
 	// `w` no longer opens a view of its own — it narrows the table to the
 	// running rows — so the sentence advertises what the key now does.
-	return s + " · w shows only those"
+	// `f` reaches the running filter; `w` used to be a shortcut to it and is
+	// gone, so this no longer names a key that does nothing.
+	return s + " · f filters to them"
 }
 
 // cqViewEmpty is the dispatch form: what you see when nothing is in flight, and

--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -469,7 +469,7 @@ func (m model) dxFooterHelp() string {
 	if m.dxTouched() {
 		return "enter next field · tab moves · ctrl+d dispatch · esc cancel"
 	}
-	return "dispatch · enter next field · tab moves · w running · esc cancel · 1…6 sections"
+	return "dispatch · enter next field · tab moves · esc cancel · 1…6 sections"
 }
 
 // ---- view ---------------------------------------------------------------------
@@ -513,8 +513,7 @@ func (m model) dxView(w, h int) string {
 	}
 
 	tail := []cqRow{
-		cqFixed(flG(fg(cFg, "w") + " " + fg(cDim, "everything in flight") + " " +
-			fg(cFaint, truncate("· "+cqUnattendedLine(), maxi(1, inner-24))))),
+		cqFixed(flG(fg(cFaint, truncate(cqUnattendedLine(), maxi(1, inner))))),
 		cqGap(9),
 	}
 

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -26,7 +26,6 @@ var helpSections = []struct {
 		{"j / k", "move the cursor — the panel and the key hints follow it"},
 		{"g / G", "first row · last row"},
 		{"f", "filter: all → wants you → needs a look → running"},
-		{"w", "running only, and back"},
 		{"⏎", "attach the session"},
 		{"y", "approve the merge, or mark it shipped once it has commits"},
 		{"x", "kill it · the branch and any dirty worktree survive"},


### PR DESCRIPTION
`w` was a shortcut to the running filter, which `f` already cycles to — it is the last of the four `f` walks (`all → wants you → needs a look → running`). It survived from v3, where it opened a working *view* of its own; v4 folded that view into the table and left the key behind as a duplicate.

Removing it also takes `w` out of the dispatch form's fall-through set, which is where it belongs: with the form open, `w` is now a letter like any other. It appears in sentences far more often than it meant a filter, and `esc` was always the way out of the form.

Everything that named it goes too — the form's footer, the in-flight line beneath the form, and the help sheet. The unattended line now says **"f filters to them"**, because that key still exists.

## Verified live

- `w` on the table is inert, and no footer mentions it
- `f` still cycles and still reaches running: **7 → 4 → 4 → 3 rows**

## Tests

Four tests pinned `w`. Rather than delete the coverage, they now cover `f` reaching the same filter, a lens digit still navigating an untouched form, and the footer *not* naming the removed key.

`make build`, `go vet`, `golangci-lint` (0 issues), `go test ./...` and `-shuffle=on` all pass.

## Release

No label — removing a duplicate shortcut, so this cuts a patch. It is technically a keybinding removal, but `f` has always reached the same filter, so nothing becomes unreachable.