### PR TITLE
Upgrade in place, with a key, from whatever installed you

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,12 @@
   and 170 columns (more panes on wide screens, never one ballooned view).
 - `internal/ship` — shipping stats (Claude-stamped = Co-Authored-By trailer).
 - `internal/version` — the build's version (stamped by goreleaser via
-  `-X claude-dispatcher/internal/version.Version`) and the cached, best-effort
-  check for a newer release that drives the cockpit's upgrade hint.
+  `-X claude-dispatcher/internal/version.Version`), the cached, best-effort
+  check for a newer release, and `Detect()`: which package manager installed
+  this binary, read from its own resolved path, and the one command that
+  upgrades it. `U` in the cockpit runs that command and re-execs. A
+  declaratively-installed Nix build is never upgraded imperatively — only an
+  entry in the imperative profile's `manifest.json` proves it may be.
 
 ## Build
 `make build` / `make vet` / `make install` (binary to ~/.local/bin — the init

--- a/README.md
+++ b/README.md
@@ -123,6 +123,43 @@ your own copies still win — which leaves `claude` and `gh` yours to provide.
 `/run/current-system/sw/bin/…`), not the `/nix/store` path behind it, so the
 hook survives upgrades and you do not have to re-run it after every rebuild.
 
+## Upgrading
+
+When a newer release exists, the cockpit says so in the bottom-right corner.
+Press **`U`**: it names the exact command, asks, hands the terminal to your
+package manager so you can watch it work, then restarts itself in place —
+same terminal, same tmux pane. Your dispatchers are tmux sessions and are not
+touched by any of this.
+
+Which command it runs is read from the running binary's own path, not guessed
+from your OS:
+
+| installed via | `U` runs |
+|---|---|
+| Homebrew cask (the tap) | `brew upgrade --cask claude-dispatcher` |
+| Homebrew formula | `brew upgrade claude-dispatcher` |
+| `nix profile install` | `nix profile upgrade claude-dispatcher` |
+| scoop | `scoop update claude-dispatcher` |
+| winget | `winget upgrade --id Innovology.claude-dispatcher` |
+
+A **declarative** Nix install — home-manager, a NixOS module, a flake input —
+is deliberately left alone: the version lives in a file you own, and an
+imperative upgrade would either fail or install a second copy shadowing the
+declared one. The footer shows the version gap and says `nix-managed` instead
+of offering the key. Same for a binary we cannot place (`make install`, or a
+copy you moved yourself) — it points at the releases page.
+
+`claude-dispatcher version` prints both lines, which is the quickest way to
+see why `U` is or is not on offer:
+
+```
+claude-dispatcher v3.1.2
+homebrew cask · brew upgrade --cask claude-dispatcher
+```
+
+On Windows there is no exec-in-place, so `U` installs and tells you to start
+the cockpit again rather than pretending to restart.
+
 `nix develop` gives the full toolchain — Go, `golangci-lint`, `goreleaser`,
 `tmux` — for working on the dispatcher itself; `nix flake check` runs the test
 suite and the `gofmt` gate.
@@ -197,11 +234,12 @@ Anything unmapped is grouped under `unassigned`, which is what a fresh install s
 | `1`–`6` | switch lens (triage · products · backlog · usage · decisions · velocity) |
 | `+` | dispatch new work — repo → feature → prompt |
 | `j` / `k` · `g` / `G` | move · first row · last row |
-| `f` · `w` | cycle the triage filter · running only, and back |
+| `f` | cycle the triage filter (all · wants you · needs a look · running) |
 | `enter` | attach the selected dispatcher's tmux session · open what is selected |
 | `y` · `x` · `s` | ship (squash-merge) · kill · skip to the back |
 | `d` · `u` | dispatch · put back the last thing you cleared |
 | `,` · `:` · `?` | settings · command palette · all keys |
+| `U` | upgrade to the published build and come straight back |
 | `q` | quit |
 
 

--- a/internal/cockpit/keys.go
+++ b/internal/cockpit/keys.go
@@ -122,6 +122,10 @@ func (m model) runCommand() (model, tea.Cmd) {
 		m.dispatchForm = newDispatchForm(m.cfg)
 		return m, m.dispatchForm.filter.Focus()
 	}
