### PR TITLE
Open on a boot screen that shows the load happening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,13 @@
 - `internal/hookcmd` — receives lifecycle hook events, drives the status
   state machine (launching/working/needs-input/blocked/done/exited).
 - `internal/dispatch` — branch + tmux + record creation.
-- `internal/ui` — Bubble Tea cockpit; responsive tiling breakpoints at 110
+- `internal/cockpit` — Bubble Tea cockpit; responsive tiling breakpoints at 110
   and 170 columns (more panes on wide screens, never one ballooned view).
+  `boot.go`/`boot_view.go` are the opening screen: a console-boot sequence over
+  the first `loadSnapshot`, which reports each stage as it runs. Every line is
+  a real stage and every figure is what it found — the list is a description of
+  that function, not decoration over it, so a stage added there gets a step here
+  (a test asserts the two sets match). Any key skips it; the load continues.
 - `internal/ship` — shipping stats (Claude-stamped = Co-Authored-By trailer).
 - `internal/version` — the build's version (stamped by goreleaser via
   `-X claude-dispatcher/internal/version.Version`), the cached, best-effort

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Anything unmapped is grouped under `unassigned`, which is what a fresh install s
 - Commits are attributed to dispatchers by **provenance** — each dispatch records the SHAs its feature branch produced (base tip at launch → branch tip). No trailers in your git history.
 - **Done means live:** when a PR merges, the tracker watches the repo's deploy workflow (auto-detected by name, or set in `[deploy_workflows]`) and flips the feature to done on a green run. Repos with no deploy workflow count merge as live.
 - The layout is **responsive**: wide terminals tile into three panes, narrower ones collapse to essentials.
+- **It opens on a boot screen.** The first load reads every dispatch record, asks tmux which sessions are still running, scans your roots and talks to the forge — seconds of work on a real portfolio. The opening screen shows each stage ticking off with what it found and how long it took, so the wait is legible instead of blank. Any key skips straight to the cockpit; the load carries on behind it.
 
 ## Keys
 

--- a/internal/cockpit/boot.go
+++ b/internal/cockpit/boot.go
@@ -1,0 +1,223 @@
+package cockpit
+
+// boot.go is the opening screen's state: the console-boot sequence the cockpit
+// runs through while its first snapshot is being built.
+//
+// The screen exists because that first load is not instant — it walks the scan
+// roots, asks the supervisor which sessions are still running, reads every
+// dispatch record's transcript and diff, and talks to the forge. Until now the
+// cockpit showed an empty frame for those seconds, which reads as "nothing
+// here" rather than "still counting".
+//
+// The discipline is the same as everywhere else in this package: every step on
+// the screen is a real stage of loadSnapshot, and every figure beside it is
+// what that stage actually found. Nothing is padded out to fill the list, and a
+// stage whose source is missing says so (warn) rather than reporting a zero as
+// if it had looked and found nothing. The one concession to theatre is timing —
+// see bootMinShow — and it delays the cockpit, never the data.
+
+import (
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// Step ids. They are the join between loadSnapshot, which reports against them,
+// and the screen, which draws them in bootSequence's order.
+const (
+	bootSupervisor  = "supervisor"
+	bootRecords     = "records"
+	bootSessions    = "sessions"
+	bootRepos       = "repos"
+	bootForge       = "forge"
+	bootDispatchers = "dispatchers"
+	bootProducts    = "products"
+	bootBacklog     = "backlog"
+	bootDecisions   = "decisions"
+	bootUsage       = "usage"
+	bootVelocity    = "velocity"
+	bootStale       = "stale"
+)
+
+// bootSequence is the POST list, in the order loadSnapshot works through it.
+// Renaming a label is cosmetic; reordering it is a lie, because the screen
+// claims to show what is happening as it happens.
+var bootSequence = []struct{ id, label string }{
+	{bootSupervisor, "SUPERVISOR"},
+	{bootRecords, "DISPATCH RECORDS"},
+	{bootSessions, "LIVE SESSIONS"},
+	{bootRepos, "REPOSITORIES"},
+	{bootForge, "FORGE"},
+	{bootDispatchers, "DISPATCHERS"},
+	{bootProducts, "PRODUCTS"},
+	{bootBacklog, "BACKLOG"},
+	{bootDecisions, "DECISIONS"},
+	{bootUsage, "USAGE"},
+	{bootVelocity, "VELOCITY"},
+	{bootStale, "STALE WORK"},
+}
+
+const (
+	bootPending = iota
+	bootRunning
+	bootDone
+)
+
+// Timing. bootTickEvery paces the spinner and the wordmark's colour sweep.
+//
+// bootMinShow is the one deliberate delay in the cockpit: on a small portfolio
+// the whole load can finish inside 200ms, and a screen that appears and
+// vanishes inside a blink reads as a glitch rather than as a boot. It holds the
+// opening screen up to this long in total — not longer, and any key skips
+// straight past it, so the floor is never a wall.
+const (
+	bootTickEvery   = 90 * time.Millisecond
+	bootReadyLinger = 650 * time.Millisecond
+	bootMinShow     = 1200 * time.Millisecond
+)
+
+// bootChanBuffer is comfortably more than the two updates per step the sequence
+// can produce, so the loader's non-blocking sends never actually drop one in
+// practice while still being unable to stall the load if nobody is listening.
+const bootChanBuffer = 64
+
+// bootUpdate is one step transition, sent from the loader goroutine to the UI.
+// complete=false means the step just started and detail says what it is doing;
+// complete=true means it finished and detail says what it found.
+type bootUpdate struct {
+	id       string
+	detail   string
+	warn     bool
+	complete bool
+}
+
+// bootReport is loadSnapshot's channel back to the opening screen. A nil
+// reporter is the normal case — every refresh after the first has no screen to
+// report to — so both methods are nil-safe and the collectors never branch.
+type bootReport func(bootUpdate)
+
+// begin marks a step as running, with what it is about to do.
+func (r bootReport) begin(id, doing string) {
+	if r != nil {
+		r(bootUpdate{id: id, detail: doing})
+	}
+}
+
+// done marks a step finished, with what it found. warn says the step's source
+// was unavailable, so its figure is an absence rather than a count.
+func (r bootReport) done(id, found string, warn bool) {
+	if r != nil {
+		r(bootUpdate{id: id, detail: found, warn: warn, complete: true})
+	}
+}
+
+// bootStep is one line of the sequence as the screen holds it.
+type bootStep struct {
+	id, label string
+	state     int
+	detail    string
+	warn      bool
+	started   time.Time
+	elapsed   time.Duration
+}
+
+// bootState is the opening screen. It lives behind a pointer on the model so
+// the loader's updates survive Bubble Tea's value-copied model.
+type bootState struct {
+	steps   []bootStep
+	frame   int
+	started time.Time
+	ready   bool
+}
+
+func newBootState() *bootState {
+	steps := make([]bootStep, len(bootSequence))
+	for i, d := range bootSequence {
+		steps[i] = bootStep{id: d.id, label: d.label}
+	}
+	return &bootState{steps: steps, started: time.Now()}
+}
+
+// apply folds one update into the sequence. An id nothing matches is dropped:
+// the screen shows the steps it knows about and never grows a row mid-boot.
+func (b *bootState) apply(u bootUpdate) {
+	for i := range b.steps {
+		s := &b.steps[i]
+		if s.id != u.id {
+			continue
+		}
+		s.detail, s.warn = u.detail, u.warn
+		if u.complete {
+			s.state = bootDone
+			if !s.started.IsZero() {
+				s.elapsed = time.Since(s.started)
+			}
+		} else {
+			s.state = bootRunning
+			s.started = time.Now()
+		}
+		return
+	}
+}
+
+// finish is called when the snapshot lands. Any step still pending is marked
+// done without a figure — the load is over, so a spinner left turning would be
+// claiming work that is not happening. It returns the tick that hands the
+// terminal to the cockpit.
+func (b *bootState) finish() tea.Cmd {
+	if b.ready {
+		return nil // a second snapshot arrived before the linger elapsed
+	}
+	for i := range b.steps {
+		if b.steps[i].state == bootDone {
+			continue
+		}
+		// The step ran — the snapshot it contributed to is here — but its
+		// report never reached the screen. Say that, rather than leave a tick
+		// beside a blank where every other line carries a figure.
+		b.steps[i].state = bootDone
+		b.steps[i].detail = "—"
+		b.steps[i].elapsed = 0
+	}
+	b.ready = true
+	return tea.Tick(b.linger(), func(time.Time) tea.Msg { return bootDoneMsg{} })
+}
+
+// linger is how long READY stays up: long enough for the whole screen to have
+// been visible for bootMinShow, and never less than a beat on READY itself.
+func (b *bootState) linger() time.Duration {
+	d := bootMinShow - time.Since(b.started)
+	if d < bootReadyLinger {
+		d = bootReadyLinger
+	}
+	return d
+}
+
+// progress counts finished steps against the whole sequence.
+func (b *bootState) progress() (done, total int) {
+	for _, s := range b.steps {
+		if s.state == bootDone {
+			done++
+		}
+	}
+	return done, len(b.steps)
+}
+
+// active is the index of the step the loader is on — the running one, or the
+// last one to finish. It is what the screen scrolls to keep in view.
+func (b *bootState) active() int {
+	last := 0
+	for i, s := range b.steps {
+		if s.state == bootRunning {
+			return i
+		}
+		if s.state == bootDone {
+			last = i
+		}
+	}
+	return last
+}
+
+func bootTick() tea.Cmd {
+	return tea.Tick(bootTickEvery, func(time.Time) tea.Msg { return bootTickMsg{} })
+}

--- a/internal/cockpit/boot_test.go
+++ b/internal/cockpit/boot_test.go
@@ -61,6 +61,32 @@ func TestLoadSnapshotIgnoresNilReporter(t *testing.T) {
 	}
 }
 
