### PR TITLE
Come back from a jump-in rechecking, not redrawing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,23 @@
   `~/.claude/settings.json` (hooks cannot be injected at launch time). The
   `CLAUDE_DISPATCHER_ID` env var is the join key from session to record.
   Transcript JSONL parsing is best-effort preview only (format is internal).
+  The one thing no hook can report is a session dying without getting a
+  `SessionEnd` out (SIGKILL, an outside `tmux kill-session`, a tmux server
+  that went down with the machine), so `dispatch.ReconcileSessions` sweeps
+  working/needs-input/blocked records whose session is gone and marks them
+  exited. It never sweeps `launching`: no hook has fired for one, so its
+  session may simply not exist *yet* — absence is only evidence where a hook
+  proved the session once existed.
+- **Coming back from a jump-in rechecks, it does not redraw.** The human has
+  just spent minutes driving the session by hand, so `cockpit.recheckCmd`
+  drops the gh cache, sweeps session liveness, reconciles PR/deploy and only
+  then rebuilds the snapshot — the ordinary poll reload would serve forge
+  state cached from before they went in and take the record's status at its
+  word. Where the handover exits on the way *out* rather than on the way home
+  (`switch-client` inside tmux, the raised console window on Windows —
+  `supervisor.AttachSwitches`), the recheck waits for the terminal focus
+  event instead. Focus alone never triggers it: a full forge re-read on every
+  alt-tab is how the gh quota gets burned.
 - Features are named at dispatch time (hybrid model): the name is the key;
   branch `feature/<slug>`, commits, and PRs enrich it automatically. Every
   dispatch works on a feature branch, even in repos that ship from main

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ There is no API for a Claude subscription's limits — so the cockpit **learns**
 
 Every act the table offers is wired to the live session — the key hints show only what the selected dispatcher can actually do:
 