+	if c.name == "upgrade" {
+		m.paletteOpen, m.paletteText = false, ""
+		return m.startUpgrade()
+	}
 	direct := map[string]string{
 		"backlog": "backlog", "usage": "usage",
 		"decisions": "decisions", "plugins": "decisions", "velocity": "velocity",
@@ -260,6 +264,12 @@ func (m model) handleKey(k string) (tea.Model, tea.Cmd) {
 	if k == "+" {
 		m.dispatchForm = newDispatchForm(m.cfg)
 		return m, m.dispatchForm.filter.Focus()
+	}
+	// Shift-U, not `u`: `u` is undo, and the two must never be one slip apart in
+	// the same hand. Bound globally rather than per-lens because the version it
+	// acts on is in the footer, which every lens carries.
+	if k == "U" {
+		return m.startUpgrade()
 	}
 	if k == "q" {
 		return m, tea.Quit

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -26,7 +26,7 @@ type shipFxState struct {
 // stored a closure, but a value-receiver model cannot, so we switch on kind.
 type confirmState struct {
 	label         string
-	kind          string // "kill" | "ship"
+	kind          string // "kill" | "ship" | "upgrade"
 	feature, repo string
 	features      []string // kill targets (marked set, or the one selected)
 }
@@ -101,6 +101,16 @@ type model struct {
 	undo    string
 	undoSeq int
 
+	// install is how this build got onto the machine, and so what would upgrade
+	// it — see version.Detect.
+	install version.Install
+
+	// relaunch says the cockpit is quitting only to come back as the build it
+	// just installed. Run reads it after the program returns — the terminal has
+	// to be handed back before we exec, or the new process inherits an alt
+	// screen and raw mode it did not set up. See relaunch().
+	relaunch bool
+
 	// ---- triage lens: the command queue -------------------------------------
 	// The queue itself is derived from the records on every read (cq.go), so the
 	// model holds only what the user did to it: the order they left it in, what
@@ -148,6 +158,11 @@ func newModel() model {
 		clMarked:     map[string]bool{},
 		clMap:        map[string]string{},
 		cqSuppressed: map[string]bool{},
+		// How this build was installed cannot change while it runs, so it is
+		// read once here rather than from the footer, which redraws on every
+		// frame. Holding it on the model is also what lets a test drive the
+		// brew/nix/unknown cases without being installed that way.
+		install: version.Detect(),
 		// The default dispatch is unattended. Without this the form opens on
 		// "asks after every step", which is not the product's default posture.
 		dxAuto: true,
@@ -230,6 +245,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case upgradeRanMsg:
+		if msg.err != nil {
+			m.notice = upgradeFailed(m.install, msg.err)
+			return m, nil
+		}
+		// The binary on disk is now the new one, but this process is still the
+		// old one — a running program cannot become a different program. Quit
+		// and let Run exec what was just installed, which keeps the human in the
+		// same terminal rather than making them start the cockpit again.
+		m.relaunch = true
+		return m, tea.Quit
+
 	case trackedMsg:
 		return m, loadSnapshotCmd(m.cfg)
 
@@ -306,6 +333,10 @@ func (m model) doConfirm() (model, tea.Cmd) {
 		mm, tick := m.startShip(x)
 		mm2, undo := mm.offerUndo("ship " + c.feature)
 		return mm2, tea.Batch(tick, shipCmd(c.feature), undo)
+	case "upgrade":
+		// No undo is offered: the package manager owns what happens next, and
+		// an offer to undo something we cannot undo would be a lie.
+		return m, upgradeRunCmd(m.install)
 	}
 	return m, nil
 }

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -59,6 +59,7 @@ var helpSections = []struct {
 	{section: "anywhere", keys: []struct{ k, d string }{
 		{",", "settings"},
 		{"+", "new dispatch, repo first"},
+		{"U", "upgrade to the published build, in place"},
 		{"ctrl+l", "redraw a garbled screen"},
 		{"q", "quit"},
 	}},

--- a/internal/cockpit/relaunch_unix.go
+++ b/internal/cockpit/relaunch_unix.go
@@ -1,0 +1,40 @@
+//go:build !windows
+
+package cockpit
+
+// relaunch_unix.go turns "upgraded" into "running the upgrade" without the
+// human doing anything.
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// relaunch replaces this process with the build that was just installed.
+//
+// syscall.Exec, not a child process: the cockpit is usually the foreground job
+// of a terminal the human is sitting in, and often a tmux pane. Spawning a
+// child would leave the old binary alive as its parent, holding the pane's
+// process group, and the human would be looking at a program inside a program.
+// Exec keeps the pid, the terminal and the place in the window; the only thing
+// that changes is the code.
+//
+// It must run after Bubble Tea has returned — the alt screen has to be left and
+// raw mode restored before the new process starts, or it inherits a terminal
+// it never configured and cannot reason about.
+//
+// The path is looked up on PATH first, deliberately. A cask upgrade repoints
+// /opt/homebrew/bin/claude-dispatcher at a new Caskroom directory and may
+// remove the old one, so os.Executable's already-resolved path can name a
+// binary that no longer exists. PATH resolves to whatever was just installed.
+func relaunch() error {
+	exe, err := exec.LookPath(binaryName)
+	if err != nil {
+		if exe, err = os.Executable(); err != nil {
+			return err
+		}
+	}
+	// Returns only on failure.
+	return syscall.Exec(exe, append([]string{exe}, os.Args[1:]...), os.Environ())
+}

--- a/internal/cockpit/relaunch_windows.go
+++ b/internal/cockpit/relaunch_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package cockpit
+
+import "fmt"
+
+// relaunch says what happened and stops.
+//
+// Windows has no exec-in-place: CreateProcess always makes a new process, so
+// the closest equivalent is spawning a child and exiting under it, which hands
+// the console to two programs at once and leaves the shell's job tracking
+// pointing at a process that has gone. Telling the human one true sentence is
+// better than that. Scoop and winget have both already replaced the binary by
+// the time this runs, so the next start is the new build.
+func relaunch() error {
+	fmt.Println("upgraded — start claude-dispatcher again to run the new build")
+	return nil
+}

--- a/internal/cockpit/run.go
+++ b/internal/cockpit/run.go
@@ -10,6 +10,10 @@ import (
 	"claude-dispatcher/internal/state"
 )
 
+// binaryName is this command as it is installed on PATH — what relaunch execs
+// after an in-place upgrade.
+const binaryName = "claude-dispatcher"
+
 // applyConfigEnv exports integration settings from config into the environment
 // so the env-gated Linear/Azure clients pick them up. A real env var already
 // set wins, so a secret can stay out of config.toml if preferred.
@@ -50,8 +54,16 @@ func Run() error {
 		m.notice = "no config — showing demo data · run `claude-dispatcher init`"
 	}
 
-	_, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
-	return err
+	final, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		return err
+	}
+	// The one exit that is not an exit: `U` installed a new build, and this
+	// process quit so the terminal would be handed back before we exec it.
+	if fm, ok := final.(model); ok && fm.relaunch {
+		return relaunch()
+	}
+	return nil
 }
 
 // forwardEvents coalesces fsnotify chatter into at most one pending signal.

--- a/internal/cockpit/types.go
+++ b/internal/cockpit/types.go
@@ -151,6 +151,7 @@ var commands = []command{
 	{name: "dispatch", hint: "repo → feature → prompt, or paste a batch"},
 	{name: "new dispatch", hint: "open the repo → feature → prompt form"},
 	{name: "product", hint: "open the product under the cursor"},
+	{name: "upgrade", hint: "install the published build and come straight back"},
 	{name: "reply", hint: "answer the selected dispatcher without attaching"},
 	{name: "attach", hint: "tmux attach at full fidelity · ctrl+\\ to come back"},
 	{name: "merge", hint: "gh pr merge --squash --auto on the selected feature"},

--- a/internal/cockpit/upgrade.go
+++ b/internal/cockpit/upgrade.go
@@ -4,6 +4,9 @@ package cockpit
 // and whether it is behind the published one.
 
 import (
+	"os/exec"
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/version"
@@ -23,16 +26,73 @@ func upgradeCheckCmd() tea.Cmd {
 	return func() tea.Msg { return upgradeMsg{latest: version.Latest()} }
 }
 
+// upgradeRanMsg reports how the package manager got on, once the terminal
+// comes back.
+type upgradeRanMsg struct{ err error }
+
 // versionForms is the bottom-right version, widest rendering first. The footer
 // takes the first one that fits, so a cramped terminal keeps the version number
-// and drops the upgrade command rather than losing both.
+// and drops the upgrade offer rather than losing both.
+//
+// The offer names the key, not the command: the key is the shorter string and
+// the one that does the work. An install we cannot upgrade in place still gets
+// its clause — the version gap is worth knowing even when we have nothing to
+// press — but it says why instead ("nix-managed · upgrade it where it is
+// declared").
 func (m model) versionForms() []string {
 	if m.upgradeTo == "" {
 		return []string{fg(cFaint, version.Display())}
 	}
 	behind := fg(cAmber, version.Display()+" → "+version.Label(m.upgradeTo))
+	tail := m.install.Note
+	if m.install.CanUpgrade() {
+		tail = "U upgrades"
+	}
 	return []string{
-		behind + fg(cDim, " · "+version.UpgradeHint()),
+		behind + fg(cDim, " · "+tail),
 		behind,
 	}
+}
+
+// startUpgrade is the U key: it asks before running anything. The confirm bar
+// spells out the exact command, because this is the one act in the cockpit
+// that reaches outside the state dir and changes the machine.
+func (m model) startUpgrade() (model, tea.Cmd) {
+	if !version.IsRelease() {
+		m.notice = "dev build — nothing to upgrade to"
+		return m, nil
+	}
+	if m.upgradeTo == "" {
+		m.notice = version.Display() + " is the latest"
+		return m, nil
+	}
+	if !m.install.CanUpgrade() {
+		m.notice = m.install.Note
+		return m, nil
+	}
+	m.confirm = &confirmState{
+		kind:  "upgrade",
+		label: m.install.Hint() + "  →  " + version.Label(m.upgradeTo),
+	}
+	return m, nil
+}
+
+// upgradeRunCmd hands the terminal to the package manager, the same way `enter`
+// hands it to tmux. Its output is the human's — a cask download has its own
+// progress to show, and hiding it behind a spinner would mean inventing a
+// summary of a process we do not control.
+func upgradeRunCmd(in version.Install) tea.Cmd {
+	if !in.CanUpgrade() {
+		return nil
+	}
+	c := exec.Command(in.Cmd[0], in.Cmd[1:]...)
+	c.Env = in.Env()
+	return tea.ExecProcess(c, func(err error) tea.Msg { return upgradeRanMsg{err: err} })
+}
+
+// upgradeFailed is the notice for a package manager that exited non-zero. Its
+// own output is already on screen above the cockpit's redraw, so this says
+// which command failed rather than repeating a reason it did not give us.
+func upgradeFailed(in version.Install, err error) string {
+	return "upgrade failed (" + strings.Join(in.Cmd, " ") + "): " + err.Error()
 }

--- a/internal/cockpit/upgrade_test.go
+++ b/internal/cockpit/upgrade_test.go
@@ -1,6 +1,7 @@
 package cockpit
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -8,6 +9,9 @@ import (
 
 	"claude-dispatcher/internal/version"
 )
+
+// errUpgrade stands in for whatever the package manager exited with.
+var errUpgrade = errors.New("exit status 1")
 
 // stampVersion runs the model as a released build for the duration of a test.
 func stampVersion(t *testing.T, v string) {
@@ -55,20 +59,164 @@ func TestFooterCarriesTheVersion(t *testing.T) {
 	}
 }
 
-// TestFooterNagsWhenTheBuildIsBehind checks the upgrade command appears beside
-// the version once a newer release is known.
+// brewInstall and nixManaged are the two shapes the footer has to tell apart:
+// one we can upgrade in place, one we must not touch.
+var (
+	brewInstall = version.Install{
+		Method: version.MethodBrewCask,
+		Cmd:    []string{"brew", "upgrade", "--cask", "claude-dispatcher"},
+	}
+	nixManaged = version.Install{
+		Method: version.MethodNixManaged,
+		Note:   "nix-managed · upgrade it where it is declared",
+	}
+)
+
+// TestFooterNagsWhenTheBuildIsBehind checks the offer appears beside the
+// version once a newer release is known — the key when we can act on it, and
+// the reason when we cannot.
 func TestFooterNagsWhenTheBuildIsBehind(t *testing.T) {
 	stampVersion(t, "2.1.1")
 	m := newModel()
 	m.width, m.height = 190, 44
 	m.upgradeTo = "v2.2.0"
+	m.install = brewInstall
 
 	footer := footerOf(m)
 	if !strings.Contains(footer, "v2.1.1 → v2.2.0") {
 		t.Errorf("footer does not show the upgrade: %q", footer)
 	}
-	if !strings.Contains(footer, version.UpgradeHint()) {
-		t.Errorf("footer does not show %q: %q", version.UpgradeHint(), footer)
+	// The key, not the command: it is shorter and it is what does the work.
+	if !strings.Contains(footer, "U upgrades") {
+		t.Errorf("footer does not offer the key: %q", footer)
+	}
+
+	// An install we will not upgrade in place says why, and never offers a key
+	// that would do nothing.
+	m.install = nixManaged
+	footer = footerOf(m)
+	if !strings.Contains(footer, "v2.1.1 → v2.2.0") {
+		t.Errorf("nix footer lost the version gap: %q", footer)
+	}
+	if !strings.Contains(footer, "nix-managed") {
+		t.Errorf("nix footer does not explain itself: %q", footer)
+	}
+	if strings.Contains(footer, "U upgrades") {
+		t.Errorf("nix footer offered a key it cannot honour: %q", footer)
+	}
+}
+
+// TestUpgradeKeyAsksFirst: U opens the confirm bar spelling out the exact
+// command, because it is the one act in the cockpit that changes the machine
+// rather than the state dir.
+func TestUpgradeKeyAsksFirst(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height = 190, 44
+	m.upgradeTo = "v2.2.0"
+	m.install = brewInstall
+	m = press(m, "4") // any lens where the dispatch prompt is not holding the keyboard
+
+	m = press(m, "U")
+	if m.confirm == nil || m.confirm.kind != "upgrade" {
+		t.Fatalf("U did not ask: %+v", m.confirm)
+	}
+	if !strings.Contains(m.confirm.label, "brew upgrade --cask claude-dispatcher") {
+		t.Errorf("confirm does not name the command: %q", m.confirm.label)
+	}
+	if !strings.Contains(m.confirm.label, "v2.2.0") {
+		t.Errorf("confirm does not name the target: %q", m.confirm.label)
+	}
+	if bar := ansi.Strip(m.barsView()); !strings.Contains(bar, "brew upgrade") {
+		t.Errorf("confirm bar does not show the command: %q", bar)
+	}
+
+	// n cancels and nothing is run.
+	m = press(m, "n")
+	if m.confirm != nil || m.relaunch {
+		t.Error("cancelling must leave nothing pending")
+	}
+}
+
+// TestUpgradeKeyRefusesWhatItCannotDo covers the three ways U is a no-op, each
+// of which has to say something rather than nothing.
+func TestUpgradeKeyRefusesWhatItCannotDo(t *testing.T) {
+	// Nix-managed: a real upgrade exists, but not one we may run.
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height = 190, 44
+	m.upgradeTo, m.install = "v2.2.0", nixManaged
+	m = press(m, "4")
+	m = press(m, "U")
+	if m.confirm != nil {
+		t.Error("a nix-managed install must not be offered an imperative upgrade")
+	}
+	if !strings.Contains(m.notice, "nix-managed") {
+		t.Errorf("notice does not explain the refusal: %q", m.notice)
+	}
+
+	// Already current.
+	m = newModel()
+	m.width, m.height, m.install = 190, 44, brewInstall
+	m = press(press(m, "4"), "U")
+	if m.confirm != nil || !strings.Contains(m.notice, "latest") {
+		t.Errorf("up-to-date build: confirm=%v notice=%q", m.confirm, m.notice)
+	}
+
+	// A dev build has no release to be behind.
+	stampVersion(t, "dev")
+	m = newModel()
+	m.width, m.height, m.install = 190, 44, brewInstall
+	m.upgradeTo = "v2.2.0"
+	m = press(press(m, "4"), "U")
+	if m.confirm != nil || !strings.Contains(m.notice, "dev build") {
+		t.Errorf("dev build: confirm=%v notice=%q", m.confirm, m.notice)
+	}
+}
+
+// TestUpgradeKeyIsTextAtThePrompt: while the dispatch prompt has the keyboard —
+// which it does whenever nothing is in flight — every letter is what the human
+// is typing, U included. The same rule already governs `?`, `u` and `q` there,
+// and a key that quietly upgraded the machine mid-sentence would be the worst
+// of the set to make an exception for.
+func TestUpgradeKeyIsTextAtThePrompt(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height = 190, 44
+	m.upgradeTo, m.install = "v2.2.0", brewInstall
+	if !m.cqPromptOn() {
+		t.Fatal("expected the empty fleet to leave the prompt holding the keyboard")
+	}
+
+	m = press(m, "U")
+	if m.confirm != nil {
+		t.Error("U interrupted the human mid-prompt")
+	}
+}
+
+// TestUpgradeRelaunches: a clean upgrade quits, but only so Run can exec the
+// build that was just installed. A failed one stays put and says so.
+func TestUpgradeRelaunches(t *testing.T) {
+	m := newModel()
+	m.width, m.height, m.install = 190, 44, brewInstall
+
+	next, cmd := m.Update(upgradeRanMsg{})
+	nm := next.(model)
+	if !nm.relaunch {
+		t.Error("a clean upgrade must ask Run to relaunch")
+	}
+	if cmd == nil {
+		t.Error("a clean upgrade must quit so the terminal is handed back first")
+	}
+
+	next, _ = m.Update(upgradeRanMsg{err: errUpgrade})
+	nm = next.(model)
+	if nm.relaunch {
+		t.Error("a failed upgrade must not relaunch into the old build")
+	}
+	if !strings.Contains(nm.notice, "upgrade failed") ||
+		!strings.Contains(nm.notice, "brew upgrade --cask claude-dispatcher") {
+		t.Errorf("failure notice does not say what failed: %q", nm.notice)
 	}
 }
 

--- a/internal/version/install.go
+++ b/internal/version/install.go
@@ -1,0 +1,256 @@
+package version
+
+// install.go answers "how did this binary get here, and what would replace
+// it?" so the cockpit can offer to upgrade in place instead of printing a
+// command and asking the human to quit, run it, and come back.
+//
+// The answer is read off the running binary's own path, resolved through its
+// symlinks — that is the only evidence on the machine that cannot disagree
+// with itself. A guess by GOOS (what UpgradeHint used to do) tells a Nix user
+// to run brew.
+//
+// Nothing here shells out. Detection must be cheap and must never hang: it
+// runs behind the footer, which redraws on every frame.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// binName is the installed command, and — for every package manager below —
+// also the package name. wingetID is the one identifier that differs.
+const (
+	binName  = "claude-dispatcher"
+	wingetID = "Innovology.claude-dispatcher"
+	relPage  = "github.com/Innovology/claude-dispatcher/releases"
+)
+
+// Method names how this build got onto the machine. The empty method is an
+// install we could not place — a copied binary, a `go build` output, a package
+// manager we do not know.
+type Method string
+
+const (
+	MethodUnknown     Method = ""
+	MethodBrewCask    Method = "homebrew cask"
+	MethodBrewFormula Method = "homebrew formula"
+	MethodNixProfile  Method = "nix profile"
+	MethodNixManaged  Method = "nix"
+	MethodScoop       Method = "scoop"
+	MethodWinget      Method = "winget"
+)
+
+// Install is what we know about the running build: where it is, how it was
+// installed, and the one command that would replace it with the published
+// release. Cmd is nil when we will not run anything — either because we cannot
+// place the install, or because placing it told us an imperative upgrade would
+// be wrong (see MethodNixManaged). Note says why, in the words the footer uses.
+type Install struct {
+	Method Method
+	Path   string
+	Cmd    []string
+	Note   string
+}
+
+// CanUpgrade reports whether we know a command that upgrades this build, and
+// so whether the cockpit offers the key at all.
+func (i Install) CanUpgrade() bool { return len(i.Cmd) > 0 }
+
+// Hint is the tail of the footer's version clause: the command we would run,
+// or why there is none.
+func (i Install) Hint() string {
+	if !i.CanUpgrade() {
+		return i.Note
+	}
+	return strings.Join(i.Cmd, " ")
+}
+
+// Env is the environment the upgrade command should run in.
+//
+// Homebrew only refreshes its taps if HOMEBREW_AUTO_UPDATE_SECS have passed
+// since the last fetch (a day, by default), and skips the refresh entirely
+// when HOMEBREW_NO_AUTO_UPDATE is set. Either one turns "upgrade me now" into
+// "already installed" on a machine that has not fetched since the release went
+// out — which is every machine, seconds after a release. Forcing the refresh
+// for this one child process is what makes the key mean what it says; it is
+// also why there is no separate `brew update` step, which would fetch every
+// tap the human has rather than the one we need.
+func (i Install) Env() []string {
+	env := os.Environ()
+	if i.Method != MethodBrewCask && i.Method != MethodBrewFormula {
+		return env
+	}
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HOMEBREW_NO_AUTO_UPDATE=") ||
+			strings.HasPrefix(kv, "HOMEBREW_AUTO_UPDATE_SECS=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "HOMEBREW_AUTO_UPDATE_SECS=0")
+}
+
+// Detect places the running build. The result cannot change while the process
+// lives — the binary behind an upgrade is a new process — so it is computed
+// once and reused; the footer asks for it on every frame.
+func Detect() Install { detectOnce.Do(func() { detected = detect() }); return detected }
+
+var (
+	detectOnce sync.Once
+	detected   Install
+)
+
+func detect() Install {
+	exe, err := os.Executable()
+	if err != nil {
+		return Install{Note: "cannot locate the running binary — see " + relPage}
+	}
+	// The invoking path is usually a symlink into the package manager's store
+	// (/opt/homebrew/bin/x → …/Caskroom/x/3.1.1/x). The store path is the one
+	// that names the manager, so resolve before classifying.
+	resolved := exe
+	if r, err := filepath.EvalSymlinks(exe); err == nil {
+		resolved = r
+	}
+	return classify(resolved, nixProfileSelector)
+}
+
+// classify is the whole decision, taking its one filesystem question as an
+// argument so the table test can drive every branch without a real install.
+func classify(path string, nixSelector func(string) (string, bool)) Install {
+	// Backslashes are folded unconditionally rather than through
+	// filepath.ToSlash, which only knows the separator of the host it is
+	// compiled for: on a unix build it leaves a Windows path untouched, so the
+	// scoop and winget branches below would only ever match on Windows and
+	// could not be tested anywhere else. A path is classified by what it says,
+	// not by who is reading it.
+	p := strings.ReplaceAll(path, `\`, "/")
+	lower := strings.ToLower(p)
+	switch {
+	// Homebrew. The tap ships a cask (see .goreleaser.yml homebrew_casks), so
+	// Caskroom is the expected case; Cellar is handled because a formula is
+	// what a hand-written tap or an older install would have left.
+	case strings.Contains(p, "/Caskroom/"):
+		return Install{Method: MethodBrewCask, Path: path,
+			Cmd: []string{"brew", "upgrade", "--cask", binName}}
+	case strings.Contains(p, "/Cellar/"):
+		return Install{Method: MethodBrewFormula, Path: path,
+			Cmd: []string{"brew", "upgrade", binName}}
+
+	// Nix. A store path alone does not say whether the install is imperative
+	// (`nix profile install`, upgradable in place) or declarative
+	// (home-manager, a NixOS module, a flake input — where the version is
+	// pinned in a file and an imperative upgrade would either fail or install
+	// a second copy that shadows the declared one). Only the profile manifest
+	// settles it; without that proof we say so and offer nothing.
+	//
+	// Matched anywhere in the path, not just at the front: a chroot or
+	// single-user Nix keeps its store under the user's home. Over-matching is
+	// harmless here because it cannot produce a command — only the manifest
+	// below can do that — so the worst case is telling someone their install is
+	// Nix-managed, which is what a path holding a Nix store says it is.
+	case strings.Contains(p, "/nix/store/"):
+		if sel, ok := nixSelector(path); ok {
+			return Install{Method: MethodNixProfile, Path: path,
+				Cmd: []string{"nix", "profile", "upgrade", sel}}
+		}
+		return Install{Method: MethodNixManaged, Path: path,
+			Note: "nix-managed · upgrade it where it is declared"}
+
+	case strings.Contains(lower, "/scoop/"):
+		return Install{Method: MethodScoop, Path: path,
+			Cmd: []string{"scoop", "update", binName}}
+	case strings.Contains(lower, "/winget/"):
+		return Install{Method: MethodWinget, Path: path,
+			Cmd: []string{"winget", "upgrade", "--id", wingetID}}
+	}
+	return Install{Path: path, Note: "see " + relPage}
+}
+
+// nixProfileSelector reports whether the running store path is registered in
+// the user's imperative `nix profile`, and returns the selector that names it
+// there.
+//
+// The manifest is the proof. `nix profile` writes manifest.json; nix-env and
+// home-manager write a manifest.nix instead, so a store path with no entry in
+// a manifest.json is one we must not try to upgrade. Reading it also answers
+// the question we would otherwise have to guess at — what the element is
+// called — which is what `nix profile upgrade` takes as its argument.
+func nixProfileSelector(resolved string) (string, bool) {
+	for _, dir := range nixProfileDirs() {
+		raw, err := os.ReadFile(filepath.Join(dir, "manifest.json"))
+		if err != nil {
+			continue
+		}
+		if sel, ok := manifestSelector(raw, resolved); ok {
+			return sel, true
+		}
+	}
+	return "", false
+}
+
+func nixProfileDirs() []string {
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		dirs = append(dirs, filepath.Join(home, ".nix-profile"))
+		dirs = append(dirs, filepath.Join(home, ".local", "state", "nix", "profiles", "profile"))
+	}
+	if st := os.Getenv("XDG_STATE_HOME"); st != "" {
+		dirs = append(dirs, filepath.Join(st, "nix", "profiles", "profile"))
+	}
+	return dirs
+}
+
+// manifestSelector finds the element whose store paths contain the running
+// binary and returns how to name it to `nix profile upgrade`.
+//
+// The manifest has had two shapes: version 1 and 2 hold an array, where an
+// element is named by its index, and version 3 an object keyed by name. Both
+// are read, because which one is on disk depends on the human's Nix, not ours.
+func manifestSelector(raw []byte, resolved string) (string, bool) {
+	type element struct {
+		StorePaths []string `json:"storePaths"`
+	}
+	holds := func(e element) bool {
+		for _, sp := range e.StorePaths {
+			if resolved == sp || strings.HasPrefix(resolved, strings.TrimSuffix(sp, "/")+"/") {
+				return true
+			}
+		}
+		return false
+	}
+
+	var byName struct {
+		Elements map[string]element `json:"elements"`
+	}
+	if json.Unmarshal(raw, &byName) == nil && byName.Elements != nil {
+		for name, e := range byName.Elements {
+			if holds(e) {
+				return name, true
+			}
+		}
+		return "", false
+	}
+
+	var byIndex struct {
+		Elements []element `json:"elements"`
+	}
+	if json.Unmarshal(raw, &byIndex) == nil {
+		for i, e := range byIndex.Elements {
+			if holds(e) {
+				return strconv.Itoa(i), true
+			}
+		}
+	}
+	return "", false
+}
+
+// UpgradeHint is the command that upgrades this build in place, or why there
+// is none. It used to answer from GOOS alone, which told every non-Homebrew
+// unix install to run brew; it now answers from the binary's own path.
+func UpgradeHint() string { return Detect().Hint() }

--- a/internal/version/install_test.go
+++ b/internal/version/install_test.go
@@ -1,0 +1,228 @@
+package version
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// noNixProfile is the selector for a store path that is in no imperative
+// profile — the declarative case.
+func noNixProfile(string) (string, bool) { return "", false }
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		name   string
+		path   string
+		want   Method
+		cmd    string
+		canUpg bool
+	}{
+		{
+			name: "homebrew cask", // what the tap actually ships
+			path: "/opt/homebrew/Caskroom/claude-dispatcher/3.1.2/claude-dispatcher",
+			want: MethodBrewCask, cmd: "brew upgrade --cask claude-dispatcher", canUpg: true,
+		},
+		{
+			name: "intel mac cask",
+			path: "/usr/local/Caskroom/claude-dispatcher/3.1.2/claude-dispatcher",
+			want: MethodBrewCask, cmd: "brew upgrade --cask claude-dispatcher", canUpg: true,
+		},
+		{
+			name: "homebrew formula",
+			path: "/opt/homebrew/Cellar/claude-dispatcher/3.1.2/bin/claude-dispatcher",
+			want: MethodBrewFormula, cmd: "brew upgrade claude-dispatcher", canUpg: true,
+		},
+		{
+			name: "linuxbrew formula",
+			path: "/home/linuxbrew/.linuxbrew/Cellar/claude-dispatcher/3.1.2/bin/claude-dispatcher",
+			want: MethodBrewFormula, cmd: "brew upgrade claude-dispatcher", canUpg: true,
+		},
+		{
+			name: "nix, not in any imperative profile",
+			path: "/nix/store/abc123-claude-dispatcher-3.1.2/bin/claude-dispatcher",
+			want: MethodNixManaged, canUpg: false,
+		},
+		{
+			name: "nix store somewhere other than /nix (chroot or single-user)",
+			path: "/home/alex/.local/share/nix/root/nix/store/abc-claude-dispatcher-3.1.2/bin/claude-dispatcher",
+			want: MethodNixManaged, canUpg: false,
+		},
+		{
+			name: "scoop",
+			path: `C:\Users\alex\scoop\apps\claude-dispatcher\current\claude-dispatcher.exe`,
+			want: MethodScoop, cmd: "scoop update claude-dispatcher", canUpg: true,
+		},
+		{
+			name: "winget",
+			path: `C:\Users\alex\AppData\Local\Microsoft\WinGet\Packages\Innovology.claude-dispatcher_x\claude-dispatcher.exe`,
+			want: MethodWinget, cmd: "winget upgrade --id Innovology.claude-dispatcher", canUpg: true,
+		},
+		{
+			name: "a binary someone built and copied",
+			path: "/home/alex/.local/bin/claude-dispatcher",
+			want: MethodUnknown, canUpg: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classify(c.path, noNixProfile)
+			if got.Method != c.want {
+				t.Errorf("method = %q, want %q", got.Method, c.want)
+			}
+			if got.CanUpgrade() != c.canUpg {
+				t.Errorf("CanUpgrade() = %v, want %v", got.CanUpgrade(), c.canUpg)
+			}
+			if c.canUpg && strings.Join(got.Cmd, " ") != c.cmd {
+				t.Errorf("cmd = %q, want %q", strings.Join(got.Cmd, " "), c.cmd)
+			}
+			// An install we will not upgrade still has to say something: the
+			// footer prints Hint() either way, and an empty clause reads as a
+			// rendering bug rather than as a decision.
+			if !c.canUpg && got.Hint() == "" {
+				t.Error("an install with no command must still explain itself")
+			}
+		})
+	}
+}
+
+// The whole point of the Nix branch: a store path is only upgradable in place
+// when the imperative profile manifest claims it. Anything else is declared in
+// a file somewhere, and `nix profile upgrade` would either fail or install a
+// second copy shadowing the declared one.
+func TestClassifyNixImperative(t *testing.T) {
+	const path = "/nix/store/abc123-claude-dispatcher-3.1.2/bin/claude-dispatcher"
+	got := classify(path, func(string) (string, bool) { return "claude-dispatcher", true })
+	if got.Method != MethodNixProfile {
+		t.Fatalf("method = %q, want %q", got.Method, MethodNixProfile)
+	}
+	if want := "nix profile upgrade claude-dispatcher"; strings.Join(got.Cmd, " ") != want {
+		t.Errorf("cmd = %q, want %q", strings.Join(got.Cmd, " "), want)
+	}
+}
+
+// manifest.json has had two shapes and both are still on people's machines:
+// v1/v2 name an element by its index, v3 by a key.
+func TestManifestSelector(t *testing.T) {
+	const resolved = "/nix/store/abc123-claude-dispatcher-3.1.2/bin/claude-dispatcher"
+
+	v3 := []byte(`{"version":3,"elements":{
+		"ripgrep":{"storePaths":["/nix/store/zzz-ripgrep-14"]},
+		"claude-dispatcher":{"storePaths":["/nix/store/abc123-claude-dispatcher-3.1.2"]}}}`)
+	if sel, ok := manifestSelector(v3, resolved); !ok || sel != "claude-dispatcher" {
+		t.Errorf("v3: got (%q, %v), want (claude-dispatcher, true)", sel, ok)
+	}
+
+	v2 := []byte(`{"version":2,"elements":[
+		{"storePaths":["/nix/store/zzz-ripgrep-14"]},
+		{"storePaths":["/nix/store/abc123-claude-dispatcher-3.1.2"]}]}`)
+	if sel, ok := manifestSelector(v2, resolved); !ok || sel != "1" {
+		t.Errorf("v2: got (%q, %v), want (1, true)", sel, ok)
+	}
+
+	// A manifest that does not carry this binary must not claim it — this is
+	// the check standing between a home-manager install and an imperative
+	// upgrade run against it.
+	other := []byte(`{"version":3,"elements":{"ripgrep":{"storePaths":["/nix/store/zzz-ripgrep-14"]}}}`)
+	if sel, ok := manifestSelector(other, resolved); ok {
+		t.Errorf("a foreign manifest claimed this binary as %q", sel)
+	}
+	if _, ok := manifestSelector([]byte("not json"), resolved); ok {
+		t.Error("unreadable manifest must not claim anything")
+	}
+
+	// A store path must match on a path boundary, never as a bare prefix:
+	// …-claude-dispatcher-3.1.2 must not be satisfied by …-claude-dispatcher-3
+	// on the way past.
+	near := []byte(`{"version":3,"elements":{"x":{"storePaths":["/nix/store/abc123-claude-dispatcher-3"]}}}`)
+	if _, ok := manifestSelector(near, resolved); ok {
+		t.Error("a different store path matched on a bare prefix")
+	}
+}
+
+// Homebrew skips its own tap refresh on a machine that fetched recently, which
+// would make "upgrade me now" a no-op seconds after a release. The child env
+// has to force the refresh, and must not disturb anything else.
+func TestEnvForcesHomebrewRefresh(t *testing.T) {
+	t.Setenv("HOMEBREW_NO_AUTO_UPDATE", "1")
+	t.Setenv("HOMEBREW_AUTO_UPDATE_SECS", "86400")
+	t.Setenv("CLAUDE_DISPATCHER_STATE", "/tmp/keep-me")
+
+	env := Install{Method: MethodBrewCask}.Env()
+	var secs int
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "HOMEBREW_NO_AUTO_UPDATE=") {
+			t.Errorf("HOMEBREW_NO_AUTO_UPDATE survived as %q", kv)
+		}
+		if kv == "HOMEBREW_AUTO_UPDATE_SECS=0" {
+			secs++
+		} else if strings.HasPrefix(kv, "HOMEBREW_AUTO_UPDATE_SECS=") {
+			t.Errorf("stale refresh window survived as %q", kv)
+		}
+	}
+	if secs != 1 {
+		t.Errorf("HOMEBREW_AUTO_UPDATE_SECS=0 appears %d times, want 1", secs)
+	}
+	if !contains(env, "CLAUDE_DISPATCHER_STATE=/tmp/keep-me") {
+		t.Error("the rest of the environment must pass through untouched")
+	}
+
+	// Nothing to force anywhere else: nix, scoop and winget all fetch on every
+	// invocation.
+	if nix := (Install{Method: MethodNixProfile}).Env(); len(nix) != len(os.Environ()) {
+		t.Error("a non-homebrew install must inherit the environment unchanged")
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Detect runs against whatever built the test binary, so it cannot assert a
+// method — only that it always answers, never panics, and never hands the
+// cockpit a half-formed offer.
+func TestDetectAlwaysAnswers(t *testing.T) {
+	in := Detect()
+	if in.CanUpgrade() {
+		if len(in.Cmd) < 2 {
+			t.Errorf("an upgrade command needs a verb: %q", in.Cmd)
+		}
+	} else if in.Hint() == "" {
+		t.Error("Hint must explain why there is no command")
+	}
+	if in.Hint() != UpgradeHint() {
+		t.Error("UpgradeHint must be Detect().Hint()")
+	}
+}
+
+// nixProfileSelector reads real files; point it at a temp profile and check it
+// both finds and refuses.
+func TestNixProfileSelectorReadsManifest(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", "")
+
+	profile := filepath.Join(home, ".nix-profile")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const resolved = "/nix/store/abc123-claude-dispatcher-3.1.2/bin/claude-dispatcher"
+	if _, ok := nixProfileSelector(resolved); ok {
+		t.Error("no manifest yet, nothing may be claimed")
+	}
+
+	manifest := `{"version":3,"elements":{"claude-dispatcher":{"storePaths":["/nix/store/abc123-claude-dispatcher-3.1.2"]}}}`
+	if err := os.WriteFile(filepath.Join(profile, "manifest.json"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sel, ok := nixProfileSelector(resolved)
+	if !ok || sel != "claude-dispatcher" {
+		t.Errorf("got (%q, %v), want (claude-dispatcher, true)", sel, ok)
+	}
+}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,7 +7,6 @@
 package version
 
 import (
-	"runtime"
 	"strconv"
 	"strings"
 )
@@ -41,15 +40,6 @@ func IsRelease() bool {
 // Anything it cannot parse — a dev build, an empty or malformed latest —
 // answers false: a version it does not understand must never nag the user.
 func IsOutdated(latest string) bool { return newer(Version, latest) }
-
-// UpgradeHint is the command that upgrades this build in place. macOS and
-// Linux ship through the Homebrew tap, Windows through the scoop bucket.
-func UpgradeHint() string {
-	if runtime.GOOS == "windows" {
-		return "scoop update claude-dispatcher"
-	}
-	return "brew upgrade claude-dispatcher"
-}
 
 // semver is a version parsed far enough to order two of them.
 type semver struct {

--- a/main.go
+++ b/main.go
@@ -52,6 +52,15 @@ func main() {
 		os.Exit(hookcmd.Run(args[1:]))
 	case "version", "--version", "-v":
 		fmt.Println("claude-dispatcher", version.Display())
+		// How this build was installed, and what would replace it. This is the
+		// second line because it is the answer to "why is the cockpit not
+		// offering me the upgrade key?" — an install we cannot place says so
+		// here rather than staying silent about it.
+		if in := version.Detect(); in.CanUpgrade() {
+			fmt.Println(string(in.Method), "·", in.Hint())
+		} else {
+			fmt.Println(in.Hint())
+		}
 	case "help", "-h", "--help":
 		fmt.Print(usage)
 	default:


### PR DESCRIPTION
The footer already knew when a newer build existed. Acting on it meant quitting the cockpit, running a command, and starting again — and the command it printed was a guess from `GOOS`, so it told every Nix user to run `brew`.

## `U`

Names the exact command, asks, hands the terminal to the package manager (its progress is the human's to watch — a cask download has its own), then **re-execs the binary that was just installed**. `syscall.Exec`, not a child process: same pid, same terminal, same tmux pane. Dispatchers are tmux sessions and never notice.

The exec has to happen *after* Bubble Tea returns — the alt screen must be left and raw mode restored before the new process starts — so the model carries a `relaunch` flag that `Run` reads once the program is done.

## Which command

Read off the running binary's own resolved path, the only evidence on the machine that cannot disagree with itself:

| path says | `U` runs |
|---|---|
| `…/Caskroom/…` | `brew upgrade --cask claude-dispatcher` |
| `…/Cellar/…` | `brew upgrade claude-dispatcher` |
| `…/nix/store/…` **and in the imperative profile manifest** | `nix profile upgrade <element>` |
| `…/scoop/…` | `scoop update claude-dispatcher` |
| `…/WinGet/…` | `winget upgrade --id Innovology.claude-dispatcher` |
| anything else | nothing — points at the releases page |

## Nix

A store path does not say whether the install is imperative or declarative, and `nix profile upgrade` against a home-manager install either fails or installs a second copy that shadows the declared one. Only an entry in the imperative profile's `manifest.json` proves it may be upgraded — `nix-env` and home-manager write a `manifest.nix` instead. Reading it also answers what the element is *called*, which is the argument the upgrade takes.

Without that proof: `v3.1.1 → v3.1.2 · nix-managed · upgrade it where it is declared`, and no key. Verified end-to-end — the same binary in the same store path answers `nix-managed` with no manifest and `nix profile upgrade claude-dispatcher` once registered in one.

Both manifest shapes are read: v1/v2 name an element by index, v3 by key.

## Smaller things

- **Homebrew skips its own tap refresh** when it fetched recently (a day, by default), which would make "upgrade me now" a no-op in exactly the window it gets pressed — the minutes after a release. The child env forces the refresh instead of paying for a full `brew update` across every tap.
- `claude-dispatcher version` now prints how it was installed. That is the answer to "why is there no `U`?".
- `U` is **text** while the dispatch prompt has the keyboard, like `?`, `u` and `q` already are. Upgrading the machine mid-sentence would be the worst of that set to make an exception for.
- Windows has no exec-in-place, so it installs and says to start again rather than pretending to restart.
- The classifier folds backslashes itself rather than via `filepath.ToSlash`, which only knows the host's separator — the scoop and winget branches were untestable anywhere but Windows. A test caught this.
- The two footer tests were passing by accident of where the test binary happened to live; the install now lives on the model, so both branches are actually driven.
- Drive-by: the keys table still documented `w`, which #36 removed.