+// TestBootLoadCmdReportsThenCloses covers the loader command end to end: it
+// produces the same snapshot as any other load, it fills the channel on the
+// way, and it closes it afterwards so the last waitBoot is released rather
+// than parked on a channel nothing will ever send to again.
+func TestBootLoadCmdReportsThenCloses(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	defer restoreVars(captureVars())
+
+	ch := make(chan bootUpdate, bootChanBuffer)
+	msg := bootLoadCmd(&config.Config{}, ch)()
+	if snapshot(msg.(snapshotMsg)).dataMode != "live" {
+		t.Error("bootLoadCmd did not produce a live snapshot")
+	}
+
+	n := 0
+	for range ch { // ranges to completion only if the channel was closed
+		n++
+	}
+	if n == 0 {
+		t.Error("bootLoadCmd reported nothing to the opening screen")
+	}
+	if got := waitBoot(ch)(); got != nil {
+		t.Errorf("waitBoot on a closed channel = %#v, want nil", got)
+	}
+}
+
 // TestBootScreenRendersAtEverySize sweeps the sizes the screen has to survive:
 // a wide terminal, the classic 80×24, and one too small for the wordmark.
 func TestBootScreenRendersAtEverySize(t *testing.T) {

--- a/internal/cockpit/boot_test.go
+++ b/internal/cockpit/boot_test.go
@@ -1,0 +1,231 @@
+package cockpit
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/config"
+)
+
+// bootAt returns a model showing the opening screen at the given terminal size.
+func bootAt(w, h int) model {
+	m := newModel()
+	m.width, m.height = w, h
+	// Mirrors what Run does when a config loads: the screen goes up, and the
+	// cockpit behind it is loading until the snapshot lands.
+	m.loading = true
+	m.boot = newBootState()
+	m.bootCh = make(chan bootUpdate, bootChanBuffer)
+	return m
+}
+
+// TestBootSequenceCoversEveryReportedStep is the guard that keeps the screen
+// honest: every id loadSnapshotReporting reports against must have a line to
+// land on, and every line must have something reporting into it. A step drawn
+// on screen that nothing ever fills would sit at pending until finish() swept
+// it, which reads as work that never happened.
+func TestBootSequenceCoversEveryReportedStep(t *testing.T) {
+	// An empty state dir and an empty config give a portfolio with no records
+	// and no roots, so every stage runs and reports without touching the
+	// developer's own dispatches. The reporter is called from
+	// loadSnapshotReporting's own goroutine, in order, so the map needs no
+	// guarding.
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	defer restoreVars(captureVars())
+
+	seen := map[string]bool{}
+	loadSnapshotReporting(&config.Config{}, func(u bootUpdate) { seen[u.id] = true })
+
+	for _, s := range bootSequence {
+		if !seen[s.id] {
+			t.Errorf("step %q is drawn on the opening screen but nothing reports it", s.id)
+		}
+		delete(seen, s.id)
+	}
+	for id := range seen {
+		t.Errorf("loadSnapshotReporting reports %q, which no boot step draws", id)
+	}
+}
+
+// TestLoadSnapshotIgnoresNilReporter checks the ordinary refresh path: no
+// screen, no reporter, and the nil-safe methods must not panic.
+func TestLoadSnapshotIgnoresNilReporter(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	defer restoreVars(captureVars())
+
+	if s := loadSnapshot(&config.Config{}); s.dataMode != "live" {
+		t.Errorf("dataMode = %q, want live", s.dataMode)
+	}
+}
+
+// TestBootScreenRendersAtEverySize sweeps the sizes the screen has to survive:
+// a wide terminal, the classic 80×24, and one too small for the wordmark.
+func TestBootScreenRendersAtEverySize(t *testing.T) {
+	sizes := [][2]int{{190, 50}, {120, 40}, {80, 24}, {60, 16}, {40, 10}}
+	for _, sz := range sizes {
+		w, h := sz[0], sz[1]
+		m := bootAt(w, h)
+		m.boot.apply(bootUpdate{id: bootRepos, detail: "scanning 3 roots…"})
+		out := m.View()
+		if strings.TrimSpace(out) == "" {
+			t.Fatalf("%dx%d: empty render", w, h)
+		}
+		if got := strings.Count(out, "\n") + 1; got > h {
+			t.Errorf("%dx%d: render is %d lines, exceeds height", w, h, got)
+		}
+		for i, ln := range strings.Split(out, "\n") {
+			if got := dispWidth(ln); got > w {
+				t.Errorf("%dx%d: line %d is %d columns wide", w, h, i, got)
+			}
+		}
+	}
+}
+
+// TestBootScreenScrollsToTheActiveStep checks the shrink behaviour: a terminal
+// that cannot hold the whole sequence must still be showing the step being
+// worked on, which is the only line that says work is happening.
+func TestBootScreenScrollsToTheActiveStep(t *testing.T) {
+	m := bootAt(80, 18)
+	for _, s := range bootSequence {
+		m.boot.apply(bootUpdate{id: s.id, detail: "working…"})
+		if out := m.View(); !strings.Contains(out, s.label) {
+			t.Errorf("active step %q is off screen at 80x18", s.label)
+		}
+		m.boot.apply(bootUpdate{id: s.id, detail: "done", complete: true})
+	}
+}
+
+// TestBootFinishSettlesEveryStep checks that landing the snapshot leaves no
+// spinner turning, and that a step whose report never arrived says so rather
+// than showing a tick beside a blank.
+func TestBootFinishSettlesEveryStep(t *testing.T) {
+	b := newBootState()
+	b.apply(bootUpdate{id: bootRepos, detail: "57 repos", complete: true})
+	if cmd := b.finish(); cmd == nil {
+		t.Fatal("finish returned no hand-over tick")
+	}
+	if !b.ready {
+		t.Error("finish did not mark the screen ready")
+	}
+	for _, s := range b.steps {
+		if s.state != bootDone {
+			t.Errorf("step %q left at state %d after finish", s.id, s.state)
+		}
+		if s.detail == "" {
+			t.Errorf("step %q finished with no figure beside it", s.id)
+		}
+	}
+	if got := b.finish(); got != nil {
+		t.Error("finish scheduled a second hand-over")
+	}
+}
+
+// TestBootProgressAndLinger covers the two derived figures the screen shows.
+func TestBootProgressAndLinger(t *testing.T) {
+	b := newBootState()
+	b.apply(bootUpdate{id: bootRepos, detail: "57 repos", complete: true})
+	b.apply(bootUpdate{id: bootForge, detail: "github cli", complete: true})
+	done, total := b.progress()
+	if done != 2 || total != len(bootSequence) {
+		t.Errorf("progress = %d/%d, want 2/%d", done, total, len(bootSequence))
+	}
+
+	// A load that finished instantly still holds the screen up to bootMinShow;
+	// one that took longer than that gets the plain READY beat and no more.
+	if got := b.linger(); got > bootMinShow || got < bootReadyLinger {
+		t.Errorf("linger on a fast load = %v, want between %v and %v", got, bootReadyLinger, bootMinShow)
+	}
+	b.started = time.Now().Add(-10 * time.Second)
+	if got := b.linger(); got != bootReadyLinger {
+		t.Errorf("linger on a slow load = %v, want %v", got, bootReadyLinger)
+	}
+}
+
+// TestBootAnyKeySkips checks the offer the screen makes. Skipping leaves the
+// screen, never the load — the snapshot still lands on the cockpit behind it.
+func TestBootAnyKeySkips(t *testing.T) {
+	m := bootAt(120, 40)
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'x'}})
+	if next.(model).boot != nil {
+		t.Fatal("a key press did not retire the opening screen")
+	}
+	if !next.(model).loading {
+		t.Error("skipping the screen must not claim the load is finished")
+	}
+
+	// Ctrl-C is the one key that still means quit rather than skip.
+	m = bootAt(120, 40)
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if next.(model).boot == nil {
+		t.Error("ctrl+c retired the screen instead of quitting")
+	}
+	if cmd == nil {
+		t.Fatal("ctrl+c on the opening screen did not quit")
+	}
+}
+
+// TestBootProgressStopsWhenSkipped checks the goroutine hygiene: once the
+// screen is gone nothing re-subscribes to the loader's channel.
+func TestBootProgressStopsWhenSkipped(t *testing.T) {
+	m := bootAt(120, 40)
+	next, cmd := m.Update(bootProgressMsg{id: bootRepos, detail: "scanning…"})
+	if cmd == nil {
+		t.Fatal("a progress update did not re-subscribe while the screen was up")
+	}
+	if got := next.(model).boot.steps[3].state; got != bootRunning {
+		t.Errorf("REPOSITORIES state = %d, want running", got)
+	}
+
+	m.boot = nil
+	if _, cmd := m.Update(bootProgressMsg{id: bootRepos}); cmd != nil {
+		t.Error("a progress update re-subscribed after the screen was retired")
+	}
+	if _, cmd := m.Update(bootTickMsg{}); cmd != nil {
+		t.Error("the animation kept ticking after the screen was retired")
+	}
+}
+
+// TestSnapshotRetiresTheOpeningScreen walks the hand-over: the snapshot lands,
+// the sequence settles, and bootDoneMsg puts the cockpit on screen.
+func TestSnapshotRetiresTheOpeningScreen(t *testing.T) {
+	m := bootAt(120, 40)
+	next, cmd := m.Update(snapshotMsg(snapshot{dataMode: "live"}))
+	mm := next.(model)
+	if mm.loading {
+		t.Error("snapshotMsg should clear loading")
+	}
+	if mm.boot == nil || !mm.boot.ready {
+		t.Fatal("snapshotMsg did not settle the opening screen")
+	}
+	if cmd == nil {
+		t.Fatal("snapshotMsg did not schedule the hand-over")
+	}
+	if out := mm.View(); !strings.Contains(out, "PRESS ANY KEY") {
+		t.Error("a settled opening screen does not offer the way past it")
+	}
+
+	next, _ = mm.Update(bootDoneMsg{})
+	if next.(model).boot != nil {
+		t.Fatal("bootDoneMsg did not retire the opening screen")
+	}
+	// The cockpit is what renders now — its lens bar is the proof.
+	if out := next.(model).View(); !strings.Contains(out, "dispatch") {
+		t.Error("the cockpit did not take over after the opening screen")
+	}
+}
+
+// TestBootOnlyRunsForTheFirstLoad checks that the screen belongs to the first
+// load alone: a plain model never carries one, and never renders one.
+func TestBootOnlyRunsForTheFirstLoad(t *testing.T) {
+	if newModel().boot != nil {
+		t.Error("a plain model should not carry an opening screen")
+	}
+	m := newModel()
+	m.width, m.height = 80, 24
+	if out := m.View(); strings.Contains(out, "SUPERVISOR") {
+		t.Error("the opening screen rendered without one being started")
+	}
+}