-- **`enter`** attach the tmux session at full fidelity (`Ctrl-\` to come back)
+- **`enter`** attach the tmux session at full fidelity (`Ctrl-\` to come back). Coming back **rechecks** rather than redraws: you have just spent minutes driving that session by hand, so the forge is read again instead of replayed from cache, and any session that died without getting a `SessionEnd` out stops being reported as working
 - **`y`** on a PR waiting to merge: `gh pr merge --squash --auto`, then mark live. Elsewhere it marks the record shipped, and it is hidden entirely when the dispatcher has produced no commits
 - **`x`** kill the session · **`s`** skip to the back of the table · **`u`** undo
 - **`d`** open the prompt · **`f`** / **`w`** filter the table · **`enter` on a backlog ticket** dispatches it

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -40,7 +40,16 @@ func (m model) attach(feature string) (model, tea.Cmd) {
 		return m, nil
 	}
 	supervisor.EnsureBackKey()
+	supervisor.EnsureFocusEvents()
 	supervisor.SetStatusHint(rec.TmuxSession)
+	// Whether this command's exit means "they are back" depends on how the
+	// handover works. A plain attach owns the terminal until they detach, so it
+	// exits on the way home. A switch-client (inside tmux) or a raised console
+	// window (Windows) exits the instant they leave, and the only notice of
+	// their return is the focus their pane or window regains — so record that
+	// they are away and let that close the loop. See the attachReturnedMsg and
+	// tea.FocusMsg cases in model.go.
+	m.away = supervisor.AttachSwitches()
 	return m, tea.ExecProcess(supervisor.AttachCmd(rec.TmuxSession), func(err error) tea.Msg {
 		return attachReturnedMsg{err: err}
 	})

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -105,6 +105,12 @@ type model struct {
 	// it — see version.Detect.
 	install version.Install
 
+	// away says the human is inside a dispatcher session this cockpit handed
+	// them to and has not come back from yet. It is only ever set when the
+	// handover exits on the way OUT rather than on the way back — see attach —
+	// and it is what earns the return trip a full recheck rather than a redraw.
+	away bool
+
 	// relaunch says the cockpit is quitting only to come back as the build it
 	// just installed. Run reads it after the program returns — the terminal has
 	// to be handed back before we exec, or the new process inherits an alt
@@ -270,12 +276,37 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case attachReturnedMsg:
 		m.notice = ""
 		if msg.err != nil {
+			// The handover never happened, so nobody went anywhere and there is
+			// no return trip to wait for.
 			m.notice = "attach failed: " + msg.err.Error()
+			m.away = false
 		}
-		if m.cfg != nil {
+		if m.cfg == nil {
+			return m, nil
+		}
+		// A handover that exits on the way out has not returned anyone yet:
+		// rechecking here would read the world at the instant the human left and
+		// then have nothing to say when they actually come back, which is the
+		// staleness this is meant to end. Wait for focus. Everywhere else this
+		// message IS the return, so recheck now.
+		if m.away {
 			return m, loadSnapshotCmd(m.cfg)
 		}
-		return m, nil
+		return m, recheckCmd(m.cfg)
+
+	case tea.FocusMsg:
+		// Only a jump-in earns a recheck; focus on its own must not. A full
+		// forge re-read every time the human alt-tabs back to the terminal is
+		// how the gh quota gets burned (see internal/gh/cache.go), and a cockpit
+		// that never left has nothing to catch up on.
+		if !m.away {
+			return m, nil
+		}
+		m.away = false
+		if m.cfg == nil {
+			return m, nil
+		}
+		return m, recheckCmd(m.cfg)
 
 	case cqFlashMsg:
 		// A stale timer must not clear a newer item — same guard as undoSeq.

--- a/internal/cockpit/recheck_test.go
+++ b/internal/cockpit/recheck_test.go
@@ -1,0 +1,138 @@
+package cockpit
+
+// recheck_test.go covers the jump-in round trip: coming back from a session has
+// to re-establish what is true rather than redraw what was true before the
+// human went in.
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/state"
+	"claude-dispatcher/internal/supervisor"
+)
+
+// A handover that exits on the way out (switch-client inside tmux, a raised
+// console window on Windows) has not brought anyone back yet, so the recheck
+// waits for the focus the cockpit's pane regains on the return trip. A handover
+// that exits on the way home is itself the return.
+func TestAttachRoundTripWaitsForTheActualReturn(t *testing.T) {
+	base := newModel()
+	base.cfg = &config.Config{}
+
+	// Away: the command exited as the human left. Still marked away, so the
+	// focus event is still owed a recheck.
+	away := base
+	away.away = true
+	got, cmd := away.Update(attachReturnedMsg{})
+	if !got.(model).away {
+		t.Error("a handover that exits on the way out must leave the cockpit marked away")
+	}
+	if cmd == nil {
+		t.Error("the cockpit should still reload when the handover command exits")
+	}
+
+	// Not away: this message IS the return, so it is not deferred to focus.
+	got, cmd = base.Update(attachReturnedMsg{})
+	if got.(model).away {
+		t.Error("a blocking attach returns the human with it — nothing to wait for")
+	}
+	if cmd == nil {
+		t.Error("returning from an attach should recheck")
+	}
+
+	// A handover that never happened sent nobody anywhere.
+	got, _ = away.Update(attachReturnedMsg{err: errFake{}})
+	if got.(model).away {
+		t.Error("a failed attach must not leave the cockpit waiting for a return")
+	}
+}
+
+// Focus is not on its own a reason to re-read the world: a full forge refetch
+// every time the human alt-tabs back to the terminal is how the gh quota gets
+// burned, and a cockpit that never left has nothing to catch up on.
+func TestFocusOnlyRechecksAfterAJumpIn(t *testing.T) {
+	base := newModel()
+	base.cfg = &config.Config{}
+
+	if _, cmd := base.Update(tea.FocusMsg{}); cmd != nil {
+		t.Error("focus without a jump-in should cost nothing")
+	}
+
+	away := base
+	away.away = true
+	got, cmd := away.Update(tea.FocusMsg{})
+	if cmd == nil {
+		t.Error("coming back from a jump-in should recheck")
+	}
+	if got.(model).away {
+		t.Error("the return trip is owed one recheck, not one per focus")
+	}
+	// And the debt is settled: a second focus is an ordinary one again.
+	if _, cmd := got.(model).Update(tea.FocusMsg{}); cmd != nil {
+		t.Error("the recheck should not repeat on every later focus")
+	}
+}
+
+// On demo data there is nothing to recheck against, and track.Refresh would be
+// handed a nil config.
+func TestFocusWithoutConfigRechecksNothing(t *testing.T) {
+	m := newModel()
+	m.away = true
+	got, cmd := m.Update(tea.FocusMsg{})
+	if cmd != nil {
+		t.Error("a config-less cockpit has no live data to recheck")
+	}
+	if got.(model).away {
+		t.Error("away should still be cleared — the human is back either way")
+	}
+}
+
+// The end-to-end claim: after a jump-in, a record whose session went away while
+// the cockpit was not looking comes back as exited rather than as the status
+// the last hook managed to write. The whole environment is real here — repos,
+// records and all — so this exercises recheckCmd's actual sequence.
+func TestRecheckRetiresSessionsThatWentAway(t *testing.T) {
+	if !supervisor.Available() {
+		t.Skip("no session supervisor on this host — the liveness sweep cannot observe anything")
+	}
+	env := buildEnvScenario(t)
+	saved := captureVars()
+	defer restoreVars(saved)
+
+	// The fixture's blocked and needs-input records name tmux sessions that do
+	// not exist — a session killed, or a tmux server that went down, while the
+	// human was inside another one.
+	before := map[string]state.Status{}
+	for _, d := range state.LoadAll() {
+		before[d.ID] = d.Status
+	}
+	if before["rec-blocked"] != state.StatusBlocked || before["rec-needs"] != state.StatusNeedsInput {
+		t.Fatalf("fixture changed: blocked=%q needs=%q", before["rec-blocked"], before["rec-needs"])
+	}
+
+	msg := recheckCmd(env.cfg)()
+	if _, ok := msg.(snapshotMsg); !ok {
+		t.Fatalf("recheckCmd returned %T, want a snapshot", msg)
+	}
+
+	after := map[string]state.Status{}
+	for _, d := range state.LoadAll() {
+		after[d.ID] = d.Status
+	}
+	for _, id := range []string{"rec-blocked", "rec-needs"} {
+		if after[id] != state.StatusExited {
+			t.Errorf("%s: status = %q after the recheck, want exited — its session is gone", id, after[id])
+		}
+	}
+	// rec-working names no session at all, so there is nothing to look for and
+	// nothing to conclude.
+	if after["rec-working"] != state.StatusWorking {
+		t.Errorf("rec-working: status = %q, want working — it names no session to check", after["rec-working"])
+	}
+	if after["rec-done"] != state.StatusDone {
+		t.Errorf("rec-done: status = %q, want done", after["rec-done"])
+	}
+}

--- a/internal/cockpit/refresh.go
+++ b/internal/cockpit/refresh.go
@@ -6,6 +6,8 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
+	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/state"
 	"claude-dispatcher/internal/track"
 )
@@ -31,6 +33,46 @@ type (
 // loadSnapshotCmd rebuilds the whole snapshot off the UI goroutine.
 func loadSnapshotCmd(cfg *config.Config) tea.Cmd {
 	return func() tea.Msg { return snapshotMsg(loadSnapshot(cfg)) }
+}
+
+// recheckCmd is the reload for a cockpit that has not been looking.
+//
+// loadSnapshotCmd is a poll's reload: it re-reads the dispatch records, but it
+// serves every forge signal out of gh's memo cache and takes each record's
+// status at its word. That is right when the cockpit has been on screen the
+// whole time, because nothing has happened that it did not already see land.
+//
+// It is wrong the moment the human comes back from jumping into a session. They
+// have just spent minutes inside it driving it by hand — approving a permission,
+// answering a question, pushing, opening or merging a PR, or ending the session
+// outright — so the cached PR and check state predates everything they did, and
+// the status on disk is only as fresh as the last hook that got to fire. The
+// screen would come back up showing what was true before they left, which is
+// precisely the reading they are least able to catch: it looks like an answer.
+//
+// So this one assumes the world moved, and re-establishes each layer in the
+// order the next one depends on:
+//
+//  1. drop the forge cache, so checks, reviews and PR state are read again
+//     rather than replayed from before the jump (shipCmd invalidates for the
+//     same reason after a merge — a hand at the wheel is no less of a change);
+//  2. re-check session liveness, so a session that died without getting a
+//     SessionEnd out stops being reported as working;
+//  3. reconcile PRs and deploys against that, and in that order — track.midWork
+//     reads status, so a record the sweep just retired can still be flipped to
+//     done by its merge, where the reverse order would hold it open;
+//  4. rebuild the snapshot from the result.
+//
+// One command rather than a chain of messages, because the sequence is the
+// point: a snapshot built before the sweep landed would show the stale status
+// this exists to clear.
+func recheckCmd(cfg *config.Config) tea.Cmd {
+	return func() tea.Msg {
+		gh.InvalidateCache()
+		dispatchpkg.ReconcileSessions(state.LoadAll())
+		track.Refresh(state.LoadAll(), cfg)
+		return snapshotMsg(loadSnapshot(cfg))
+	}
 }
 
 // trackRefreshCmd reconciles PR and deploy state, persisting any change; the

--- a/internal/cockpit/run.go
+++ b/internal/cockpit/run.go
@@ -54,7 +54,13 @@ func Run() error {
 		m.notice = "no config — showing demo data · run `claude-dispatcher init`"
 	}
 
-	final, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	// Focus reporting is what tells the cockpit the human has come back from a
+	// session it switched them to rather than attached them to — the handover
+	// there exits on the way out, so nothing else marks the return. Terminals
+	// that do not report focus simply never send the message; see the
+	// tea.FocusMsg case in model.go, which ignores it unless we handed someone
+	// over in the first place.
+	final, err := tea.NewProgram(m, tea.WithAltScreen(), tea.WithReportFocus()).Run()
 	if err != nil {
 		return err
 	}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -146,8 +146,62 @@ func liveDispatch(slug string) *state.Dispatch {
 	return nil
 }
 
-// sessionAlive is a seam: tests swap it rather than stand up real sessions.
-var sessionAlive = supervisor.HasSession
+// sessionAlive and supervisorReady are seams: tests swap them rather than
+// stand up real sessions.
+var (
+	sessionAlive    = supervisor.HasSession
+	supervisorReady = supervisor.Available
+)
+
+// ReconcileSessions re-derives status from the one fact the lifecycle hook
+// cannot report — whether the session behind a record still exists — and marks
+// every stray record exited. It returns how many it changed.
+//
+// Status normally comes from Claude Code hooks, and they are truth right up to
+// the moment a session dies without getting to say so: a SIGKILL, a
+// `tmux kill-session` from another terminal, a tmux server that went down with
+// the machine. No SessionEnd fires for any of those, so the record goes on
+// claiming "working" or "waiting on you" forever and the triage table carries a
+// dispatcher that is not there. The live session, not the record's status, is
+// ground truth — the same call liveDispatch makes.
+//
+// Note what does NOT strand a record: claude merely exiting. launchCommand
+// drops to a login shell so the session survives for inspection, and SessionEnd
+// fires on the way out. A missing session means something took it away.
+//
+// The three statuses swept are a boundary, not caution. Each is reachable only
+// through a hook fired from inside the session, so the session provably
+// existed and its absence now proves it ended. A launching record has had no
+// hook at all, and there is a window — between Launch saving it and NewSession
+// returning — where its session does not exist yet and never did; absence
+// there proves nothing, so nothing is claimed. Likewise a supervisor we cannot
+// even reach is not evidence that every session is gone, which is why an
+// unavailable backend sweeps nothing rather than retiring the whole fleet.
+func ReconcileSessions(ds []*state.Dispatch) int {
+	if !supervisorReady() {
+		return 0
+	}
+	n := 0
+	for _, d := range ds {
+		if d.TmuxSession == "" {
+			continue
+		}
+		switch d.Status {
+		case state.StatusWorking, state.StatusNeedsInput, state.StatusBlocked:
+		default:
+			continue
+		}
+		if sessionAlive(d.TmuxSession) {
+			continue
+		}
+		d.Status = state.StatusExited
+		d.StatusReason = "its " + supervisor.Backend() + " session is gone"
+		if state.Save(d) == nil {
+			n++
+		}
+	}
+	return n
+}
 
 // fetchTimeout bounds the pre-dispatch fetch. Refreshing the base is a
 // courtesy; a slow or unreachable remote must never stall a launch.

--- a/internal/dispatch/reconcile_test.go
+++ b/internal/dispatch/reconcile_test.go
@@ -1,0 +1,150 @@
+package dispatch
+
+import (
+	"testing"
+
+	"claude-dispatcher/internal/state"
+)
+
+// withFakeSessions swaps the supervisor seams so the sweep runs against a
+// hand-written liveness map instead of a real tmux server.
+func withFakeSessions(t *testing.T, alive map[string]bool, ready bool) {
+	t.Helper()
+	prevAlive, prevReady := sessionAlive, supervisorReady
+	t.Cleanup(func() { sessionAlive, supervisorReady = prevAlive, prevReady })
+	sessionAlive = func(name string) bool { return alive[name] }
+	supervisorReady = func() bool { return ready }
+}
+
+func saveAll(t *testing.T, recs ...*state.Dispatch) {
+	t.Helper()
+	for _, r := range recs {
+		if err := state.Save(r); err != nil {
+			t.Fatalf("state.Save(%s): %v", r.ID, err)
+		}
+	}
+}
+
+// statusOnDisk re-reads a record so the test asserts what was persisted rather
+// than what was mutated in memory.
+func statusOnDisk(t *testing.T, id string) state.Status {
+	t.Helper()
+	for _, d := range state.LoadAll() {
+		if d.ID == id {
+			return d.Status
+		}
+	}
+	t.Fatalf("record %s vanished", id)
+	return ""
+}
+
+// A record only reaches working, needs-input or blocked through a hook fired
+// from inside its session, so the session provably existed — and its absence
+// now is proof it ended, however it ended. Everything else is left alone.
+func TestReconcileSessionsRetiresOnlyProvableStrays(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+
+	rec := func(id string, st state.Status, session string) *state.Dispatch {
+		return &state.Dispatch{ID: id, Feature: id, Status: st, TmuxSession: session}
+	}
+	live := rec("live", state.StatusWorking, "disp-live")
+	gone := rec("gone", state.StatusWorking, "disp-gone")
+	needs := rec("needs", state.StatusNeedsInput, "disp-needs")
+	blocked := rec("blocked", state.StatusBlocked, "disp-blocked")
+	launching := rec("launching", state.StatusLaunching, "disp-launching")
+	done := rec("done", state.StatusDone, "disp-done")
+	exited := rec("exited", state.StatusExited, "disp-exited")
+	unnamed := rec("unnamed", state.StatusWorking, "")
+	saveAll(t, live, gone, needs, blocked, launching, done, exited, unnamed)
+
+	withFakeSessions(t, map[string]bool{"disp-live": true}, true)
+
+	if n := ReconcileSessions(state.LoadAll()); n != 3 {
+		t.Errorf("ReconcileSessions retired %d records, want 3 (gone, needs, blocked)", n)
+	}
+
+	for _, id := range []string{"gone", "needs", "blocked"} {
+		if got := statusOnDisk(t, id); got != state.StatusExited {
+			t.Errorf("%s: status = %q, want exited — its session is gone", id, got)
+		}
+	}
+	if got := statusOnDisk(t, "live"); got != state.StatusWorking {
+		t.Errorf("live: status = %q, want working — its session is still there", got)
+	}
+	// Nothing has fired a hook for a launching record, so there is a window in
+	// which its session does not exist yet and never did. Absence proves
+	// nothing there, and the sweep must not claim otherwise.
+	if got := statusOnDisk(t, "launching"); got != state.StatusLaunching {
+		t.Errorf("launching: status = %q, want launching — the launch window is not evidence", got)
+	}
+	if got := statusOnDisk(t, "done"); got != state.StatusDone {
+		t.Errorf("done: status = %q, want done — done means live", got)
+	}
+	if got := statusOnDisk(t, "exited"); got != state.StatusExited {
+		t.Errorf("exited: status = %q, want exited", got)
+	}
+	if got := statusOnDisk(t, "unnamed"); got != state.StatusWorking {
+		t.Errorf("unnamed: status = %q, want working — there is no session to look for", got)
+	}
+}
+
+// The reason has to say what was actually observed, since it is what the
+// cockpit shows in place of the status the hook never got to write.
+func TestReconcileSessionsExplainsItself(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	saveAll(t, &state.Dispatch{
+		ID: "stray", Feature: "stray", Status: state.StatusWorking,
+		TmuxSession: "disp-stray", StatusReason: "processing your prompt",
+	})
+	withFakeSessions(t, nil, true)
+
+	ReconcileSessions(state.LoadAll())
+	for _, d := range state.LoadAll() {
+		if d.ID != "stray" {
+			continue
+		}
+		if d.StatusReason == "processing your prompt" {
+			t.Error("a retired record kept the reason from the status it no longer has")
+		}
+		if d.StatusReason == "" {
+			t.Error("a retired record must say why")
+		}
+	}
+}
+
+// A supervisor we cannot reach is not evidence that every session is gone. If
+// it were swept anyway, one missing tmux would retire the whole fleet at once.
+func TestReconcileSessionsSweepsNothingWithoutASupervisor(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	saveAll(t, &state.Dispatch{
+		ID: "orphan", Feature: "orphan", Status: state.StatusWorking,
+		TmuxSession: "disp-orphan",
+	})
+	withFakeSessions(t, nil, false)
+
+	if n := ReconcileSessions(state.LoadAll()); n != 0 {
+		t.Errorf("ReconcileSessions retired %d records with no supervisor, want 0", n)
+	}
+	if got := statusOnDisk(t, "orphan"); got != state.StatusWorking {
+		t.Errorf("orphan: status = %q, want working — nothing observed it", got)
+	}
+}
+
+// The sweep must be idempotent: a second pass over records it already retired
+// changes nothing and reports nothing, so a cockpit polling it does not churn
+// the state dir (every save wakes the fsnotify watcher).
+func TestReconcileSessionsIsIdempotent(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	saveAll(t, &state.Dispatch{
+		ID: "twice", Feature: "twice", Status: state.StatusBlocked,
+		TmuxSession: "disp-twice",
+	})
+	withFakeSessions(t, nil, true)
+
+	if n := ReconcileSessions(state.LoadAll()); n != 1 {
+		t.Fatalf("first pass retired %d, want 1", n)
+	}
+	if n := ReconcileSessions(state.LoadAll()); n != 0 {
+		t.Errorf("second pass retired %d, want 0", n)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -19,4 +19,6 @@
 //	UniqueName(base) string                  — a session name not already taken
 //	SetStatusHint(name)                      — show the way back in its status line
 //	EnsureBackKey()                          — bind the prefix-free "back" key
+//	EnsureFocusEvents()                      — have the host report focus changes
+//	AttachSwitches() bool                    — does AttachCmd exit on the way out
 package supervisor

--- a/internal/supervisor/supervisor_unix.go
+++ b/internal/supervisor/supervisor_unix.go
@@ -23,6 +23,14 @@ func SetStatusHint(name string)                   { tmux.SetStatusHint(name) }
 // EnsureBackKey binds the prefix-free "back to the cockpit" key (Ctrl-\).
 func EnsureBackKey() { tmux.EnsureDetachKey() }
 
+// EnsureFocusEvents turns on tmux's focus reporting, which is what tells a
+// cockpit hosted in tmux that its pane has come back to the front.
+func EnsureFocusEvents() { tmux.EnsureFocusEvents() }
+
+// AttachSwitches is true inside tmux, where the handover is a switch-client
+// that exits as the human leaves rather than when they come back.
+func AttachSwitches() bool { return tmux.AttachSwitches() }
+
 // SendKeys types text into the session and presses Enter, as if at the prompt.
 func SendKeys(name, text string) error {
 	return exec.Command("tmux", "send-keys", "-t", "="+name, text, "Enter").Run()

--- a/internal/supervisor/supervisor_unix_test.go
+++ b/internal/supervisor/supervisor_unix_test.go
@@ -33,6 +33,7 @@ func TestNonMutatingCallsAreSafe(t *testing.T) {
 	}
 	SetStatusHint("definitely-not-a-real-session-xyz")
 	EnsureBackKey()
+	EnsureFocusEvents()
 	if cmd := AttachCmd("x"); cmd == nil {
 		t.Error("AttachCmd returned nil")
 	}
@@ -40,4 +41,30 @@ func TestNonMutatingCallsAreSafe(t *testing.T) {
 	// is fine — we only require they return without panicking.
 	_ = SendKeys("definitely-not-a-real-session-xyz", "hello")
 	_ = KillSession("definitely-not-a-real-session-xyz")
+}
+
+// AttachSwitches answers one question — does AttachCmd's exit mean the human is
+// back, or that they have just left — and the cockpit's return-trip recheck
+// hangs off it. It must agree with the command AttachCmd actually builds, or
+// the cockpit waits for a return that already happened (or rechecks one that
+// has not).
+func TestAttachSwitchesMatchesTheCommandBuilt(t *testing.T) {
+	for _, tc := range []struct {
+		name, tmux, wantArg string
+		wantSwitches        bool
+	}{
+		{name: "inside tmux", tmux: "/tmp/tmux-501/default,1,0", wantArg: "switch-client", wantSwitches: true},
+		{name: "bare terminal", tmux: "", wantArg: "attach-session", wantSwitches: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("TMUX", tc.tmux)
+			if got := AttachSwitches(); got != tc.wantSwitches {
+				t.Errorf("AttachSwitches() = %v, want %v", got, tc.wantSwitches)
+			}
+			args := AttachCmd("some-session").Args
+			if len(args) < 2 || args[1] != tc.wantArg {
+				t.Errorf("AttachCmd args = %v, want %q — it disagrees with AttachSwitches", args, tc.wantArg)
+			}
+		})
+	}
 }

--- a/internal/supervisor/supervisor_windows.go
+++ b/internal/supervisor/supervisor_windows.go
@@ -191,6 +191,16 @@ func UniqueName(base string) string {
 }
 
 // SetStatusHint and EnsureBackKey are tmux status-line / key-binding concerns
-// with no console-window analogue; they are no-ops on Windows.
+// with no console-window analogue; they are no-ops on Windows. Focus reporting
+// is the console's own business rather than something we can switch on for it,
+// so EnsureFocusEvents is a no-op too.
 func SetStatusHint(name string) {}
 func EnsureBackKey()            {}
+func EnsureFocusEvents()        {}
+
+// AttachSwitches is true here for the same reason it is true inside tmux: the
+// Windows handover raises the session's own console window and returns at once,
+// so the human is over there and this command's exit is not their return. The
+// cockpit therefore waits for focus rather than rechecking on that exit — see
+// the attachReturnedMsg case in internal/cockpit.
+func AttachSwitches() bool { return true }

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -46,6 +46,22 @@ func EnsureDetachKey() {
 	_ = exec.Command("tmux", "bind-key", "-n", `C-\`, "detach-client").Run()
 }
 
+// EnsureFocusEvents asks tmux to pass focus in and out through to the programs
+// it hosts. tmux ships with it off, and without it a cockpit running inside
+// tmux is never told when its own pane comes back to the front — which is the
+// only notice it gets that the human has returned from a session it switched
+// them to, because switch-client exits at the moment they leave rather than the
+// moment they come back (see AttachSwitches). Set server-wide, like the detach
+// key, so it covers the cockpit's client and not just the sessions we start.
+func EnsureFocusEvents() {
+	_ = exec.Command("tmux", "set-option", "-g", "focus-events", "on").Run()
+}
+
+// AttachSwitches reports whether AttachCmd moves the human to another client
+// instead of taking this terminal over until they detach — which decides
+// whether that command's exit means "they are back" or "they have just left".
+func AttachSwitches() bool { return os.Getenv("TMUX") != "" }
+
 func KillSession(name string) error {
 	return exec.Command("tmux", "kill-session", "-t", "="+name).Run()
 }
@@ -53,7 +69,7 @@ func KillSession(name string) error {
 // AttachCmd returns the command that hands the terminal over to a session.
 // Inside an existing tmux client we switch rather than nest.
 func AttachCmd(name string) *exec.Cmd {
-	if os.Getenv("TMUX") != "" {
+	if AttachSwitches() {
 		return exec.Command("tmux", "switch-client", "-t", "="+name)
 	}
 	return exec.Command("tmux", "attach-session", "-t", "="+name)


### PR DESCRIPTION
## The defect

Returning from an attach reloaded the snapshot. That sounds like enough. It isn't.

`loadSnapshotCmd` re-reads the dispatch records off disk, but every forge signal in it — PR state, checks, reviews — comes from `gh`'s memo cache (45s–3min TTLs), and each record's status is taken at its word.

Both are correct for a *poll*, where the cockpit has been on screen the whole time and nothing has happened that it did not watch land. Both are wrong the moment the human comes back from inside a session. They have just spent minutes driving it by hand — approving a permission, answering a question, pushing, opening or merging a PR, or ending the session outright. The cached PR state predates all of it, and the status on disk is only as fresh as the last hook that got to fire.

So the screen came back up showing what was true before they left. That is the reading a human is least able to catch, because it looks like an answer.

## The fix

The return trip gets its own reload, `recheckCmd`, which assumes the world moved and re-establishes each layer in the order the next one depends on:

1. drop the forge cache — `shipCmd` already invalidates after a merge for exactly this reason; a hand at the wheel is no less of a change;
2. sweep session liveness;
3. reconcile PR/deploy **against that** — `track.midWork` reads status, so a record the sweep just retired can still be flipped to done by its merge, where the reverse order would hold it open;
4. rebuild the snapshot.

One command rather than a chain of messages, because the sequence is the point: a snapshot built before the sweep landed would show the stale status this exists to clear.

## The liveness sweep

`dispatch.ReconcileSessions` covers the one fact no hook can report: a session that died without getting a `SessionEnd` out — a SIGKILL, an outside `tmux kill-session`, a tmux server that went down with the machine. The record went on claiming `working` or `waiting on you` forever and the triage table carried a dispatcher that was not there. A live session is ground truth, exactly as `liveDispatch` already has it.

Note what does *not* strand a record: claude merely exiting. `launchCommand` drops to a login shell so the session survives for inspection, and `SessionEnd` fires. A missing session means something took it away.

It sweeps `working`, `needs-input` and `blocked` only. That is a boundary, not caution — each is reachable only through a hook fired from inside the session, so the session provably existed and its absence now proves it ended. A `launching` record has had no hook, and there is a window between `Launch` saving it and `NewSession` returning where its session does not exist yet and never did; absence proves nothing there. An unreachable supervisor is likewise not evidence that every session is gone, so it sweeps nothing rather than retiring the whole fleet at once.

## Knowing when the human is actually back

Not free either, and it differs by handover:

| handover | exits when | so the return is |
|---|---|---|
| `attach-session` (bare terminal) | they detach | the command's exit |
| `switch-client` (inside tmux) | they leave | the focus its pane regains |
| raised console window (Windows) | they leave | the focus it regains |

Rechecking on the exit in the latter two would read the world at the moment of departure and have nothing to say on the way home. Those cases mark the cockpit `away` and wait for focus — which means turning on tmux's `focus-events` (off by default) and asking bubbletea to report focus.

Focus alone never triggers a recheck. A full forge re-read every time the human alt-tabs back to the terminal is how the gh quota gets burned (see `internal/gh/cache.go`); only a jump-in earns one, and it is one per return trip, not one per focus.

## Coverage

- `internal/dispatch/reconcile_test.go` — the sweep's boundary (every status, an unnamed session, an unavailable supervisor), that it explains itself, and that it is idempotent so a re-run does not churn the state dir and wake fsnotify.
- `internal/cockpit/recheck_test.go` — the away/focus state machine, plus an end-to-end run of `recheckCmd` over the real on-disk environment fixture proving a record whose session went away comes back `exited`.
- `internal/supervisor/supervisor_unix_test.go` — `AttachSwitches` must agree with the command `AttachCmd` actually builds, or the cockpit waits for a return that already happened.

`go test ./... -race`, `go vet`, `gofmt`, `golangci-lint` clean; `GOOS=windows` builds and vets.