### PR TITLE
Never let "done" strand a session that is still running

### DIFF
--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -16,6 +16,9 @@
 // the idle_prompt payload carries no task info, so the Stop's verdict is
 // persisted (WaitingOnTasks) and idle_prompt defers to it.
 //
+// A done record is terminal for every event but the two that prove its session
+// is still going — see reopensDone.
+//
 // Events are attributed to a dispatch by, in order: the CLAUDE_DISPATCHER_ID
 // env var (set at launch, inherited through tmux -> claude -> hook), the
 // session_id, or — for SessionStart only — the newest still-launching
@@ -137,11 +140,31 @@ func resolve(dispatcherID, event string, in hookInput) *state.Dispatch {
 	return nil
 }
 
+// reopensDone names the two events that outrank "done means live".
+//
+// internal/track flips a record to done the moment its PR merges, and a
+// dispatcher told to open and merge its own PR and keep working routinely
+// merges mid-run — so "done" can land on a session that is still going. When
+// that happened, this guard used to swallow everything the session said
+// afterwards, including the permission prompt it was stuck on: the record
+// froze at done, and since the triage table only admits blocked/needs/review/
+// working rows, a live dispatcher waiting on an approval vanished from the
+// cockpit entirely, which then showed the empty-fleet dispatch form.
+//
+// A permission prompt and a human's new prompt are proof the session is not
+// finished, and both mean it wants something — and anything that wants
+// something belongs on the table. Every other event (a Stop, an idle prompt, a
+// session ending) is what a shipped feature looks like and still cannot
+// downgrade done. track re-flips it once the turn ends; see track.midWork.
+func reopensDone(event string) bool {
+	return event == "Notification:permission_prompt" || event == "UserPromptSubmit"
+}
+
 // apply mutates the dispatch for the event; it reports whether anything
 // changed and a save is warranted.
 func apply(d *state.Dispatch, event string, in hookInput) bool {
-	if d.Status == state.StatusDone {
-		return false // done means live; nothing downgrades it
+	if d.Status == state.StatusDone && !reopensDone(event) {
+		return false // done means live; only proof of life downgrades it
 	}
 	switch event {
 	case "SessionStart":

--- a/internal/hookcmd/hookcmd_test.go
+++ b/internal/hookcmd/hookcmd_test.go
@@ -26,6 +26,9 @@ func TestApplyTransitions(t *testing.T) {
 		{state.StatusWorking, "SessionEnd", state.StatusExited, true},
 		{state.StatusDone, "Stop", state.StatusDone, false},
 		{state.StatusDone, "SessionEnd", state.StatusDone, false},
+		{state.StatusDone, "Notification:idle_prompt", state.StatusDone, false},
+		{state.StatusDone, "PostToolUse", state.StatusDone, false},
+		{state.StatusDone, "SessionStart", state.StatusDone, false},
 		{state.StatusWorking, "SomeUnknownEvent", state.StatusWorking, false},
 	}
 	for _, c := range cases {
@@ -35,6 +38,31 @@ func TestApplyTransitions(t *testing.T) {
 			t.Errorf("%s + %s: got (%s, changed=%v), want (%s, changed=%v)",
 				c.from, c.event, d.Status, changed, c.want, c.changed)
 		}
+	}
+}
+
+// track flips a record to done the moment its PR merges, which routinely
+// happens while the session is still running. When the session then asks for a
+// permission approval, or the human sends it another prompt, the record has to
+// come back — otherwise a live dispatcher sits at a prompt nobody can see,
+// because triage only shows blocked/needs/review/working rows.
+func TestApplyReopensDone(t *testing.T) {
+	d := &state.Dispatch{Status: state.StatusDone}
+	if !apply(d, "Notification:permission_prompt", hookInput{}) {
+		t.Fatal("a permission prompt must reopen a done dispatch")
+	}
+	if d.Status != state.StatusBlocked {
+		t.Fatalf("want blocked, got %s", d.Status)
+	}
+	// And once reopened it behaves like any other blocked dispatch: the tool
+	// completing means the approval was given.
+	if !apply(d, "PostToolUse", hookInput{}) || d.Status != state.StatusWorking {
+		t.Fatalf("want working after PostToolUse, got %s", d.Status)
+	}
+
+	d = &state.Dispatch{Status: state.StatusDone}
+	if !apply(d, "UserPromptSubmit", hookInput{}) || d.Status != state.StatusWorking {
+		t.Fatalf("a new prompt must reopen a done dispatch, got %s", d.Status)
 	}
 }
 

--- a/internal/track/track.go
+++ b/internal/track/track.go
@@ -6,6 +6,10 @@
 // state dir, and the cockpit's fsnotify watcher picks them up like any other
 // status change. (Consequence: auto-done only advances while a cockpit is
 // open somewhere.)
+//
+// It never marks a dispatch done out from under a session that is still
+// working or waiting on an approval — a merged PR is not the end of a run.
+// See midWork.
 package track
 
 import (
@@ -34,7 +38,18 @@ func Refresh(ds []*state.Dispatch, cfg *config.Config) int {
 			d.PRMergedAt = pr.MergedAt
 			changed = true
 		}
-		if d.PRState == "MERGED" && d.PRMergedAt != nil && d.DeployedAt == nil {
+		// The done flip waits until the session behind the dispatch has stopped;
+		// see midWork. The PR fields above are refreshed either way, so a row
+		// still on the triage table keeps showing where its PR stands.
+		//
+		// There is deliberately no "DeployedAt == nil" guard here. A record that
+		// shipped and was then reopened — hookcmd.reopensDone, when its session
+		// turned out to still be going — already carries a deploy time, and
+		// skipping it would leave it open forever once its session went quiet
+		// again. Re-asking is cheap (gh memoises the read) and both branches
+		// write the same timestamp they wrote the first time, so it is idempotent
+		// and the reason stays the one the signal actually justifies.
+		if !midWork(d) && d.PRState == "MERGED" && d.PRMergedAt != nil {
 			deployed, at, hasWorkflow := gh.DeploySignal(
 				d.RepoPath, *d.PRMergedAt, cfg.DeployWorkflows[d.RepoName])
 			switch {
@@ -56,4 +71,26 @@ func Refresh(ds []*state.Dispatch, cfg *config.Config) int {
 		}
 	}
 	return updated
+}
+
+// midWork reports whether the session behind a dispatch is still doing
+// something: working, stopped at a permission prompt it needs answered, or not
+// yet started.
+//
+// Such a dispatch is not done however the forge reads. These dispatchers are
+// told to open and merge their own PRs and keep going, so a merged PR mid-run
+// is routine, not the end — and flipping the record to done there used to
+// strand a live session off the triage table for good, because
+// internal/hookcmd would not let anything the session said afterwards
+// downgrade done. Waiting for the turn to end costs one poll; "done means
+// live" still holds, a few seconds later.
+//
+// A needs-input dispatch is deliberately not mid-work: the turn is over and
+// the feature shipped, which is exactly the case "done means live" is about.
+func midWork(d *state.Dispatch) bool {
+	switch d.Status {
+	case state.StatusWorking, state.StatusBlocked, state.StatusLaunching:
+		return true
+	}
+	return false
 }

--- a/internal/track/track_test.go
+++ b/internal/track/track_test.go
@@ -1,0 +1,31 @@
+package track
+
+import (
+	"testing"
+
+	"claude-dispatcher/internal/state"
+)
+
+// The regression this guards: a dispatcher that merges its own PR mid-run was
+// flipped to done while its session was still going, and hookcmd would not let
+// anything the session said afterwards downgrade that — so a live session
+// stuck at a permission prompt disappeared from the cockpit, which then showed
+// the empty-fleet dispatch form.
+func TestMidWork(t *testing.T) {
+	cases := []struct {
+		status state.Status
+		want   bool
+	}{
+		{state.StatusWorking, true},
+		{state.StatusBlocked, true},
+		{state.StatusLaunching, true},
+		{state.StatusNeedsInput, false}, // turn over — "done means live" applies
+		{state.StatusExited, false},
+		{state.StatusDone, false},
+	}
+	for _, c := range cases {
+		if got := midWork(&state.Dispatch{Status: c.status}); got != c.want {
+			t.Errorf("midWork(%s) = %v, want %v", c.status, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## What happened

A dispatcher was sitting at a permission prompt in tmux while the cockpit showed `queue clear · 1 thing handled` and the new-dispatch form. Eight live `claude` sessions were invisible.

Reconstructed from `events.jsonl` (all BST):

| time | what |
|---|---|
| 19:19:20 | `UserPromptSubmit` → status `working` |
| 19:19:52 | the dispatcher merged its own PR |
| 19:20:23 | cockpit poll runs `track.Refresh` → status `done` |
| 19:21:16 | `Notification:permission_prompt` → **dropped** |

`track.Refresh` decided purely from PR/deploy state, with no check that the session was still going — and these prompts explicitly tell each dispatcher to "open the PR and fix your own CI failures without stopping to ask", so merging mid-run is the normal case. `hookcmd.apply` then refused to let a done record be downgraded by anything, including the one event that proves the record is lying. Since the triage table only admits blocked/needs/review/working rows, the record had no way back on screen: `fleetAll()` came back empty, and `fleet_view.go` swaps the table for the dispatch form when it does.

## The fix

Both halves, either of which alone would have contained it:

- **`track.midWork`** — the done flip waits until the session has stopped. A merged PR is not the end of a run. PR fields still refresh every poll, so a row on the table keeps showing where its PR stands; `needs-input` is deliberately *not* mid-work, so "done means live" still applies the moment the turn ends.
- **`hookcmd.reopensDone`** — a permission prompt or a human's new prompt reopens a done record. Both prove the session is not finished and both mean it wants something, and anything that wants something belongs on the triage table. A Stop, an idle prompt, or a session ending are all compatible with a shipped feature and still cannot downgrade done.

The `DeployedAt == nil` guard in `track` goes with it, so a record that shipped, got reopened, and then went quiet again can settle back to done instead of staying open forever. Re-asking is memoised and both branches rewrite the same timestamp, so it is idempotent.

## Note

The global hook runs `/opt/homebrew/bin/claude-dispatcher`, so this only takes effect on a machine once a release ships and the cask upgrades.