--- a/internal/cockpit/boot_view.go
+++ b/internal/cockpit/boot_view.go
@@ -1,0 +1,233 @@
+package cockpit
+
+// boot_view.go draws the opening screen: a block wordmark over a POST list of
+// the load's real stages, a progress meter and the way past it.
+//
+// The reference is a 90s console boot — chunky letters, a colour sweep, a
+// diagnostic list ticking off with times beside it, "press any key". What keeps
+// it honest is that the list is loadSnapshot's actual stages reporting as they
+// run, and the times are measured, not scripted.
+
+import (
+	"strconv"
+	"strings"
+
+	"claude-dispatcher/internal/version"
+)
+
+// bootLeader is the dotted rail between a step's label and its figure. It has
+// to read as texture at a glance and never compete with the figure itself, so
+// it sits between cRule (a border, invisible as type) and cFaint (which the
+// footer already uses for real words).
+const bootLeader = "#243244"
+
+// bootRamp is the wordmark's vertical gradient, violet at the top through to
+// the cyan the cockpit uses for anything in flight. While the load is running
+// the ramp is offset by the frame so the colour sweeps down the letters; on
+// READY it settles.
+var bootRamp = []string{"#a78bfa", "#8ba3fb", "#6ebcf5", "#4ac8f2", "#22d3ee"}
+
+// bootFont is a 5-row block face, 6 columns per letter with 2-column stems, for
+// the eight letters the wordmark needs. Wider stems are what make it read as a
+// console logo rather than as ASCII art.
+var bootFont = map[rune][5]string{
+	'D': {"█████ ", "██  ██", "██  ██", "██  ██", "█████ "},
+	'I': {"██████", "  ██  ", "  ██  ", "  ██  ", "██████"},
+	'S': {"██████", "██    ", "██████", "    ██", "██████"},
+	'P': {"██████", "██  ██", "██████", "██    ", "██    "},
+	'A': {"██████", "██  ██", "██████", "██  ██", "██  ██"},
+	'T': {"██████", "  ██  ", "  ██  ", "  ██  ", "  ██  "},
+	'C': {"██████", "██    ", "██    ", "██    ", "██████"},
+	'H': {"██  ██", "██  ██", "██████", "██  ██", "██  ██"},
+}
+
+const (
+	bootWord      = "DISPATCH"
+	bootFontRows  = 5
+	bootWordWidth = len(bootWord)*6 + (len(bootWord) - 1) // letters plus 1-col gaps
+	bootMaxWidth  = 84                                    // the block never sprawls on a wide terminal
+	bootLabelW    = 18                                    // where the dotted rail starts
+	bootMeterW    = 56                                    // the meter is a gauge, not a horizon
+
+	// bootMinSteps is how much of the sequence has to stay visible for the big
+	// wordmark to be worth its five rows. Below it the compact mark takes over:
+	// the list is the part carrying information, and a logo that squeezes it to
+	// three lines has the priority backwards.
+	bootMinSteps = 5
+)
+
+// viewBoot renders the whole opening screen into w×h.
+func (m model) viewBoot(w, h int) string {
+	b := m.boot
+	if b == nil {
+		return ""
+	}
+	inner := mini(maxi(w-2*pad, 1), bootMaxWidth)
+	foot := bootFoot(b, inner)
+
+	// The big wordmark needs the columns to hold it and enough rows left over
+	// for the sequence to still be worth reading. Everything below the list is
+	// fixed, so whatever the head and foot leave is the list's — and when that
+	// is less than the whole sequence the list scrolls to keep the step being
+	// worked on in view.
+	head := bootHead(b, inner, inner >= bootWordWidth)
+	budget := h - len(head) - len(foot)
+	if budget < bootMinSteps {
+		head = bootHead(b, inner, false)
+		budget = h - len(head) - len(foot)
+	}
+	steps := bootStepLines(b, inner, maxi(budget, 1))
+
+	body := append(append(head, steps...), foot...)
+
+	// Centre the block vertically, then place it at a common left margin so the
+	// rule, the rail and the meter all share one edge.
+	left := strings.Repeat(" ", maxi((w-inner)/2, 0))
+	out := make([]string, 0, h)
+	for i := 0; i < maxi((h-len(body))/2, 0); i++ {
+		out = append(out, "")
+	}
+	for _, ln := range body {
+		if ln == "" {
+			out = append(out, "") // no line is padded out to trailing whitespace
+			continue
+		}
+		out = append(out, left+ln)
+	}
+	if len(out) > h {
+		out = out[:h]
+	}
+	return strings.Join(out, "\n")
+}
+
+// bootHead is the wordmark, the product line and the rule above the sequence.
+func bootHead(b *bootState, inner int, big bool) []string {
+	var out []string
+	if big {
+		for _, r := range bootWordmark(b) {
+			out = append(out, bootCentre(r, inner))
+		}
+		out = append(out, "")
+	} else {
+		out = append(out, bootCentre(fg(bootRamp[0], "⚡ D I S P A T C H"), inner), "")
+	}
+
+	// The build is named here rather than in the sequence: which supervisor and
+	// which forge are findings the load reports, but which binary is running is
+	// known before a single step has run.
+	out = append(out, bootCentre(fg(cDim, "CLAUDE DISPATCHER ")+fg(cFaint, "· "+version.Display()), inner))
+	out = append(out, "", fg(cRule, strings.Repeat("─", inner)), "")
+	return out
+}
+
+// bootWordmark draws the block letters, one colour per row, sweeping while the
+// load runs and settled once it is done.
+func bootWordmark(b *bootState) []string {
+	rows := make([]string, bootFontRows)
+	for r := 0; r < bootFontRows; r++ {
+		var line strings.Builder
+		for i, ch := range bootWord {
+			if i > 0 {
+				line.WriteString(" ")
+			}
+			g, ok := bootFont[ch]
+			if !ok {
+				continue
+			}
+			line.WriteString(g[r])
+		}
+		shift := 0
+		if !b.ready {
+			shift = b.frame / 3
+		}
+		rows[r] = fg(bootRamp[(r+shift)%len(bootRamp)], line.String())
+	}
+	return rows
+}
+
+// bootStepLines renders the sequence, scrolled so the active step stays in
+// view when the terminal cannot hold all of it.
+func bootStepLines(b *bootState, w, budget int) []string {
+	first := 0
+	if budget < len(b.steps) {
+		// Keep the step being worked on near the bottom, with the next couple
+		// still visible ahead of it — a POST list scrolling under the cursor.
+		first = clampCursor(b.active()-budget+2, len(b.steps)-budget+1)
+	}
+	last := mini(first+budget, len(b.steps))
+	out := make([]string, 0, last-first)
+	for _, s := range b.steps[first:last] {
+		out = append(out, bootStepLine(s, b.frame, w))
+	}
+	return out
+}
+
+// bootSpinner is the running glyph: a quartered block turning once a beat. It
+// is deliberately not the braille spinner the rest of the terminal world uses —
+// this screen is drawn in blocks.
+var bootSpinner = []string{"◐", "◓", "◑", "◒"}
+
+// bootStepLine draws one step: glyph, label, dotted rail, figure, and — once it
+// has finished — how long it took.
+func bootStepLine(s bootStep, frame, w int) string {
+	glyph, lc, dc := fg(cFaint, "·"), cFaint, cFaint
+	switch s.state {
+	case bootRunning:
+		glyph, lc, dc = fg(cBlue, bootSpinner[(frame/2)%len(bootSpinner)]), cWhite, cDim
+	case bootDone:
+		glyph, lc, dc = fg(cGreen, "✓"), cMid, cFg
+		if s.warn {
+			// The step ran and reported an absence. It is not a failure — the
+			// cockpit degrades to fewer signals — but it is the line the human
+			// wants to find later when a lens looks emptier than expected.
+			glyph, lc, dc = fg(cAmber, "!"), cMid, cAmber
+		}
+	}
+
+	lead := maxi(bootLabelW-dispWidth(s.label), 1)
+	left := glyph + " " + fg(lc, s.label) + " " + fg(bootLeader, strings.Repeat("·", lead)) + " " + fg(dc, s.detail)
+
+	left = truncateAnsi(left, w)
+	if s.state != bootDone || s.elapsed <= 0 {
+		return left // nothing to hang on the right edge, so no padding out to it
+	}
+	return flSpread(left, fg(cFaint, bootSecs(s.elapsed.Seconds())), w)
+}
+
+// bootSecs formats a measured duration the way a POST screen does.
+func bootSecs(sec float64) string {
+	return strconv.FormatFloat(sec, 'f', 2, 64) + "s"
+}
+
+// bootFoot is the progress meter and the way past the screen.
+func bootFoot(b *bootState, inner int) []string {
+	done, total := b.progress()
+
+	count := itoa(done) + "/" + itoa(total)
+	barW := mini(maxi(inner-dispWidth(count)-4, 8), bootMeterW)
+
+	fill := cBlue
+	if b.ready {
+		fill = cGreen
+	}
+	meter := bootCentre(fg(cRule, "[")+fg(fill, bar(pct(done, total), barW))+fg(cRule, "]")+"  "+fg(cDim, count), inner)
+
+	// A blink on READY, the way the screen it is quoting did. While the load
+	// runs the hint is steady — it is an offer, not a prompt.
+	hint := fg(cFaint, "press any key to skip")
+	if b.ready {
+		hint = ""
+		if b.frame/5%2 == 0 {
+			hint = fg(cGreen, "▶ ") + fg(cWhite, "PRESS ANY KEY")
+		}
+	}
+	return []string{"", meter, "", bootCentre(hint, inner)}
+}
+
+// bootCentre pads an already-coloured line to sit centred in w columns.
+func bootCentre(s string, w int) string {
+	if d := dispWidth(s); d < w {
+		return strings.Repeat(" ", (w-d)/2) + s
+	}
+	return s
+}

--- a/internal/cockpit/live.go
+++ b/internal/cockpit/live.go
@@ -17,8 +17,10 @@ import (
 	"strings"
 
 	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 	"claude-dispatcher/internal/state"
+	"claude-dispatcher/internal/supervisor"
 )
 
 // snapshot is a full rebuild of every reassignable data var, plus the record
@@ -130,26 +132,144 @@ func (c *collectCtx) forge(repoPath string) string {
 
 // loadSnapshot assembles a full snapshot from the real backends. Each collector
 // fills its own fields; collectors live in collect_*.go.
-func loadSnapshot(cfg *config.Config) snapshot {
-	ctx := &collectCtx{
-		cfg:     cfg,
-		records: state.LoadAll(),
-		repos:   repos.Discover(cfg),
+func loadSnapshot(cfg *config.Config) snapshot { return loadSnapshotReporting(cfg, nil) }
+
+// loadSnapshotReporting is loadSnapshot with the opening screen watching. Every
+// stage announces what it is about to do and then what it found, so the boot
+// sequence is a description of this function rather than a decoration over it.
+// A nil report is the ordinary refresh: no screen, no reporting, same work.
+func loadSnapshotReporting(cfg *config.Config, r bootReport) snapshot {
+	r.begin(bootSupervisor, "looking for "+supervisor.Backend()+"…")
+	if supervisor.Available() {
+		r.done(bootSupervisor, supervisor.Backend(), false)
+	} else {
+		// Without the supervisor there is nothing to attach to or kill; the
+		// cockpit still opens, so this is a warning and not an exit.
+		r.done(bootSupervisor, supervisor.Backend()+" not found", true)
 	}
+
+	r.begin(bootRecords, "reading "+state.DispatchesDir()+"…")
+	records := state.LoadAll()
+	r.done(bootRecords, countOf(len(records), "dispatch", "dispatches"), false)
+
+	r.begin(bootSessions, "asking "+supervisor.Backend()+" what is still running…")
+	live := liveSessions(records)
+	r.done(bootSessions, countOf(live, "session", "sessions")+" live of "+itoa(len(records)), false)
+
+	roots := cfg.ExpandedRoots()
+	r.begin(bootRepos, "scanning "+countOf(len(roots), "root", "roots")+"…")
+	found := repos.Discover(cfg)
+	// No repos with roots configured means the roots point somewhere without
+	// any: an empty cockpit whose cause is worth naming here rather than
+	// leaving the human to infer it from six empty lenses.
+	r.done(bootRepos, countOf(len(found), "repo", "repos"), len(found) == 0)
+
+	r.begin(bootForge, "checking the github cli…")
+	if gh.Available() {
+		r.done(bootForge, "github cli", false)
+	} else {
+		r.done(bootForge, "gh not found — no pr or check signals", true)
+	}
+
+	ctx := &collectCtx{cfg: cfg, records: records, repos: found}
 	var s snapshot
 	s.dataMode = "live"
 	s.discovered = ctx.repos
+
+	r.begin(bootDispatchers, "reading transcripts, diffs and prs…")
 	collectFloor(ctx, &s)
 	// collectFleet must follow collectFloor: it reads the forge, diff and
 	// transcript work that load already did rather than paying for it twice.
 	collectFleet(ctx, &s)
+	r.done(bootDispatchers, countOf(len(s.dispatches), "dispatcher", "dispatchers")+" in flight", false)
+
+	r.begin(bootProducts, "grouping repos by product…")
 	collectProducts(ctx, &s)
+	r.done(bootProducts, countOf(namedProducts(s.products), "product", "products"), false)
+
+	r.begin(bootBacklog, "fetching assigned issues…")
 	collectBacklog(ctx, &s)
+	r.done(bootBacklog, countOf(len(s.backlogTickets), "ticket", "tickets"), false)
+
+	r.begin(bootDecisions, "scanning repos for adrs…")
 	collectDecisions(ctx, &s)
+	r.done(bootDecisions, countOf(countDecisions(s.decisions), "adr", "adrs")+
+		" in "+countOf(len(s.decisionRepoOrder), "repo", "repos"), false)
+
+	r.begin(bootUsage, "totalling this week's tokens…")
 	collectUsage(ctx, &s)
+	r.done(bootUsage, countOf(len(s.usageModels), "model", "models")+" this week", false)
+
+	r.begin(bootVelocity, "measuring what reached production…")
 	collectVelocity(ctx, &s)
+	// Deploys, not len(doraWeeks): the week series is a fixed six-week window
+	// the collector always emits, so its length would report "6 weeks of
+	// history" on a portfolio that has never shipped anything.
+	r.done(bootVelocity, countOf(countDeploys(s.doraWeeks), "deploy", "deploys")+" in 6 weeks", false)
+
+	r.begin(bootStale, "looking for repos nothing is working on…")
 	collectStale(ctx, &s)
+	r.done(bootStale, countOf(len(s.staleRepos), "repo", "repos")+" gone quiet", false)
+
 	return s
+}
+
+// liveSessions counts the recorded dispatches whose supervisor session is still
+// running, from one listing rather than a probe per record.
+//
+// It is read for the opening screen alone. The cockpit's own notion of what is
+// live comes from the records the lifecycle hook writes, and replacing that
+// with a session probe would be a different change with different consequences
+// — a session can outlive the work in it, and the work can outlive a session
+// the human killed by hand.
+func liveSessions(records []*state.Dispatch) int {
+	alive := map[string]bool{}
+	for _, name := range supervisor.Sessions() {
+		alive[name] = true
+	}
+	n := 0
+	for _, rec := range records {
+		if rec.TmuxSession != "" && alive[rec.TmuxSession] {
+			n++
+		}
+	}
+	return n
+}
+
+// namedProducts counts real products, excluding the bucket every unmapped repo
+// is folded into — the same distinction the header's portfolio line makes.
+func namedProducts(ps []product) int {
+	n := 0
+	for _, p := range ps {
+		if p.name != clUnassigned {
+			n++
+		}
+	}
+	return n
+}
+
+// countDecisions totals the ADRs found across every repo that has any.
+func countDecisions(byRepo map[string][]decision) int {
+	n := 0
+	for _, ds := range byRepo {
+		n += len(ds)
+	}
+	return n
+}
+
+// countDeploys totals what reached production across the measured window.
+func countDeploys(weeks []doraWeek) int {
+	n := 0
+	for _, w := range weeks {
+		n += w.deploys
+	}
+	return n
+}
+
+// countOf renders "0 repos" / "1 repo" / "57 repos" — the boot sequence's only
+// figure format, so a zero reads as a counted zero and not as a blank.
+func countOf(n int, one, many string) string {
+	return itoa(n) + " " + plural(n, one, many)
 }
 
 // applySnapshot swaps freshly collected data into the package vars. It runs on

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -43,6 +43,13 @@ type model struct {
 	settings     *settingsState
 	dispatchForm *dispatchForm
 
+	// boot is the opening screen, non-nil only while the first load is running
+	// (and for a beat after it lands). It is a pointer because the loader's
+	// progress has to survive Bubble Tea copying the model on every message.
+	// bootCh is the loader's side of that conversation.
+	boot   *bootState
+	bootCh chan bootUpdate
+
 	// key is the untouched message for the key being handled. Routing is by
 	// name (handleKey takes a string), but text input must come from the
 	// message itself — see typedText in keys.go.
@@ -218,7 +225,16 @@ func (m model) Init() tea.Cmd {
 	if m.cfg == nil {
 		return upgradeCheckCmd() // no config — run on demo seed data
 	}
-	return tea.Batch(loadSnapshotCmd(m.cfg), trackRefreshCmd(m.cfg), waitState(m.stateCh), refreshTick(), upgradeCheckCmd())
+	// The first load is the one with a screen watching it: it reports each
+	// stage as it runs, and the model subscribes for those reports and ticks
+	// the animation. Every later load takes the plain path.
+	load := loadSnapshotCmd(m.cfg)
+	cmds := []tea.Cmd{trackRefreshCmd(m.cfg), waitState(m.stateCh), refreshTick(), upgradeCheckCmd()}
+	if m.boot != nil {
+		load = bootLoadCmd(m.cfg, m.bootCh)
+		cmds = append(cmds, waitBoot(m.bootCh), bootTick())
+	}
+	return tea.Batch(append([]tea.Cmd{load}, cmds...)...)
 }
 
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -230,11 +246,37 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case snapshotMsg:
 		applySnapshot(snapshot(msg))
 		m.loading = false
+		// The load the opening screen was narrating is over: settle the
+		// sequence and start the countdown that hands the terminal over.
+		var boot tea.Cmd
+		if m.boot != nil {
+			boot = m.boot.finish()
+		}
 		// The fleet is rebuilt from the fresh records; fold the user's ordering
 		// and cleared set back onto it before anything renders, then re-key the
 		// cursor onto the row it was on — a rank that changed in this refresh
 		// would otherwise move the selection under the reader's hands.
-		return m.cqReconcile().fleetSync(), nil
+		return m.cqReconcile().fleetSync(), boot
+
+	case bootProgressMsg:
+		// Re-arming only while the screen is up is what stops a skipped boot
+		// leaving a goroutine parked on a channel nobody will read again.
+		if m.boot == nil {
+			return m, nil
+		}
+		m.boot.apply(bootUpdate(msg))
+		return m, waitBoot(m.bootCh)
+
+	case bootTickMsg:
+		if m.boot == nil {
+			return m, nil
+		}
+		m.boot.frame++
+		return m, bootTick()
+
+	case bootDoneMsg:
+		m.boot = nil
+		return m, nil
 
 	case stateChangedMsg:
 		return m, tea.Batch(loadSnapshotCmd(m.cfg), waitState(m.stateCh))
@@ -332,6 +374,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// "PRESS ANY KEY" means any key. The load keeps running underneath —
+		// skipping is leaving the screen, not cancelling the work — so the
+		// cockpit comes up on its own loading state and fills in when the
+		// snapshot lands. Ctrl-C is the one key that still means quit.
+		if m.boot != nil {
+			if msg.String() == "ctrl+c" {
+				return m, tea.Quit
+			}
+			m.boot = nil
+			return m, nil
+		}
 		// Ctrl-L: force a full clear + repaint, the universal "redraw" key —
 		// handy after a tmux attach or any terminal noise garbles the screen.
 		if msg.String() == "ctrl+l" {

--- a/internal/cockpit/refresh.go
+++ b/internal/cockpit/refresh.go
@@ -28,6 +28,12 @@ type (
 	refreshTickMsg struct{}
 	// trackedMsg fires after a track.Refresh pass (PR/deploy reconciliation).
 	trackedMsg struct{}
+	// bootProgressMsg carries one opening-screen step transition to the UI.
+	bootProgressMsg bootUpdate
+	// bootTickMsg paces the opening screen's spinner and colour sweep.
+	bootTickMsg struct{}
+	// bootDoneMsg retires the opening screen and hands over to the cockpit.
+	bootDoneMsg struct{}
 )
 
 // loadSnapshotCmd rebuilds the whole snapshot off the UI goroutine.
@@ -72,6 +78,38 @@ func recheckCmd(cfg *config.Config) tea.Cmd {
 		dispatchpkg.ReconcileSessions(state.LoadAll())
 		track.Refresh(state.LoadAll(), cfg)
 		return snapshotMsg(loadSnapshot(cfg))
+	}
+}
+
+// bootLoadCmd is the first load, narrating itself to the opening screen. The
+// snapshot it produces is identical to loadSnapshotCmd's.
+//
+// Sends are non-blocking over a buffered channel, so a screen that has been
+// skipped — or a UI busy elsewhere — can never hold the load up waiting to be
+// watched. A dropped update costs one line's figure, never a step.
+func bootLoadCmd(cfg *config.Config, ch chan bootUpdate) tea.Cmd {
+	return func() tea.Msg {
+		report := func(u bootUpdate) {
+			select {
+			case ch <- u:
+			default:
+			}
+		}
+		return snapshotMsg(loadSnapshotReporting(cfg, report))
+	}
+}
+
+// waitBoot blocks until the loader reports its next step.
+func waitBoot(ch chan bootUpdate) tea.Cmd {
+	return func() tea.Msg {
+		if ch == nil {
+			return nil
+		}
+		u, ok := <-ch
+		if !ok {
+			return nil
+		}
+		return bootProgressMsg(u)
 	}
 }
 

--- a/internal/cockpit/refresh.go
+++ b/internal/cockpit/refresh.go
@@ -95,11 +95,17 @@ func bootLoadCmd(cfg *config.Config, ch chan bootUpdate) tea.Cmd {
 			default:
 			}
 		}
-		return snapshotMsg(loadSnapshotReporting(cfg, report))
+		s := loadSnapshotReporting(cfg, report)
+		// Every send happens inside the call above, on this goroutine, so the
+		// channel is safe to close here — and closing it is what releases the
+		// waitBoot that would otherwise sit on it for the life of the process.
+		close(ch)
+		return snapshotMsg(s)
 	}
 }
 
-// waitBoot blocks until the loader reports its next step.
+// waitBoot blocks until the loader reports its next step. A closed channel ends
+// the subscription: the load is over and nothing more will be reported.
 func waitBoot(ch chan bootUpdate) tea.Cmd {
 	return func() tea.Msg {
 		if ch == nil {

--- a/internal/cockpit/run.go
+++ b/internal/cockpit/run.go
@@ -50,6 +50,11 @@ func Run() error {
 			}
 		}
 		m.loading = true
+		// The opening screen belongs to the first load and only to it. Without
+		// a config nothing is loaded, so there is nothing to narrate and the
+		// cockpit opens straight onto its "run init" notice.
+		m.boot = newBootState()
+		m.bootCh = make(chan bootUpdate, bootChanBuffer)
 	} else {
 		m.notice = "no config — showing demo data · run `claude-dispatcher init`"
 	}

--- a/internal/cockpit/view.go
+++ b/internal/cockpit/view.go
@@ -26,6 +26,11 @@ func (m model) View() string {
 	if m.width == 0 || m.height == 0 {
 		return "loading…"
 	}
+	// The opening screen owns the whole terminal: no lens bar, no footer. The
+	// cockpit's chrome names keys that do nothing until the data is here.
+	if m.boot != nil {
+		return m.viewBoot(m.width, m.height)
+	}
 	header := m.headerView()
 	bars := m.barsView()
 	footer := m.footerView()

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -13,6 +13,7 @@
 //	Backend() string                         — its name, for messages ("tmux")
 //	NewSession(name, dir, shellCommand) error — start a detached session
 //	HasSession(name) bool                    — is that session still alive
+//	Sessions() []string                      — every live session, in one call
 //	AttachCmd(name) *exec.Cmd                — hand the terminal to it
 //	KillSession(name) error                  — end it
 //	SendKeys(name, text) error               — type text at its prompt + Enter

--- a/internal/supervisor/supervisor_unix.go
+++ b/internal/supervisor/supervisor_unix.go
@@ -14,6 +14,7 @@ import (
 func Available() bool                             { return tmux.Available() }
 func Backend() string                             { return "tmux" }
 func HasSession(name string) bool                 { return tmux.HasSession(name) }
+func Sessions() []string                          { return tmux.ListSessions() }
 func NewSession(name, dir, shellCmd string) error { return tmux.NewSession(name, dir, shellCmd) }
 func AttachCmd(name string) *exec.Cmd             { return tmux.AttachCmd(name) }
 func KillSession(name string) error               { return tmux.KillSession(name) }

--- a/internal/supervisor/supervisor_windows.go
+++ b/internal/supervisor/supervisor_windows.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"syscall"
 
@@ -133,6 +134,27 @@ func HasSession(name string) bool {
 	delete(reg, name)
 	_ = saveRegistry(reg)
 	return false
+}
+
+// Sessions names every tracked process still alive, pruning the ones that have
+// exited in the same pass. It is the whole-registry form of HasSession.
+func Sessions() []string {
+	reg := loadRegistry()
+	var live []string
+	changed := false
+	for name, pid := range reg {
+		if processAlive(pid) {
+			live = append(live, name)
+			continue
+		}
+		delete(reg, name)
+		changed = true
+	}
+	if changed {
+		_ = saveRegistry(reg)
+	}
+	sort.Strings(live)
+	return live
 }
 
 // KillSession terminates name's tracked process tree and drops it from the

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -20,6 +20,25 @@ func HasSession(name string) bool {
 	return exec.Command("tmux", "has-session", "-t", "="+name).Run() == nil
 }
 
+// ListSessions names every live session on the server, in one round trip.
+// HasSession answers the same question for one name, but asking it per record
+// costs a subprocess per dispatch; the opening screen wants the whole picture
+// at once. No server running is not an error — it is zero sessions, which is
+// exactly what a machine with nothing dispatched looks like.
+func ListSessions() []string {
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, ln := range strings.Split(string(out), "\n") {
+		if ln = strings.TrimSpace(ln); ln != "" {
+			names = append(names, ln)
+		}
+	}
+	return names
+}
+
 // NewSession starts a detached session running shellCommand in dir.
 func NewSession(name, dir, shellCommand string) error {
 	out, err := exec.Command("tmux", "new-session", "-d", "-s", name, "-c", dir, shellCommand).CombinedOutput()


### PR DESCRIPTION
The cockpit's first load is not instant. It reads every dispatch record, asks tmux which sessions are still running, walks the scan roots and talks to the forge. On a real portfolio that is tens of seconds — measured on mine, 16.5s for the dispatchers stage alone and longer again for products on a cold `gh` cache — and until now every second of it happened behind an empty frame that reads as "nothing here" rather than "still counting".

## What this adds

An opening screen: a console-boot sequence over that first load.

```
                █████  ██████ ██████ ██████ ██████ ██████ ██████ ██  ██
                ██  ██   ██   ██     ██  ██ ██  ██   ██   ██     ██  ██
                ██  ██   ██   ██████ ██████ ██████   ██   ██     ██████
                ██  ██   ██       ██ ██     ██  ██   ██   ██     ██  ██
                █████  ██████ ██████ ██     ██  ██   ██   ██████ ██  ██

                                CLAUDE DISPATCHER · dev

  ────────────────────────────────────────────────────────────────────────

  ✓ SUPERVISOR ········ tmux                                         0.00s
  ✓ DISPATCH RECORDS ·· 29 dispatches                                0.00s
  ✓ LIVE SESSIONS ····· 18 sessions live of 29                       0.01s
  ✓ REPOSITORIES ······ 58 repos                                     0.00s
  ✓ FORGE ············· github cli                                   0.00s
  ◓ DISPATCHERS ······· reading transcripts, diffs and prs…
  · PRODUCTS ··········
  · BACKLOG ···········

            [██████████████████████░░░░░░░░░░░░░░░░░░░░░░░░]  5/12

                             press any key to skip
```

## How it stays honest

`loadSnapshot` gains a reporter and announces each stage as it starts and what it found when it ends. The screen draws those stages — it is a description of that function, not decoration over it. A nil reporter is the ordinary refresh, so every load after the first takes exactly the path it always did.

- Every figure is what the stage actually found. A missing source says so and goes amber: no `gh`, no `tmux`, roots holding no repos — rather than reporting a zero as if it had looked.
- A test asserts the drawn steps and the reported ids are the same set, so a stage added to the load cannot quietly stop being shown, and a step nothing fills cannot sit on screen pretending to be work.
- The velocity figure counts deploys, not `len(doraWeeks)` — that series is a fixed six-week window, so its length would have claimed "6 weeks of history" on a portfolio that has never shipped anything.

## Getting past it

Any key skips straight to the cockpit and the load carries on behind it; ctrl-c still quits. The one deliberate delay is `bootMinShow` (1.2s), which keeps a fast load's screen from appearing and vanishing inside a blink — and it delays the cockpit, never the data.

Without a config there is no load to narrate, so the cockpit opens straight onto its "run init" notice as before.

## Also

`supervisor` grows `Sessions()`: the whole live-session list in one call rather than a subprocess per record (tmux `list-sessions` on Unix, the PID registry on Windows). It is read for this screen only — what the cockpit treats as live still comes from the records the lifecycle hook writes, because a session can outlive the work in it and the work can outlive a session killed by hand.

## Verification

`make build`, `make vet`, `go test ./...`, `go test -race`, `gofmt`, and `golangci-lint run` are all clean, plus `GOOS=windows` build and vet. Driven for real in tmux at 120×40, 100×30, 80×24 and 60×16: the wordmark gives way to a compact mark when the rows are not there, and the step list scrolls to keep the running stage in view.
