### PR TITLE
A session ending is not a dispatcher disappearing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,11 @@
   `~/.local/state/claude-dispatcher/` (override: `CLAUDE_DISPATCHER_STATE`).
 - `internal/hookcmd` — receives lifecycle hook events, drives the status
   state machine (launching/working/needs-input/blocked/done/exited).
-- `internal/dispatch` — branch + tmux + record creation.
+- `internal/dispatch` — branch + tmux + record creation, and `Resume`: a
+  finished dispatcher's session reopened with `claude --resume <session id>`
+  in its own worktree (rebuilt if it was reclaimed). A session ending never
+  loses a dispatcher — triage's `h` and the product panel's `H` tab list every
+  finished one and resume it.
 - `internal/cockpit` — Bubble Tea cockpit; responsive tiling breakpoints at 110
   and 170 columns (more panes on wide screens, never one ballooned view).
   `boot.go`/`boot_view.go` are the opening screen: a console-boot sequence over

--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ Switch with the number keys. Each lens is a different question about the same fa
 
 **Triage is the whole fleet, ranked.** One table of everything in flight — the dispatchers that want you above the ones getting on with it — and a detail panel for the row under the cursor: what it wants, where it stands, and the keys that answer it. The cursor holds its row across refreshes, so nothing moves under your hands.
 
-**`w` narrows to what is running.** Everything working away unattended, with how long since each one last said anything. Nothing there needs you — which is why it sorts below what does. `f` cycles the other filters.
+**`f` narrows to what is running.** Everything working away unattended, with how long since each one last said anything. Nothing there needs you — which is why it sorts below what does. `f` cycles the other filters too.
 
 ![The fleet filtered to what is running](docs/working.svg)
+
+**`h` is what has already finished.** Shipped, killed, or simply exited — every dispatcher whose session is over, newest first, on the table the live fleet leaves. `enter` resumes one: the worktree comes back if it was reclaimed and the conversation picks up where it stopped, so a session ending is never the end of it.
 
 **With the fleet clear, the same screen becomes the prompt.** Give it a title — that is the branch — then the brief, which wraps for as long as it needs to be, and what "done" means. `tab` moves between the fields; `ctrl+d` dispatches.
 
@@ -70,7 +72,8 @@ Every act the table offers is wired to the live session — the key hints show o
 - **`enter`** attach the tmux session at full fidelity (`Ctrl-\` to come back). Coming back **rechecks** rather than redraws: you have just spent minutes driving that session by hand, so the forge is read again instead of replayed from cache, and any session that died without getting a `SessionEnd` out stops being reported as working
 - **`y`** on a PR waiting to merge: `gh pr merge --squash --auto`, then mark live. Elsewhere it marks the record shipped, and it is hidden entirely when the dispatcher has produced no commits
 - **`x`** kill the session · **`s`** skip to the back of the table · **`u`** undo
-- **`d`** open the prompt · **`f`** / **`w`** filter the table · **`enter` on a backlog ticket** dispatches it
+- **`d`** open the prompt · **`f`** filter the table · **`enter` on a backlog ticket** dispatches it
+- **`h`** the finished dispatchers, and **`enter`** on one resumes its session — `claude --resume` on the same transcript, in the same worktree, so it comes back knowing what it already did
 
 ## Install
 
@@ -196,7 +199,7 @@ claude-dispatcher init     # first run: writes config, scans for repos, installs
 claude-dispatcher            # open the cockpit
 ```
 
-Press `1`–`6` to move between lenses. On triage, `j`/`k` move down the fleet, act on the selected row or `s` to skip it; `f` and `w` filter, `d` opens the prompt. Elsewhere `j`/`k` move and `enter` opens. `:` is the command palette, `?` lists every key, and `,` opens settings.
+Press `1`–`6` to move between lenses. On triage, `j`/`k` move down the fleet, act on the selected row or `s` to skip it; `f` filters, `h` shows what has already finished, `d` opens the prompt. Elsewhere `j`/`k` move and `enter` opens. `:` is the command palette, `?` lists every key, and `,` opens settings.
 
 ## Settings
 
@@ -224,6 +227,7 @@ Anything unmapped is grouped under `unassigned`, which is what a fresh install s
 - Each dispatcher is an interactive `claude` session inside its own tmux session (`disp-<slug>`), started on a `feature/<slug>` branch. Sessions survive cockpit restarts; the cockpit is a stateless viewer over `~/.local/state/claude-dispatcher/`.
 - Status comes from **one** global Claude Code lifecycle hook (installed by `init` into `~/.claude/settings.json`). It maps events to states: working, needs you, blocked, done, exited.
 - Commits are attributed to dispatchers by **provenance** — each dispatch records the SHAs its feature branch produced (base tip at launch → branch tip). No trailers in your git history.
+- **Nothing disappears:** a session that ends — shipped, killed or simply exited — moves to history rather than off the screen. `h` on triage and the product panel's `H` tab both list them, and `enter` resumes one: its worktree is put back if it was reclaimed and `claude --resume` picks the same conversation up where it stopped.
 - **Done means live:** when a PR merges, the tracker watches the repo's deploy workflow (auto-detected by name, or set in `[deploy_workflows]`) and flips the feature to done on a green run. Repos with no deploy workflow count merge as live.
 - The layout is **responsive**: wide terminals tile into three panes, narrower ones collapse to essentials.
 - **It opens on a boot screen.** The first load reads every dispatch record, asks tmux which sessions are still running, scans your roots and talks to the forge — seconds of work on a real portfolio. The opening screen shows each stage ticking off with what it found and how long it took, so the wait is legible instead of blank. Any key skips straight to the cockpit; the load carries on behind it.
@@ -235,7 +239,8 @@ Anything unmapped is grouped under `unassigned`, which is what a fresh install s
 | `1`–`6` | switch lens (triage · products · backlog · usage · decisions · velocity) |
 | `+` | dispatch new work — repo → feature → prompt |
 | `j` / `k` · `g` / `G` | move · first row · last row |
-| `f` | cycle the triage filter (all · wants you · needs a look · running) |
+| `f` | cycle the triage filter (all · wants you · needs a look · running · history) |
+| `h` | history — every dispatcher whose session is over; `enter` resumes one |
 | `enter` | attach the selected dispatcher's tmux session · open what is selected |
 | `y` · `x` · `s` | ship (squash-merge) · kill · skip to the back |
 | `d` · `u` | dispatch · put back the last thing you cleared |

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -39,9 +39,19 @@ func (m model) attach(feature string) (model, tea.Cmd) {
 		m.notice = "no live tmux session for \"" + feature + "\""
 		return m, nil
 	}
+	return m.attachSession(rec.TmuxSession)
+}
+
+// attachSession hands the terminal to a named session. attach resolves a
+// feature to one; a resume has just started one and knows its name directly.
+func (m model) attachSession(name string) (model, tea.Cmd) {
+	if name == "" || !supervisor.HasSession(name) {
+		m.notice = "no live session to attach to"
+		return m, nil
+	}
 	supervisor.EnsureBackKey()
 	supervisor.EnsureFocusEvents()
-	supervisor.SetStatusHint(rec.TmuxSession)
+	supervisor.SetStatusHint(name)
 	// Whether this command's exit means "they are back" depends on how the
 	// handover works. A plain attach owns the terminal until they detach, so it
 	// exits on the way home. A switch-client (inside tmux) or a raised console
@@ -50,7 +60,7 @@ func (m model) attach(feature string) (model, tea.Cmd) {
 	// they are away and let that close the loop. See the attachReturnedMsg and
 	// tea.FocusMsg cases in model.go.
 	m.away = supervisor.AttachSwitches()
-	return m, tea.ExecProcess(supervisor.AttachCmd(rec.TmuxSession), func(err error) tea.Msg {
+	return m, tea.ExecProcess(supervisor.AttachCmd(name), func(err error) tea.Msg {
 		return attachReturnedMsg{err: err}
 	})
 }
@@ -157,6 +167,44 @@ type launchedMsg struct {
 	feature string
 	notice  string
 	failed  bool
+}
+
+// resumedMsg carries a finished dispatcher's resume back to the UI: the notice
+// to show, and the session to hand the terminal to when one was started.
+// Attaching cannot happen inside the command itself — only Update may return
+// tea.ExecProcess — so the command reports and Update does the handover.
+type resumedMsg struct {
+	notice  string
+	session string
+}
+
+// resumeCmd reopens a finished dispatcher's Claude session, with prompt as the
+// first thing said to it when there is one.
+//
+// The record is addressed by id, not by feature: a feature name can belong to
+// several finished dispatchers (re-dispatching a shipped feature is normal, and
+// deliberately reuses the name), so the feature map would resolve the wrong one.
+func resumeCmd(id, prompt string) tea.Cmd {
+	return func() tea.Msg {
+		rec := recordByID(id)
+		if rec == nil {
+			return actionMsg{notice: "no dispatch record to resume"}
+		}
+		mode, session, err := dispatchpkg.Resume(rec, strings.TrimSpace(prompt))
+		if err != nil {
+			return actionMsg{notice: "resume failed: " + err.Error()}
+		}
+		if mode == dispatchpkg.ResumeLive {
+			return resumedMsg{
+				notice:  "\"" + rec.Feature + "\" is still running — attaching to it",
+				session: session,
+			}
+		}
+		return resumedMsg{
+			notice:  "resumed \"" + rec.Feature + "\" in " + rec.RepoName,
+			session: session,
+		}
+	}
 }
 
 // launchCmd dispatches a new feature into repoName with prompt.

--- a/internal/cockpit/collect_products.go
+++ b/internal/cockpit/collect_products.go
@@ -162,6 +162,7 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 	s.productNote = map[string]string{}
 	s.productStats = map[string]productStat{}
 	s.shipped = map[string][]shippedDay{}
+	s.productHistory = map[string][]historyItem{}
 	s.productVelocity = map[string][]velTile{}
 	s.team = map[string][]teamRow{}
 	s.teamVerdict = map[string]string{}
@@ -184,8 +185,34 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 			t  time.Time
 		}
 		shipGroups := map[time.Time][]shipEntry{}
+		// Every finished dispatcher in this product, shipped or not — see
+		// historyItem for why the ship log cannot stand in for it.
+		type histEntry struct {
+			it historyItem
+			t  time.Time
+		}
+		var hist []histEntry
 
 		for _, rec := range recs {
+			if rec.Status == state.StatusDone || rec.Status == state.StatusExited {
+				pr := ""
+				if rec.PRNumber > 0 {
+					pr = "#" + itoa(rec.PRNumber)
+				}
+				hist = append(hist, histEntry{
+					it: historyItem{
+						id:      rec.ID,
+						feature: rec.Feature,
+						repo:    rec.RepoName,
+						pr:      pr,
+						at:      prodAge(rec.UpdatedAt) + " ago",
+						ended:   cqEnded(rec),
+						session: rec.SessionID,
+						prompt:  rec.Prompt,
+					},
+					t: rec.UpdatedAt,
+				})
+			}
 			if rec.Status != state.StatusDone && rec.Status != state.StatusExited {
 				inflight++
 			}
@@ -226,6 +253,7 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 			}
 			shipGroups[key] = append(shipGroups[key], shipEntry{
 				it: shippedItem{
+					id:       rec.ID,
 					feature:  rec.Feature,
 					repo:     rec.RepoName,
 					pr:       pr,
@@ -356,6 +384,19 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 			shippedDays = append(shippedDays, shippedDay{day: prodDayLabel(k, now), items: items})
 		}
 		s.shipped[p] = shippedDays
+
+		// ---- history (every finished session, newest first) -----------------
+		sort.Slice(hist, func(i, j int) bool {
+			if !hist[i].t.Equal(hist[j].t) {
+				return hist[i].t.After(hist[j].t)
+			}
+			return hist[i].it.id < hist[j].it.id
+		})
+		items := make([]historyItem, 0, len(hist))
+		for _, h := range hist {
+			items = append(items, h.it)
+		}
+		s.productHistory[p] = items
 
 		// ---- velocity tiles ------------------------------------------------
 		deploys7 := 0

--- a/internal/cockpit/cq.go
+++ b/internal/cockpit/cq.go
@@ -263,6 +263,23 @@ func cqClashNote(rec *state.Dispatch, clash *cqClash) string {
 // the dispatch form).  Attaching is the honest answer to all of them: it hands
 // you the session where the prompt actually is.
 func cqActs(rec *state.Dispatch, kind string) []cqAct {
+	// A finished dispatcher has no session to attach to and nothing left to
+	// approve or kill. What it has is a transcript, so ⏎ resumes it — and the
+	// act keeps its row, because until the resumed session reports in, the
+	// record it was fired on is still a finished one.
+	if kind == "past" {
+		acts := []cqAct{
+			{k: "⏎", d: "resume", ok: "resuming \"" + rec.Feature + "\"…", keep: true},
+		}
+		if rec.PRNumber > 0 {
+			// No forge is threaded in here, so the flash names the feature rather
+			// than a "#123" that would be wrong on azure devops. The row's REF
+			// cell already carries the id in the right notation (cqRef).
+			acts = append(acts, cqAct{k: "o", d: "open pr",
+				ok: "opening the pull request for \"" + rec.Feature + "\"…", keep: true})
+		}
+		return acts
+	}
 	acts := []cqAct{
 		{k: "⏎", d: "attach", ok: "attaching to " + rec.RepoName + " session…", keep: true},
 	}

--- a/internal/cockpit/cq_keys.go
+++ b/internal/cockpit/cq_keys.go
@@ -26,7 +26,21 @@ type cqUndoEntry struct{ id, label string }
 // because `d` opened it, or because nothing is in flight and there is nothing
 // else to do.
 func (m model) cqPromptOn() bool {
-	return m.cqFlash == "" && (m.cqDispatch || len(m.fleetAll()) == 0)
+	return m.cqFlash == "" && m.cqFormOn()
+}
+
+// cqFormOn is whether the dispatch form is the screen — because `d` opened it,
+// or because there is nothing in flight to show instead.
+//
+// The history table is exempt: with nothing in flight the form would otherwise
+// cover it and own the keyboard, so the one screen that exists to reach
+// finished dispatchers could never be worked once the fleet emptied — which is
+// exactly when the human goes looking for it.
+func (m model) cqFormOn() bool {
+	if m.fleetFilter() == fleetHistory {
+		return false
+	}
+	return m.cqDispatch || len(m.fleetAll()) == 0
 }
 
 // fleetSync keeps the cursor on the row it was on.
@@ -119,7 +133,15 @@ func (m model) cqReconcile() model {
 func (m model) cqRun(r fleetRow, a cqAct) (model, tea.Cmd) {
 	switch a.k {
 	case "⏎":
+		// On a history row ⏎ means resume: there is no live session to attach
+		// to, and the record is addressed by id because a feature name can
+		// belong to several finished dispatchers.
+		if r.kind == "past" {
+			return m, resumeCmd(r.id, "")
+		}
 		return m.attach(r.feature)
+	case "o":
+		return m, openPRCmd(r.repo, r.ref)
 	case "y":
 		// On a review row y means "merge it", which is a real squash-merge on
 		// the forge; everywhere else it only marks the record done.
@@ -208,7 +230,12 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 		// flight (where the form is already up), and the repo list silently
 		// narrowed to the repos containing "d" while nothing appeared to happen.
 		// Falling through re-opens the form, which on an untouched one is a no-op.
-		navKey := isLensDigit(k) || k == ":" || k == "d"
+		// `h` joins that set for the same reason `d` is in it: it is the key that
+		// leaves this form for the history table, and swallowing it would type an
+		// "h" into the repo filter instead — with nothing in flight, the form is
+		// always up, so `h` would be unreachable exactly when history is the only
+		// thing left to look at.
+		navKey := isLensDigit(k) || k == ":" || k == "d" || k == "h"
 		if m.dxTouched() || !navKey {
 			mm, cmd := m.dxKey(k)
 			return mm, cmd, true
@@ -226,7 +253,21 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 		return m.fleetTo(len(m.fleetRows()) - 1), nil, true
 	case "f":
 		return m.fleetSetFilter(fleetNextFilter(m.fleetFilter())), nil, true
+	case "h":
+		// A toggle, not a step in the cycle: history is where you go to fetch one
+		// thing back, and the way out of it is the key that got you in. It closes
+		// the dispatch form on the way, which is what was covering the table.
+		if m.fleetFilter() == fleetHistory {
+			return m.fleetSetFilter(fleetFilters[0]), nil, true
+		}
+		return m.dxReset().fleetSetFilter(fleetHistory), nil, true
 	case "d":
+		// Dispatching leaves history behind: the form is drawn over the fleet,
+		// never over the history table, so opening it there would set a form up
+		// that nothing renders.
+		if m.fleetFilter() == fleetHistory {
+			m = m.fleetSetFilter(fleetFilters[0])
+		}
 		return m.dxOpen(""), nil, true
 	}
 

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -58,6 +58,20 @@ func installFleetFixture(t *testing.T) {
 			},
 			moved: now.Add(-6 * time.Second), waited: now.Add(-6 * time.Second),
 		},
+		{
+			// History: a session that is over. It is in the same collected slice
+			// as the live rows and out of the live table — only `h` and the
+			// history filter show it, and ⏎ on it resumes rather than attaches.
+			id: "id-four", kind: "past", rank: fleetPastRank, product: "alpha",
+			feature: "four", repo: "alpha-api", ref: "#4", pass: 3,
+			signal: "merged", tone: "normal", why: "Session ended.",
+			goal: "ship the fourth thing", goalLabel: "prompt",
+			acts: []cqAct{
+				{k: "⏎", d: "resume", ok: "resuming \"four\"…", keep: true},
+				{k: "o", d: "open pr", ok: "opening the pull request for \"four\"…", keep: true},
+			},
+			moved: now.Add(-3 * time.Hour), waited: now.Add(-3 * time.Hour),
+		},
 	}
 	cqLastOutput = "6s"
 }
@@ -231,14 +245,17 @@ func TestFleetCursorFollowsItsRowAcrossARebuild(t *testing.T) {
 	}
 }
 
-// `f` walks the four filters and comes back round; each one narrows to a real
-// question, and the cursor starts again at the top of what is left.
+// `f` walks the filters and comes back round; each one narrows to a real
+// question, and the cursor starts again at the top of what is left. History is
+// the last stop and the one that is not a narrowing at all: it swaps the live
+// table for the finished dispatchers, which no other filter shows.
 func TestFleetFilterCycles(t *testing.T) {
 	m := cqModel(t)
 	want := []struct{ filter, rows string }{
 		{"wants you", "one,two"},
 		{"needs a look", "one,two"},
 		{"running", "three"},
+		{fleetHistory, "four"},
 		{"all", "one,two,three"},
 	}
 	m = press(m, "j") // move off the top so the reset is visible
@@ -480,9 +497,11 @@ func TestCQFooterHelpFollowsTheCursor(t *testing.T) {
 		t.Error("nothing here follows a session without attaching")
 	}
 
-	// On the running row there is nothing to skip and nothing to approve.
+	// On the running row there is nothing to skip and nothing to approve. The
+	// act verbs are joined with " · ", so " y " is the act and "y ·" is any word
+	// that happens to end in one — "h history" among them.
 	onRun := press(press(m, "j"), "j").footerHelp()
-	if strings.Contains(onRun, "s skip") || strings.Contains(onRun, "y ") {
+	if strings.Contains(onRun, "s skip") || strings.Contains(onRun, " y ") {
 		t.Errorf("a running row's verbs = %q", onRun)
 	}
 

--- a/internal/cockpit/data.go
+++ b/internal/cockpit/data.go
@@ -58,6 +58,7 @@ var (
 	team            = map[string][]teamRow{}
 	teamVerdict     = map[string]string{}
 	shipped         = map[string][]shippedDay{}
+	productHistory  = map[string][]historyItem{}
 	productVelocity = map[string][]velTile{}
 )
 

--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -93,7 +93,7 @@ func (m model) dxOpen(filter string) model {
 
 // dxTouched reports whether anything has been typed into the four text fields.
 // It is what decides whether a navigation key is navigation or text: an
-// untouched form is not a trap, so 1–6, ':' and 'w' still leave it, but the
+// untouched form is not a trap, so 1–6, ':', 'd' and 'h' still leave it, but the
 // moment there is a filter or a sentence they are letters again. dxAuto and
 // dxField deliberately do not count — toggling auto or tabbing about is not
 // typing, and must not strand the human on this screen.

--- a/internal/cockpit/fixtures_test.go
+++ b/internal/cockpit/fixtures_test.go
@@ -82,6 +82,14 @@ func installFixture(t *testing.T) {
 			{feature: "two", repo: "alpha-web", pr: "#2", at: "11:00", session: "disp-two", closedBy: "merge", prompt: "do the other thing"},
 		}}},
 	}
+	// History is the wider list: the two shipped features plus the one that was
+	// killed, which the ship log cannot show.
+	productHistory = map[string][]historyItem{
+		"alpha": {
+			{id: "h-1", feature: "three", repo: "alpha-api", ended: "stopped", at: "2h ago", session: "sess-three", prompt: "spike an idea"},
+			{id: "h-2", feature: "one", repo: "alpha-api", pr: "#1", ended: "merged", at: "3h ago", session: "sess-one", prompt: "do the thing"},
+		},
+	}
 	productVelocity = map[string][]velTile{
 		"alpha": {{k: "lead time", v: "2h", band: "high", spark: "▁▂▃"}},
 	}

--- a/internal/cockpit/fleet.go
+++ b/internal/cockpit/fleet.go
@@ -45,8 +45,10 @@ type fleetRow struct {
 	// from the records on every poll and every fsnotify event, and that UI state
 	// has to survive the rebuild.
 	id string
-	// kind is "queue" — it is waiting on you — or "run", it is getting on with
-	// it. rank orders the table and picks the glyph; see fleetRank.
+	// kind is "queue" — it is waiting on you — "run", it is getting on with it,
+	// or "past", its session is over. rank orders the table and picks the glyph;
+	// see fleetRank. Past rows are not part of the in-flight table at all: they
+	// are what `h` and the history filter show, and what resume acts on.
 	kind string
 	rank int
 	// ask classifies what a queue row wants: permission | review | turn-done |
@@ -139,6 +141,14 @@ func collectFleet(ctx *collectCtx, s *snapshot) {
 			if mt.After(lastOut) {
 				lastOut = mt
 			}
+		default:
+			// Everything else is a session that is over: shipped ("live"), or
+			// ended without shipping (floorState ""). Both used to be dropped
+			// here, and a dropped record is a dispatcher the cockpit can never
+			// show again — its transcript, branch and worktree all still exist,
+			// but nothing on any screen could reach them. They are collected as
+			// history rows, kept out of the in-flight table, and resumable.
+			rows = append(rows, fleetPastRow(ctx, passes, rec))
 		}
 	}
 
@@ -165,7 +175,14 @@ func collectFleet(ctx *collectCtx, s *snapshot) {
 // The design's other rank-2 trigger, thrash, is not implemented and must not
 // be: it needs a check result sampled twice over time, and gh.Checks is a point
 // sample. See cqShipDetail.
+//
+// Rank 4 is history. It is below every live row and never shares a table with
+// one, so it needs no glyph or colour of its own: both fall through to the
+// rank-3 defaults, and the SIGNAL cell says how the session ended.
 func fleetRank(kind, tone string, stalled bool) int {
+	if kind == "past" {
+		return fleetPastRank
+	}
 	if kind == "queue" {
 		if tone == "red" {
 			return 0
@@ -192,6 +209,15 @@ func fleetSort(rows []fleetRow) {
 		a, b := rows[i], rows[j]
 		if a.rank != b.rank {
 			return a.rank < b.rank
+		}
+		if a.kind == "past" {
+			// History reads the other way round from the live table: the thing
+			// that just ended is the one you are most likely to want back, so the
+			// newest sits at the top.
+			if !a.moved.Equal(b.moved) {
+				return a.moved.After(b.moved)
+			}
+			return a.id < b.id
 		}
 		if a.kind == "queue" {
 			if ua, ub := cqUrgency(a), cqUrgency(b); ua != ub {
@@ -347,6 +373,55 @@ func fleetRunRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 	}, mt
 }
 
+// fleetPastRank is where history sits: below everything alive.
+const fleetPastRank = 4
+
+// fleetPastRow builds a row for a dispatcher whose session is over.
+//
+// It is deliberately the cheapest row of the three. A machine accumulates
+// finished dispatchers forever while the live table stays small, so this pays
+// for no gh request, no diff and no transcript read — one stat for the age, and
+// facts already on the record. That is also why the STAGE cell is left empty:
+// the phase is inferred from a transcript tail (cqPhase), and reading one per
+// finished record on every five-second poll would cost the whole history.
+func fleetPastRow(ctx *collectCtx, passes map[string]int, rec *state.Dispatch) fleetRow {
+	goal, goalLabel := cqGoal(rec)
+	return fleetRow{
+		id:        rec.ID,
+		kind:      "past",
+		rank:      fleetRank("past", "normal", false),
+		product:   ctx.productFor(rec),
+		feature:   rec.Feature,
+		repo:      rec.RepoName,
+		ref:       cqRef(ctx.forge(rec.RepoPath), rec),
+		pass:      passes[rec.ID],
+		signal:    cqEnded(rec),
+		tone:      "normal",
+		why:       cqSentence(rec.StatusReason),
+		goal:      goal,
+		goalLabel: goalLabel,
+		acts:      cqActs(rec, "past"),
+		moved:     fleetMoved(rec),
+		waited:    rec.UpdatedAt,
+	}
+}
+
+// cqEnded is how a finished dispatcher finished, in the SIGNAL cell's width. It
+// reports the furthest point its work actually reached — deployed over merged
+// over marked — and "stopped" for a session that ended with none of them, which
+// is the honest word for both a kill and a plain exit.
+func cqEnded(rec *state.Dispatch) string {
+	switch {
+	case rec.DeployedAt != nil:
+		return "deployed"
+	case rec.PRState == "MERGED":
+		return "merged"
+	case rec.Status == state.StatusDone:
+		return "marked shipped"
+	}
+	return "stopped"
+}
+
 // fleetMoved is how long since anything happened to a dispatcher: the freshest
 // of what it last wrote and when the hook last saved it.
 //
@@ -379,9 +454,13 @@ func fleetRepo(repo, product string) string {
 
 // ---- the derived table ------------------------------------------------------------
 
-// fleetFilters is the cycle `f` walks. "all" is the resting state; the other
-// three each narrow to a question the human might be asking.
-var fleetFilters = []string{"all", "wants you", "needs a look", "running"}
+// fleetHistory is the filter that swaps the live table for the finished one.
+const fleetHistory = "history"
+
+// fleetFilters is the cycle `f` walks. "all" is the resting state; the next
+// three each narrow to a question the human might be asking, and the last
+// leaves the fleet entirely for what it used to be — see fleetPast.
+var fleetFilters = []string{"all", "wants you", "needs a look", "running", fleetHistory}
 
 // fleetKeep reports whether a row survives a filter.
 //
@@ -396,8 +475,10 @@ func fleetKeep(filter string, r fleetRow) bool {
 		return r.rank <= 2
 	case "running":
 		return r.kind == "run"
+	case fleetHistory:
+		return r.kind == "past"
 	}
-	return true
+	return r.kind != "past"
 }
 
 // fleetFilter is the active filter, defaulting to "all" so a zero model reads
@@ -409,15 +490,22 @@ func (m model) fleetFilter() string {
 	return m.cqFilter
 }
 
-// fleetAll is the whole table in display order: the ids the user has arranged
-// first, then anything that has arrived since, in the collector's rank order.
-// Rows acted on this session are suppressed until their record actually leaves
-// the fleet — the kill or the merge takes a moment to land, and without this the
-// row the user just cleared would reappear on the next 5s refresh.
+// fleetAll is the in-flight table in display order: the ids the user has
+// arranged first, then anything that has arrived since, in the collector's rank
+// order. Rows acted on this session are suppressed until their record actually
+// leaves the fleet — the kill or the merge takes a moment to land, and without
+// this the row the user just cleared would reappear on the next 5s refresh.
+//
+// History is not in here, and must not be. Every "is anything in flight"
+// question in the cockpit is this function's length — the dispatch form opens
+// on an empty fleet, the headline counts it — and a machine with a month of
+// finished dispatchers would answer all of them wrongly.
 func (m model) fleetAll() []fleetRow {
 	byID := make(map[string]fleetRow, len(fleet))
 	for _, r := range fleet {
-		byID[r.id] = r
+		if r.kind != "past" {
+			byID[r.id] = r
+		}
 	}
 	out := make([]fleetRow, 0, len(fleet))
 	placed := make(map[string]bool, len(fleet))
@@ -428,7 +516,7 @@ func (m model) fleetAll() []fleetRow {
 		}
 	}
 	for _, r := range fleet {
-		if !placed[r.id] && !m.cqSuppressed[r.id] {
+		if r.kind != "past" && !placed[r.id] && !m.cqSuppressed[r.id] {
 			out = append(out, r)
 		}
 	}
@@ -442,9 +530,28 @@ func (m model) fleetAll() []fleetRow {
 	return out
 }
 
-// fleetRows is what the table actually draws: fleetAll narrowed by `f`.
+// fleetPast is the history table: every dispatcher whose session is over,
+// newest first (fleetSort). The user's ordering does not apply — `s` rotates a
+// queue, and there is no queue here — but the suppressed set still does, so a
+// row cleared moments ago does not reappear under `h` while the record catches
+// up.
+func (m model) fleetPast() []fleetRow {
+	out := make([]fleetRow, 0, len(fleet))
+	for _, r := range fleet {
+		if r.kind == "past" && !m.cqSuppressed[r.id] {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// fleetRows is what the table actually draws: fleetAll narrowed by `f`, or the
+// history table when that is what `f` (or `h`) selected.
 func (m model) fleetRows() []fleetRow {
 	f := m.fleetFilter()
+	if f == fleetHistory {
+		return m.fleetPast()
+	}
 	all := m.fleetAll()
 	if f == fleetFilters[0] {
 		return all

--- a/internal/cockpit/fleet_view.go
+++ b/internal/cockpit/fleet_view.go
@@ -211,10 +211,13 @@ func fleetDataLine(w int, cols fleetCols, r fleetRow, on bool) string {
 // Every count is over the FILTERED rows, because the line sits on top of the
 // table and describes what is on it.
 func (m model) fleetHeadline(inner int, rows []fleetRow) string {
-	wants, warn, clean := fleetCount(rows)
 	f := m.fleetFilter()
+	if f == fleetHistory {
+		return m.fleetHistoryHeadline(inner, rows)
+	}
+	wants, warn, clean := fleetCount(rows)
 
-	title, right := itoa(len(rows))+" in flight", "f filters · sorted by urgency"
+	title, right := itoa(len(rows))+" in flight", "f filters · h history · sorted by urgency"
 	if f != fleetFilters[0] {
 		title, right = itoa(len(rows))+" · "+f, "showing "+f+" · f cycles"
 	}
@@ -233,6 +236,22 @@ func (m model) fleetHeadline(inner int, rows []fleetRow) string {
 		fg(warnHex, itoa(warn)+" need a look") + "   " +
 		fg(cFaint, itoa(clean)+" running clean")
 	return flG(flSpread(left, fg(cFaint, right), inner))
+}
+
+// fleetHistoryHeadline is the line above the history table. It answers the two
+// questions history is for — how much of it there is, and how much of it
+// actually shipped — and says the way back, because `h` got you here.
+func (m model) fleetHistoryHeadline(inner int, rows []fleetRow) string {
+	shipped := 0
+	for _, r := range rows {
+		if r.signal != "stopped" {
+			shipped++
+		}
+	}
+	left := fg(cFg, itoa(len(rows))+" finished") + "   " +
+		fg(cFaint, itoa(shipped)+" shipped") + "   " +
+		fg(cFaint, itoa(len(rows)-shipped)+" stopped")
+	return flG(flSpread(left, fg(cFaint, "⏎ resumes one · h back to the fleet"), inner))
 }
 
 // ---- the detail panel -----------------------------------------------------------
@@ -314,8 +333,9 @@ func (m model) viewCQ(w, h int) string {
 	// The gate is the UNFILTERED fleet. The design tests its filtered row count,
 	// so narrowing to `running` with nothing running dropped the human into the
 	// dispatch form and its own "nothing matches this filter" line could never
-	// render.
-	if m.cqDispatch || len(m.fleetAll()) == 0 {
+	// render. cqFormOn also holds the form back on the history filter, which is
+	// a table of its own rather than a narrowing of the fleet.
+	if m.cqFormOn() {
 		return m.cqViewEmpty(w, h)
 	}
 	return m.viewFleet(w, h)
@@ -351,7 +371,11 @@ func (m model) viewFleet(w, h int) string {
 	}
 	layout = cqShed(layout, maxi(1, h-fleetMinRows))
 
-	body := fleetBody(w, cols, rows, sel, maxi(0, h-cqSolid(layout)))
+	empty := "nothing matches this filter"
+	if m.fleetFilter() == fleetHistory {
+		empty = "no dispatcher has finished yet · h goes back to the fleet"
+	}
+	body := fleetBody(w, cols, rows, sel, maxi(0, h-cqSolid(layout)), empty)
 	out := make([]cqRow, 0, len(layout)+len(body))
 	for _, r := range layout {
 		if !r.fill {
@@ -370,16 +394,16 @@ func (m model) viewFleet(w, h int) string {
 // There is no "↑ N more" / "↓ N more" sacrificial row: window() keeps the
 // cursor on screen and j/k move the cursor rather than a scroll offset, so no
 // row is unreachable and none of the height needs spending to say so.
-func fleetBody(w int, cols fleetCols, rows []fleetRow, sel, h int) []string {
+func fleetBody(w int, cols fleetCols, rows []fleetRow, sel, h int, empty string) []string {
 	if h <= 0 {
 		return nil
 	}
 	out := make([]string, 0, h)
 	if len(rows) == 0 {
 		// viewCQ would have shown the dispatch form if the fleet were empty, so
-		// this is the filter — and it says which, rather than reading as
-		// "nothing is running".
-		out = append(out, flG(fg(cFaint, "nothing matches this filter")))
+		// this is the filter — and the caller's line says which, rather than
+		// reading as "nothing is running".
+		out = append(out, flG(fg(cFaint, empty)))
 	}
 	start, end := window(sel, len(rows), h)
 	for i := start; i < end; i++ {
@@ -401,7 +425,7 @@ func fleetBody(w int, cols fleetCols, rows []fleetRow, sel, h int) []string {
 // without attaching to it, so it is not advertised here, in the help sheet or
 // in the key handler.
 func (m model) cqFooterHelp() string {
-	if m.cqDispatch || len(m.fleetAll()) == 0 {
+	if m.cqFormOn() {
 		return m.dxFooterHelp()
 	}
 	parts := make([]string, 0, 8)
@@ -410,6 +434,11 @@ func (m model) cqFooterHelp() string {
 			parts = append(parts, a.k+" "+a.d)
 		}
 	}
-	parts = append(parts, "j/k move", "f filter", "d dispatch", "u undo", "? keys")
+	if m.fleetFilter() == fleetHistory {
+		// No f, no d, no undo: none of them act on a finished dispatcher, and the
+		// footer only names keys that work right now.
+		return strings.Join(append(parts, "j/k move", "h back to the fleet", "? keys"), " · ")
+	}
+	parts = append(parts, "j/k move", "f filter", "h history", "d dispatch", "u undo", "? keys")
 	return strings.Join(parts, " · ")
 }

--- a/internal/cockpit/history_test.go
+++ b/internal/cockpit/history_test.go
@@ -1,0 +1,328 @@
+package cockpit
+
+// history_test.go covers the disappearing-session bug in both places it bit:
+// the triage lens, which collected only what was in flight and dropped every
+// finished record on the floor, and the product panel, whose SHIPPED tab is a
+// ship log and could not see a dispatcher that ended any other way.
+//
+// The through-line of every test here is that a dispatcher is still reachable
+// after its session ends — a record, a branch and a transcript do not stop
+// existing because a turn did — and that the way back into one really resumes
+// it rather than announcing that it did.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/state"
+)
+
+// ---- the collector ----------------------------------------------------------
+
+// collectFleet used to switch on blocked/needs/review/working and drop
+// everything else, so a shipped dispatcher and a killed one both vanished from
+// the cockpit for good.
+func TestCollectFleetKeepsFinishedDispatchers(t *testing.T) {
+	env := buildEnvScenario(t)
+	saved := captureVars()
+	defer restoreVars(saved)
+
+	snap := loadSnapshot(env.cfg)
+	byID := map[string]fleetRow{}
+	for _, r := range snap.fleet {
+		byID[r.id] = r
+	}
+
+	// rec-done shipped (merged + deployed); rec-exited was killed without ever
+	// opening a PR, which is the case floorState dropped entirely.
+	for id, wantSignal := range map[string]string{"rec-done": "deployed", "rec-exited": "stopped"} {
+		r, ok := byID[id]
+		if !ok {
+			t.Fatalf("%s is missing from the fleet — a finished dispatcher the cockpit cannot show is one it has lost", id)
+		}
+		if r.kind != "past" {
+			t.Errorf("%s kind = %q, want past", id, r.kind)
+		}
+		if r.signal != wantSignal {
+			t.Errorf("%s signal = %q, want %q", id, r.signal, wantSignal)
+		}
+		if r.rank != fleetPastRank {
+			t.Errorf("%s rank = %d, want %d", id, r.rank, fleetPastRank)
+		}
+	}
+
+	// And the record is reachable by id, which is how an act on a finished row
+	// finds the session to resume.
+	if snap.recordsByID["rec-exited"] == nil {
+		t.Error("an exited record must still be addressable — nothing else can resume it")
+	}
+}
+
+// The live table and the history table are separate questions. Every "is
+// anything in flight" test in the cockpit is fleetAll's length, so history
+// leaking into it would make an idle machine look busy.
+func TestHistoryStaysOutOfTheLiveTable(t *testing.T) {
+	m := cqModel(t)
+	for _, r := range m.fleetAll() {
+		if r.kind == "past" {
+			t.Fatalf("%q is finished and still on the live table", r.feature)
+		}
+	}
+	past := m.fleetPast()
+	if len(past) != 1 || past[0].feature != "four" {
+		t.Fatalf("history = %#v", past)
+	}
+}
+
+// Newest first: the thing that just ended is the one you are most likely to
+// want back.
+func TestHistoryIsNewestFirst(t *testing.T) {
+	now := time.Now()
+	rows := []fleetRow{
+		{id: "old", kind: "past", rank: fleetPastRank, moved: now.Add(-3 * time.Hour)},
+		{id: "new", kind: "past", rank: fleetPastRank, moved: now.Add(-2 * time.Minute)},
+		{id: "mid", kind: "past", rank: fleetPastRank, moved: now.Add(-30 * time.Minute)},
+	}
+	fleetSort(rows)
+	if rows[0].id != "new" || rows[1].id != "mid" || rows[2].id != "old" {
+		t.Errorf("history order = %s,%s,%s", rows[0].id, rows[1].id, rows[2].id)
+	}
+}
+
+// ---- the triage lens --------------------------------------------------------
+
+// `h` is the way in and the way out, and the table it shows is the finished
+// dispatchers.
+func TestHistoryKeyTogglesTheTable(t *testing.T) {
+	m := cqModel(t)
+	m = press(m, "h")
+	if m.fleetFilter() != fleetHistory {
+		t.Fatalf("h left the filter at %q", m.fleetFilter())
+	}
+	if got := fleetFeatures(m); got != "four" {
+		t.Errorf("history shows %q, want the finished dispatcher", got)
+	}
+	if !strings.Contains(m.View(), "four") {
+		t.Error("the history table does not render the row it holds")
+	}
+	m = press(m, "h")
+	if m.fleetFilter() != "all" {
+		t.Errorf("h should come back to the fleet, filter = %q", m.fleetFilter())
+	}
+}
+
+// The dispatch form opens over an empty fleet and owns the keyboard. History is
+// exactly what a human wants when nothing is in flight, so the form must not
+// cover it — and `h` must reach it from inside the form.
+func TestHistoryIsReachableWithNothingInFlight(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	now := time.Now()
+	fleet = []fleetRow{{
+		id: "id-past", kind: "past", rank: fleetPastRank, feature: "shipped thing",
+		repo: "acme-api", signal: "merged", moved: now.Add(-time.Hour),
+		acts: []cqAct{{k: "⏎", d: "resume", ok: "resuming…", keep: true}},
+	}}
+
+	m := newModel()
+	m.width, m.height = 130, 40
+	if !m.cqFormOn() {
+		t.Fatal("with nothing in flight the dispatch form should be the screen")
+	}
+	m = press(m, "h")
+	if m.cqFormOn() {
+		t.Fatal("the dispatch form is still covering the history table")
+	}
+	if m.cqPromptOn() {
+		t.Fatal("the dispatch form still owns the keyboard over the history table")
+	}
+	out := m.View()
+	if !strings.Contains(out, "shipped thing") {
+		t.Errorf("history did not render:\n%s", out)
+	}
+	// And the cursor works on it, which it cannot if the form is eating keys.
+	m = press(m, "j")
+	if r, ok := m.fleetSel(); !ok || r.id != "id-past" {
+		t.Errorf("no selectable history row: %#v", r)
+	}
+}
+
+// ⏎ on a finished row resumes; it must not try to attach to a session that
+// ended. With no record behind the fixture row, the command reports that
+// rather than doing nothing.
+func TestEnterOnAHistoryRowResumes(t *testing.T) {
+	m := cqModel(t)
+	m = press(m, "h")
+	r, ok := m.fleetSel()
+	if !ok || r.kind != "past" {
+		t.Fatalf("expected a history row under the cursor, got %#v", r)
+	}
+	if r.acts[0].d != "resume" {
+		t.Errorf("the first act on a finished row is %q, want resume", r.acts[0].d)
+	}
+	mm, cmd := m.cqRun(r, r.acts[0])
+	if cmd == nil {
+		t.Fatal("⏎ on a finished row returned no command")
+	}
+	if strings.Contains(mm.notice, "no live") {
+		t.Errorf("⏎ tried to attach to a finished session: %q", mm.notice)
+	}
+	msg, _ := cmd().(actionMsg)
+	if !strings.Contains(msg.notice, "resume") {
+		t.Errorf("resume notice = %q", msg.notice)
+	}
+}
+
+// A finished dispatcher has nothing to approve and nothing to kill, and the
+// footer only names keys that work right now.
+func TestHistoryFooterOffersOnlyWhatWorks(t *testing.T) {
+	m := press(cqModel(t), "h")
+	got := m.footerHelp()
+	for _, gone := range []string{"y ", "x kill", "s skip", "u undo"} {
+		if strings.Contains(got, gone) {
+			t.Errorf("history footer offers %q: %s", gone, got)
+		}
+	}
+	if !strings.Contains(got, "⏎ resume") || !strings.Contains(got, "h back to the fleet") {
+		t.Errorf("history footer = %q", got)
+	}
+}
+
+// ---- the product panel ------------------------------------------------------
+
+// The product's HISTORY tab lists every finished dispatcher in it, including
+// the ones SHIPPED cannot show: a kill, and a feature marked shipped by hand
+// with no merge behind it.
+func TestProductHistoryTabListsEverySession(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_DISPATCHER_STATE", dir)
+	saved := captureVars()
+	defer restoreVars(saved)
+
+	now := time.Now()
+	merged := now.Add(-2 * time.Hour)
+	recs := []*state.Dispatch{
+		{ID: "r-ship", Feature: "seat limits", RepoName: "shop-api", Product: "shop",
+			PRNumber: 9, PRState: "MERGED", PRMergedAt: &merged, SessionID: "sess-ship",
+			Status: state.StatusDone, StatusReason: "deployed — live",
+			CreatedAt: now.Add(-5 * time.Hour), UpdatedAt: merged},
+		{ID: "r-hand", Feature: "docs tidy", RepoName: "shop-api", Product: "shop",
+			SessionID: "sess-hand", Status: state.StatusDone, StatusReason: "marked shipped",
+			CreatedAt: now.Add(-4 * time.Hour), UpdatedAt: now.Add(-3 * time.Hour)},
+		{ID: "r-kill", Feature: "abandoned spike", RepoName: "shop-api", Product: "shop",
+			SessionID: "sess-kill", Status: state.StatusExited, StatusReason: "killed from cockpit",
+			CreatedAt: now.Add(-90 * time.Minute), UpdatedAt: now.Add(-time.Hour)},
+	}
+	for _, r := range recs {
+		if err := state.Save(r); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var s snapshot
+	cfg := &config.Config{Products: map[string][]string{"shop": {"shop-api"}}}
+	collectProducts(&collectCtx{cfg: cfg, records: state.LoadAll()}, &s)
+
+	hist := s.productHistory["shop"]
+	if len(hist) != 3 {
+		t.Fatalf("history = %#v", hist)
+	}
+	// Newest first, and each says how it ended.
+	want := []struct{ feature, ended string }{
+		{"abandoned spike", "stopped"},
+		{"docs tidy", "marked shipped"},
+		{"seat limits", "merged"},
+	}
+	for i, w := range want {
+		if hist[i].feature != w.feature || hist[i].ended != w.ended {
+			t.Errorf("history[%d] = %q/%q, want %q/%q", i, hist[i].feature, hist[i].ended, w.feature, w.ended)
+		}
+	}
+	// The ship log still says only what shipped — history is the wider list, not
+	// a replacement for it.
+	shippedCount := 0
+	for _, d := range s.shipped["shop"] {
+		shippedCount += len(d.items)
+	}
+	if shippedCount != 1 {
+		t.Errorf("shipped items = %d, want just the merged one", shippedCount)
+	}
+}
+
+// enter on a history row opens the resume overlay against that row, and
+// submitting it resumes the recorded session — with or without a follow-up,
+// because "just give it back to me" is a real ask.
+func TestProductHistoryResumesTheSession(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	products = []product{{name: "acme"}}
+	productHistory = map[string][]historyItem{"acme": {
+		{id: "rec-1", feature: "csv export", repo: "acme-hq", pr: "#144",
+			at: "2h ago", ended: "stopped", session: "sess-1", prompt: "export a csv"},
+	}}
+
+	m := newModel()
+	m.width, m.height = 190, 44
+	m.lens = "product"
+	m.rightTab = "history"
+
+	mm, _ := m.updateProduct("enter")
+	if !mm.resumeOpen {
+		t.Fatal("enter on a finished dispatcher should open the resume overlay")
+	}
+	if mm.resumeAt == nil || mm.resumeAt.id != "rec-1" {
+		t.Fatalf("the overlay is about %#v, want the selected history row", mm.resumeAt)
+	}
+	if !strings.Contains(mm.View(), "sess-1") {
+		t.Error("the overlay does not say which session it reopens")
+	}
+
+	// Empty is a resume, not a refusal: there is a session to reopen.
+	done, cmd := mm.updateProduct("enter")
+	if cmd == nil {
+		t.Fatal("submitting an empty resume did nothing")
+	}
+	if strings.Contains(done.notice, "nothing to dispatch") {
+		t.Errorf("notice = %q — a recorded session can be reopened with nothing to add", done.notice)
+	}
+	if done.resumeOpen || done.resumeAt != nil {
+		t.Error("submitting should close the overlay and clear its target")
+	}
+}
+
+// A record with no session id cannot be resumed, and the overlay says so
+// instead of promising a full-context resume it cannot perform — which is what
+// the SHIPPED tab's copy did while launching a brand new session underneath.
+func TestResumeOverlayIsHonestWithoutASession(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	products = []product{{name: "acme"}}
+	productHistory = map[string][]historyItem{"acme": {
+		{id: "rec-2", feature: "old thing", repo: "acme-hq", ended: "stopped", prompt: "do it"},
+	}}
+
+	m := newModel()
+	m.width, m.height = 190, 44
+	m.lens = "product"
+	m.rightTab = "history"
+	mm, _ := m.updateProduct("enter")
+
+	out := mm.View()
+	if !strings.Contains(out, "no session was recorded") {
+		t.Errorf("overlay copy does not admit there is nothing to resume:\n%s", out)
+	}
+	if strings.Contains(out, "reopens session") {
+		t.Error("overlay promises to reopen a session that was never recorded")
+	}
+	// Without a session a fresh dispatch is the only honest offer, and it needs
+	// a prompt.
+	empty, cmd := mm.updateProduct("enter")
+	if cmd != nil {
+		t.Error("an empty prompt with nothing to resume should launch nothing")
+	}
+	if !strings.Contains(empty.notice, "nothing to dispatch") {
+		t.Errorf("notice = %q", empty.notice)
+	}
+}

--- a/internal/cockpit/live.go
+++ b/internal/cockpit/live.go
@@ -15,6 +15,7 @@ package cockpit
 import (
 	"os/exec"
 	"strings"
+	"sync"
 
 	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/gh"
@@ -55,6 +56,7 @@ type snapshot struct {
 	team            map[string][]teamRow
 	teamVerdict     map[string]string
 	shipped         map[string][]shippedDay
+	productHistory  map[string][]historyItem
 	productVelocity map[string][]velTile
 
 	decisions         map[string][]decision
@@ -80,6 +82,14 @@ type snapshot struct {
 	// records maps a view dispatch's feature to its live record, so an action
 	// on the selected row reaches the real tmux session / branch / PR.
 	records map[string]*state.Dispatch
+	// recordsByID is EVERY record, finished ones included, keyed by its own id.
+	//
+	// records cannot serve the history rows: it is keyed by feature, so a
+	// re-dispatch of a name shadows the earlier record under the same key, and
+	// it only holds what the floor shows — a dispatcher that ended without
+	// shipping is not on the floor at all. An act on a finished session
+	// therefore addresses its record by id, which is unique and permanent.
+	recordsByID map[string]*state.Dispatch
 	// dataMode is "live" once a real load has run, "" while still on seed.
 	dataMode string
 }
@@ -89,6 +99,15 @@ type collectCtx struct {
 	cfg     *config.Config
 	records []*state.Dispatch
 	repos   []repos.Repo
+
+	// forges memoises forge(repoPath) for the life of one load. Every record
+	// asks for its repo's forge — collectFloor, collectFleet and the history
+	// rows all do — and a machine with fifty records in a handful of repos would
+	// otherwise pay fifty `git remote get-url` calls per refresh for a handful
+	// of distinct answers. Guarded because collectFloor resolves records
+	// concurrently (forEach).
+	forgeMu sync.Mutex
+	forges  map[string]string
 }
 
 // productFor maps a record onto the same product key collectProducts uses,
@@ -117,8 +136,28 @@ func (c *collectCtx) productFor(rec *state.Dispatch) string {
 }
 
 // forge reports the forge a repo path belongs to: "ado" for Azure DevOps
-// remotes, else "gh". Detection is by the origin remote URL.
+// remotes, else "gh". Detection is by the origin remote URL, and the answer is
+// memoised per load (see collectCtx.forges).
 func (c *collectCtx) forge(repoPath string) string {
+	c.forgeMu.Lock()
+	if f, ok := c.forges[repoPath]; ok {
+		c.forgeMu.Unlock()
+		return f
+	}
+	c.forgeMu.Unlock()
+
+	f := readForge(repoPath)
+
+	c.forgeMu.Lock()
+	if c.forges == nil {
+		c.forges = map[string]string{}
+	}
+	c.forges[repoPath] = f
+	c.forgeMu.Unlock()
+	return f
+}
+
+func readForge(repoPath string) string {
 	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin").Output()
 	if err != nil {
 		return "gh"
@@ -175,6 +214,10 @@ func loadSnapshotReporting(cfg *config.Config, r bootReport) snapshot {
 	var s snapshot
 	s.dataMode = "live"
 	s.discovered = ctx.repos
+	s.recordsByID = make(map[string]*state.Dispatch, len(ctx.records))
+	for _, rec := range ctx.records {
+		s.recordsByID[rec.ID] = rec
+	}
 
 	r.begin(bootDispatchers, "reading transcripts, diffs and prs…")
 	collectFloor(ctx, &s)
@@ -391,6 +434,12 @@ func applySnapshot(s snapshot) {
 	if s.records != nil {
 		liveRecords = s.records
 	}
+	if s.recordsByID != nil {
+		liveByID = s.recordsByID
+	}
+	if s.productHistory != nil {
+		productHistory = s.productHistory
+	}
 }
 
 // liveRecords maps the selected view dispatch's feature to its real record. It
@@ -398,5 +447,12 @@ func applySnapshot(s snapshot) {
 // feature has no record (e.g. while still showing seed data).
 var liveRecords = map[string]*state.Dispatch{}
 
+// liveByID is every record, finished ones included, keyed by its own id — the
+// map the history rows and the resume overlay act through.
+var liveByID = map[string]*state.Dispatch{}
+
 // recordFor returns the live record backing feature, or nil.
 func recordFor(feature string) *state.Dispatch { return liveRecords[feature] }
+
+// recordByID returns the record with this id, finished or not, or nil.
+func recordByID(id string) *state.Dispatch { return liveByID[id] }

--- a/internal/cockpit/live_test.go
+++ b/internal/cockpit/live_test.go
@@ -32,6 +32,7 @@ func restoreVars(s snapshot) {
 	outputWeeks, outputHeadline = s.outputWeeks, s.outputHead
 	outputUnit, outputDelta, outputSpark = s.outputUnit, s.outputDelta, s.outputSpark
 	notVelocity, liveRecords = s.notVelocity, s.records
+	liveByID, productHistory = s.recordsByID, s.productHistory
 }
 
 // captureVars snapshots the current data vars so a test can restore them and
@@ -53,6 +54,7 @@ func captureVars() snapshot {
 		doraWeeks: doraWeeks, outputWeeks: outputWeeks, outputHead: outputHeadline,
 		outputUnit: outputUnit, outputDelta: outputDelta, outputSpark: outputSpark,
 		notVelocity: notVelocity, records: liveRecords,
+		recordsByID: liveByID, productHistory: productHistory,
 	}
 }
 

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -68,9 +68,15 @@ type model struct {
 	// it, "" when up to date, unknown, or running unstamped.
 	upgradeTo string
 
-	shipCursor int
-	resumeOpen bool
-	resumeText string
+	shipCursor    int
+	historyCursor int
+	resumeOpen    bool
+	resumeText    string
+	// resumeAt is what the resume overlay is about. It is set when the overlay
+	// opens, because the overlay outlives the cursor that opened it: the panel
+	// keeps refreshing underneath, and a target re-read from the cursor could
+	// resume a different dispatcher than the one the human is reading about.
+	resumeAt *resumeTarget
 
 	backlogCursor int
 	picked        map[string]bool
@@ -343,6 +349,22 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.fleetSync(), loadSnapshotCmd(m.cfg)
 		}
 		return m.fleetSync(), nil
+
+	case resumedMsg:
+		// The resumed session is the thing the human asked for, so they land in
+		// it — the same handover "jump in" does.
+		if mm, cmd := m.attachSession(msg.session); cmd != nil {
+			mm.notice = msg.notice
+			return mm, cmd
+		}
+		// Nothing to hand over: report what the resume did (never attachSession's
+		// own "no live session", which would describe the handover instead of the
+		// resume) and pick the record's new state up on the next load.
+		m.notice = msg.notice
+		if m.cfg != nil {
+			return m, loadSnapshotCmd(m.cfg)
+		}
+		return m, nil
 
 	case attachReturnedMsg:
 		m.notice = ""

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -25,13 +25,19 @@ var helpSections = []struct {
 	{section: "work the fleet", keys: []struct{ k, d string }{
 		{"j / k", "move the cursor — the panel and the key hints follow it"},
 		{"g / G", "first row · last row"},
-		{"f", "filter: all → wants you → needs a look → running"},
+		{"f", "filter: all → wants you → needs a look → running → history"},
 		{"⏎", "attach the session"},
 		{"y", "approve the merge, or mark it shipped once it has commits"},
 		{"x", "kill it · the branch and any dirty worktree survive"},
 		{"s", "skip · send it to the back, it comes round again"},
 		{"d", "dispatch · pick a repo, say what it does"},
 		{"u", "put back the last thing you cleared"},
+	}},
+	{section: "what has finished", keys: []struct{ k, d string }{
+		{"h", "history · every dispatcher whose session is over, and back again"},
+		{"⏎", "resume it · its own transcript, in its own worktree"},
+		{"o", "open its pull request"},
+		{"", "a resumed dispatcher rejoins the fleet and you land in its session"},
 	}},
 	{section: "move", keys: []struct{ k, d string }{
 		{"1…6", "triage · products · backlog · usage · decisions · velocity"},
@@ -41,7 +47,7 @@ var helpSections = []struct {
 	}},
 	{section: "products · lens 2", keys: []struct{ k, d string }{
 		{"⏎", "open the product panel beside the table"},
-		{"O R T S", "in the panel: overview · review · team · shipped"},
+		{"O R T S H", "in the panel: overview · review · team · shipped · history"},
 		{"esc", "close the panel"},
 		{"a", "assign repos to products"},
 		{"n", "new product — names it and moves the marked repos in"},

--- a/internal/cockpit/product.go
+++ b/internal/cockpit/product.go
@@ -56,6 +56,51 @@ func (m model) shipSelected() shippedItem {
 	return f[clampCursor(m.shipCursor, len(f))]
 }
 
+// historyFlat is every finished dispatcher in the focused product, newest first.
+func (m model) historyFlat() []historyItem { return productHistory[m.productFocusName()] }
+
+// historySelected returns the finished dispatcher under the history cursor.
+func (m model) historySelected() (historyItem, bool) {
+	h := m.historyFlat()
+	if len(h) == 0 {
+		return historyItem{}, false
+	}
+	return h[clampCursor(m.historyCursor, len(h))], true
+}
+
+// ---- the resume target ------------------------------------------------------
+
+// resumeTarget is the dispatcher the resume overlay is about, from whichever
+// tab opened it. id addresses the record; session is the conversation to pick
+// back up, and "" means there is none — the overlay then offers the only honest
+// alternative, which is to dispatch the feature again.
+type resumeTarget struct {
+	id, feature, repo, pr, at, session, prompt string
+}
+
+// resumable reports whether this target can actually be resumed: a record we
+// can find, and a session id on it.
+func (t resumeTarget) resumable() bool { return t.id != "" && t.session != "" }
+
+func shipTarget(s shippedItem) *resumeTarget {
+	return &resumeTarget{id: s.id, feature: s.feature, repo: s.repo, pr: s.pr,
+		at: "shipped " + s.at, session: s.session, prompt: s.prompt}
+}
+
+func historyTarget(h historyItem) *resumeTarget {
+	return &resumeTarget{id: h.id, feature: h.feature, repo: h.repo, pr: h.pr,
+		at: h.ended + " " + h.at, session: h.session, prompt: h.prompt}
+}
+
+// resumeSelected is the overlay's target: the one it opened on, falling back to
+// the shipped cursor for a caller that opened the overlay without setting one.
+func (m model) resumeSelected() resumeTarget {
+	if m.resumeAt != nil {
+		return *m.resumeAt
+	}
+	return *shipTarget(m.shipSelected())
+}
+
 // productSelectedReview returns the review under the review cursor, if any.
 func (m model) productSelectedReview() (reviewItem, bool) {
 	rv := reviews[m.productFocusName()]
@@ -149,6 +194,8 @@ func (m model) productPanel(cw int) []string {
 		out = append(out, m.productTeamBody(cw, name)...)
 	case "shipped":
 		out = append(out, m.productShippedBody(cw)...)
+	case "history":
+		out = append(out, m.productHistoryBody(cw)...)
 	default:
 		out = append(out, m.productReviewBody(cw, name)...)
 	}
@@ -163,8 +210,9 @@ func productSummaryLine(name string) string {
 	return itoa(n) + " " + plural(n, "repo", "repos") + " · " + itoa(p.inflight) + " in flight · " + itoa(p.live) + " live today"
 }
 
-// productTabStrip is the O/R/T/S strip. The counts are on the tabs because they
-// are the reason to switch to one: nothing waiting is worth a keypress to see.
+// productTabStrip is the O/R/T/S/H strip. The counts are on the tabs because
+// they are the reason to switch to one: nothing waiting is worth a keypress to
+// see.
 func (m model) productTabStrip(name string) string {
 	waiting := 0
 	for _, r := range reviews[name] {
@@ -183,6 +231,7 @@ func (m model) productTabStrip(name string) string {
 		tab("review", "R review "+itoa(waiting)),
 		tab("team", "T team"),
 		tab("shipped", "S shipped "+itoa(len(m.shippedFlat()))),
+		tab("history", "H history "+itoa(len(m.historyFlat()))),
 	}, "  ")
 }
 
@@ -383,7 +432,61 @@ func (m model) productShippedBody(cw int) []string {
 	}
 	// `c clone to another repo` is not offered: nothing implements it, and a key
 	// the footer names that does nothing is worse than an absent one.
-	out = append(out, fg(cDim, "enter dispatch again · o open pr"))
+	out = append(out, fg(cDim, "enter pick it back up · o open pr · H every finished session"))
+	return out
+}
+
+// productHistoryBody is the H tab: every dispatcher in this product whose
+// session is over, newest first, and the way back into one.
+//
+// This is the tab that answers "where did it go". A dispatcher that was killed,
+// that ended without opening a PR, or that was marked shipped by hand is on no
+// other screen in the cockpit — SHIPPED is a ship log and the triage table is
+// what is in flight — so without it the session, its transcript and its branch
+// were all still on disk with nothing anywhere able to reach them.
+func (m model) productHistoryBody(cw int) []string {
+	items := m.historyFlat()
+	var out []string
+	if len(items) == 0 {
+		out = append(out, fg(cFaint, "no dispatcher in this product has finished yet"))
+		return out
+	}
+	sel := clampCursor(m.historyCursor, len(items))
+	for i, h := range items {
+		bg, marker, featColor := "", " ", cFg
+		if i == sel {
+			bg, marker, featColor = cSel, "▸", cWhite
+		}
+		endedColor := cDim
+		if h.ended == "stopped" {
+			endedColor = cFaint
+		}
+		out = append(out, row(cw, bg,
+			c(marker, 2, cFaint),
+			flexc(h.feature, featColor),
+			c(h.repo, 16, cDim),
+			c(h.ended, 15, endedColor),
+			cr(h.at, 8, cFaint)))
+	}
+
+	h, _ := m.historySelected()
+	out = append(out, fg(cRule, strings.Repeat("─", cw)))
+	ref := h.pr
+	if ref == "" {
+		ref = "no pr"
+	}
+	out = append(out, fg(cMid, h.feature)+fg(cFaint, " · "+ref+" · "+h.ended))
+	// The session id is the handle resume works through, so its absence is
+	// stated rather than left as a blank.
+	if h.session == "" {
+		out = append(out, fg(cFaint, "no session recorded — enter dispatches it again"))
+	} else {
+		out = append(out, fg(cFaint, "session "+h.session))
+	}
+	for _, ln := range productWrap(h.prompt, cw) {
+		out = append(out, fg(cMid, ln))
+	}
+	out = append(out, fg(cDim, "enter resume it · o open pr"))
 	return out
 }
 
@@ -460,27 +563,54 @@ func (m model) viewReview(w, h int) string {
 
 // ---- resume overlay ---------------------------------------------------------
 
+// viewResume is the overlay that picks a finished dispatcher back up.
+//
+// Its copy used to promise a resume it did not perform — "resumes session <id>
+// with its full context — the branch is recreated from the merge commit" — over
+// a key that launched an entirely new session on the same feature name. Both
+// halves are now real and each says which one is about to happen: with a
+// recorded session the transcript is reopened in the dispatch's own worktree;
+// without one there is nothing to reopen, and a fresh dispatch is offered as
+// what it is.
 func (m model) viewResume(w, h int) string {
-	s := m.shipSelected()
+	t := m.resumeSelected()
 	cw := w - 2*pad
 	if cw < 10 {
 		cw = w
 	}
+	where := t.repo
+	for _, part := range []string{t.pr, t.at} {
+		if part != "" && part != "—" {
+			where += " · " + part
+		}
+	}
+
 	var out []string
-	out = append(out, fg(cDim, "enhance a shipped feature"))
-	out = append(out, line(s.feature, cw, cWhite, ""))
-	out = append(out, fg(cDim, s.repo+" · "+s.pr+" · shipped "+s.at))
-	for _, ln := range productWrap("resumes session "+s.session+" with its full context — the branch is recreated from the merge commit", cw) {
+	lead, explain := "pick a finished dispatcher back up", "reopens session "+t.session+
+		" in its own worktree, with everything it already knows — leave the line empty to just open it"
+	if !t.resumable() {
+		lead = "dispatch this feature again"
+		explain = "no session was recorded for this one, so there is no conversation to reopen — " +
+			"this starts a fresh dispatcher on the same feature, and needs a prompt"
+	}
+	out = append(out, fg(cDim, lead))
+	out = append(out, line(t.feature, cw, cWhite, ""))
+	out = append(out, fg(cDim, where))
+	for _, ln := range productWrap(explain, cw) {
 		out = append(out, fg(cFaint, ln))
 	}
 	out = append(out, "")
 	out = append(out, fg(cDim, "originally"))
-	for _, ln := range productWrap(s.prompt, cw) {
+	for _, ln := range productWrap(t.prompt, cw) {
 		out = append(out, fg(cMid, ln))
 	}
 	out = append(out, fg(cRule, strings.Repeat("─", cw)))
 	out = append(out, fg(cAmber, "now ")+fg(cWhite, m.resumeText+"▏"))
-	out = append(out, fg(cFaint, "enter dispatch · esc cancel"))
+	verb := "enter resume"
+	if !t.resumable() {
+		verb = "enter dispatch"
+	}
+	out = append(out, fg(cFaint, verb+" · esc cancel"))
 	return clampLines(gutter(strings.Join(out, "\n"), pad), h)
 }
 
@@ -518,22 +648,28 @@ func (m model) updateProduct(k string) (model, tea.Cmd) {
 	if m.resumeOpen {
 		next, submit, cancel := applyEdit(m.resumeText, k, m.key)
 		if cancel {
-			m.resumeOpen, m.resumeText = false, ""
+			m.resumeOpen, m.resumeText, m.resumeAt = false, "", nil
 			return m, nil
 		}
 		if submit {
-			sel := m.shipSelected()
+			t := m.resumeSelected()
 			text := strings.TrimSpace(m.resumeText)
-			m.resumeOpen, m.resumeText = false, ""
+			m.resumeOpen, m.resumeText, m.resumeAt = false, "", nil
+			// A recorded session is reopened where it ran, and an empty line is a
+			// legitimate ask: "just give it back to me". Without one there is no
+			// conversation to reopen, so this falls back to a fresh dispatch on
+			// the same feature — which does need a prompt, and says so rather
+			// than announcing a dispatch it did not make.
+			if t.resumable() {
+				m.notice = "resuming \"" + t.feature + "\"…"
+				return m, resumeCmd(t.id, text)
+			}
 			if text == "" {
 				m.notice = "nothing to dispatch — type what to change"
 				return m, nil
 			}
-			// This used to set a notice saying the feature had been "dispatched
-			// again" and launch nothing. It re-dispatches the same feature, which
-			// reuses its branch and worktree, with the typed text as the prompt.
-			m.notice = "dispatching \"" + sel.feature + "\" again…"
-			return m, launchCmd(m.cfg, sel.repo, sel.feature, text)
+			m.notice = "dispatching \"" + t.feature + "\" again…"
+			return m, launchCmd(m.cfg, t.repo, t.feature, text)
 		}
 		m.resumeText = next
 		return m, nil
@@ -560,6 +696,9 @@ func (m model) updateProduct(k string) (model, tea.Cmd) {
 		return m, nil
 	case "S":
 		m.rightTab = "shipped"
+		return m, nil
+	case "H":
+		m.rightTab, m.historyCursor = "history", 0
 		return m, nil
 	}
 
@@ -598,6 +737,31 @@ func (m model) updateProduct(k string) (model, tea.Cmd) {
 		// Neither tab has a cursor. Without this the fall-through below would
 		// move the shipped cursor from a tab that cannot show it moving.
 		return m, nil
+	case "history":
+		items := m.historyFlat()
+		sel, has := m.historySelected()
+		switch k {
+		case "j", "down":
+			if len(items) > 0 {
+				m.historyCursor = mini(m.historyCursor+1, len(items)-1)
+			}
+		case "k", "up":
+			m.historyCursor = maxi(m.historyCursor-1, 0)
+		case "enter":
+			if has {
+				m.resumeOpen, m.resumeText, m.resumeAt = true, "", historyTarget(sel)
+			}
+		case "o":
+			if !has {
+				return m, nil
+			}
+			if sel.pr == "" {
+				m.notice = "\"" + sel.feature + "\" has no pull request"
+				return m, nil
+			}
+			return m, openPRCmd(sel.repo, sel.pr)
+		}
+		return m, nil
 	}
 
 	// shipped tab
@@ -611,7 +775,7 @@ func (m model) updateProduct(k string) (model, tea.Cmd) {
 		m.shipCursor = maxi(m.shipCursor-1, 0)
 	case "enter":
 		if n > 0 {
-			m.resumeOpen, m.resumeText = true, ""
+			m.resumeOpen, m.resumeText, m.resumeAt = true, "", shipTarget(m.shipSelected())
 		}
 	case "o":
 		sel := m.shipSelected()

--- a/internal/cockpit/smoke_test.go
+++ b/internal/cockpit/smoke_test.go
@@ -103,7 +103,7 @@ func TestProductTabs(t *testing.T) {
 	if m.rightTab != "overview" {
 		t.Errorf("enter should open the panel on overview, got %q", m.rightTab)
 	}
-	for _, tab := range []string{"R", "T", "S", "O"} {
+	for _, tab := range []string{"R", "T", "S", "H", "O"} {
 		m = press(m, tab)
 		renderClean(t, m, "product tab "+tab)
 	}
@@ -123,6 +123,11 @@ func TestProductTabs(t *testing.T) {
 	m = press(m, "enter")
 	renderClean(t, m, "resume or list")
 	m = press(m, "esc")
+	// history → the same overlay, on a dispatcher that never shipped
+	m = press(m, "H")
+	m = press(m, "enter")
+	renderClean(t, m, "history resume or list")
+	m = press(m, "esc")
 	// esc with no overlay up closes the panel and leaves the products lens
 	// showing, which is the only way back out — q is quit, not close.
 	m = press(m, "esc")
@@ -136,7 +141,7 @@ func TestProductTabs(t *testing.T) {
 func TestProductPanelRendersAtEveryWidth(t *testing.T) {
 	installFixture(t)
 	for _, w := range smokeWidths {
-		for _, tab := range []string{"O", "R", "T", "S"} {
+		for _, tab := range []string{"O", "R", "T", "S", "H"} {
 			m := newModel()
 			m.width, m.height = w, 44
 			m = press(m, "2")

--- a/internal/cockpit/types_product.go
+++ b/internal/cockpit/types_product.go
@@ -29,13 +29,31 @@ type teamRow struct {
 
 // ---- shipped ----------------------------------------------------------------
 
+// id is the dispatch record's own id, and is what the resume overlay acts
+// through — a feature name can belong to several records, its id cannot.
 type shippedItem struct {
-	feature, repo, pr, at, session, closedBy, prompt string
+	id, feature, repo, pr, at, session, closedBy, prompt string
 }
 
 type shippedDay struct {
 	day   string
 	items []shippedItem
+}
+
+// ---- history ----------------------------------------------------------------
+
+// historyItem is one finished dispatcher on the product's HISTORY tab: every
+// session that is over, whether it shipped or not.
+//
+// SHIPPED cannot answer for these. It is a ship log — grouped by the day a
+// feature went live, and built only from records with a merge or a deploy
+// behind them — so a dispatcher that was killed, that ended without a PR, or
+// that was marked shipped by hand appears on it nowhere, and used to be
+// unreachable from every screen in the product. ended says how it finished and
+// session is the transcript to resume; an empty session means there is nothing
+// to resume and the overlay says so rather than pretending.
+type historyItem struct {
+	id, feature, repo, pr, at, ended, session, prompt string
 }
 
 // ---- diffs + findings -------------------------------------------------------

--- a/internal/cockpit/view.go
+++ b/internal/cockpit/view.go
@@ -13,7 +13,7 @@ var footerByLens = map[string]string{
 	"products": "j/k move · enter opens the product panel · a assign · n new product · : palette",
 	// The design also offers J/K scroll and q close. Neither is wired — the
 	// panel does not scroll, and q is quit everywhere — so neither is offered.
-	"product":   "O overview · R review · T team · S shipped · esc close · 1 triage",
+	"product":   "O overview · R review · T team · S shipped · H history · esc close · 1 triage",
 	"backlog":   "j/k move · space pick · enter dispatch · ctrl+d dispatch picked · s source · 1 triage",
 	"usage":     "budget by window, model and product · 6 velocity · 1 triage",
 	"decisions": "j/k records · J/K repo · → body · a accept · s supersede · e tool · o open",

--- a/internal/dispatch/launchcmd_unix.go
+++ b/internal/dispatch/launchcmd_unix.go
@@ -16,6 +16,19 @@ func launchCommand(dispatcherID, prompt string) string {
 		dispatcherID, shellQuote(prompt))
 }
 
+// resumeCommand is launchCommand for a session that already exists: claude
+// picks the recorded conversation back up instead of starting a new one, and an
+// empty prompt is left off entirely rather than passed as an empty argument,
+// which claude would read as a first message with nothing in it.
+func resumeCommand(dispatcherID, sessionID, prompt string) string {
+	arg := ""
+	if prompt != "" {
+		arg = " " + shellQuote(prompt)
+	}
+	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude --resume %s%s; exec ${SHELL:-/bin/sh}",
+		dispatcherID, shellQuote(sessionID), arg)
+}
+
 // shellQuote single-quotes a string for POSIX shells, escaping embedded quotes.
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"

--- a/internal/dispatch/launchcmd_windows.go
+++ b/internal/dispatch/launchcmd_windows.go
@@ -18,6 +18,19 @@ func launchCommand(dispatcherID, prompt string) string {
 		dispatcherID, winQuote(prompt))
 }
 
+// resumeCommand is launchCommand for a session that already exists: claude
+// picks the recorded conversation back up instead of starting a new one, and an
+// empty prompt is left off entirely rather than passed as an empty argument,
+// which claude would read as a first message with nothing in it.
+func resumeCommand(dispatcherID, sessionID, prompt string) string {
+	arg := ""
+	if prompt != "" {
+		arg = " " + winQuote(prompt)
+	}
+	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude --resume %s%s & pause`,
+		dispatcherID, winQuote(sessionID), arg)
+}
+
 // winQuote wraps a string in double quotes for cmd.exe, doubling any embedded
 // double quotes. cmd.exe quoting is best-effort; newlines are collapsed to
 // spaces since a cmd command line is single-line.

--- a/internal/dispatch/resume.go
+++ b/internal/dispatch/resume.go
@@ -1,0 +1,152 @@
+package dispatch
+
+// resume.go reopens a dispatcher whose session is over.
+//
+// A dispatch does not stop existing when its claude session ends: the record,
+// the branch, the worktree and — the part that matters — the session transcript
+// all survive. Claude Code can pick that transcript back up (`claude --resume
+// <session id>`), but only from the directory the session ran in, because that
+// is what its project store is keyed by. So resuming is: put the worktree back
+// if it was reclaimed, and start claude in it with the recorded session id.
+//
+// What it deliberately does not do is invent a session. With no recorded id and
+// no transcript to read one from, there is nothing to resume, and the caller is
+// told so rather than handed a fresh session dressed up as the old one.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"claude-dispatcher/internal/state"
+	"claude-dispatcher/internal/supervisor"
+)
+
+// The supervisor calls Resume makes, as seams: tests swap them rather than
+// stand up real sessions. sessionAlive is shared with Launch.
+var (
+	sessionIdle = supervisor.SessionIdle
+	killSession = supervisor.KillSession
+	uniqueName  = supervisor.UniqueName
+	newSession  = supervisor.NewSession
+)
+
+// ResumeMode is what Resume actually did, so the caller's notice can say it
+// rather than assume it.
+type ResumeMode string
+
+const (
+	// ResumeStarted: a session is running claude --resume on the transcript.
+	ResumeStarted ResumeMode = "started"
+	// ResumeLive: the dispatcher's own session is still busy, so nothing was
+	// started — the thing to do with it is attach, not resume.
+	ResumeLive ResumeMode = "live"
+)
+
+// Resume reopens d's Claude session in its own worktree, optionally with prompt
+// as the first thing said to it, and returns the session name to hand the
+// terminal to.
+//
+// The record is updated in place (new session name, status back to launching)
+// and saved: a record left at done would make the lifecycle hook swallow
+// everything the resumed session says — done is terminal for every event but
+// proof of life (see hookcmd.reopensDone).
+func Resume(d *state.Dispatch, prompt string) (ResumeMode, string, error) {
+	if d == nil {
+		return "", "", fmt.Errorf("no dispatch record")
+	}
+	sid := SessionIDOf(d)
+	if sid == "" {
+		return "", "", fmt.Errorf("%q never recorded a session id — there is nothing to resume", d.Feature)
+	}
+	// The transcript is what --resume reads. An absent one is the honest end of
+	// this road: claude would open, fail to find the conversation and leave the
+	// human in a session that is not the one they asked for.
+	if d.TranscriptPath != "" {
+		if _, err := os.Stat(d.TranscriptPath); err != nil {
+			return "", "", fmt.Errorf("the transcript for %q is gone (%s)", d.Feature, d.TranscriptPath)
+		}
+	}
+
+	dir := d.WorktreePath
+	if dir == "" {
+		dir = d.RepoPath
+	}
+	if dir == "" {
+		return "", "", fmt.Errorf("%q recorded no directory to resume in", d.Feature)
+	}
+	// Same guard as Launch: one live dispatcher per slug, because the worktree
+	// path is keyed by it. Resuming into a checkout another session is working
+	// in is the collision per-dispatch worktrees exist to prevent.
+	if live := liveDispatch(d.Slug); live != nil && live.ID != d.ID {
+		return "", "", fmt.Errorf("%q is live in the same worktree (session %s) — kill it first",
+			live.Feature, live.TmuxSession)
+	}
+
+	// The session's own supervisor session, if it outlived claude. Idle means
+	// claude has ended and the name is free to take back; busy means the
+	// dispatcher is still going and resuming it would fork the transcript under
+	// a session that is still writing to it.
+	if d.TmuxSession != "" && sessionAlive(d.TmuxSession) {
+		idle, known := sessionIdle(d.TmuxSession)
+		switch {
+		case known && !idle:
+			return ResumeLive, d.TmuxSession, nil
+		case known && idle:
+			_ = killSession(d.TmuxSession)
+		}
+		// Unknown: leave it running and take a new name below. A backend that
+		// cannot see into a session must not have it killed on a guess.
+	}
+
+	// The worktree may have been reclaimed when the dispatcher was killed
+	// (CleanupWorktree removes a clean one). Put it back at the same path —
+	// which is what makes the transcript findable again — reusing the feature
+	// branch when it still exists.
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if d.RepoPath == "" || d.Branch == "" {
+			return "", "", fmt.Errorf("%s is gone and there is not enough on the record to rebuild it", dir)
+		}
+		if err := ensureWorktree(d.RepoPath, dir, d.Branch); err != nil {
+			return "", "", fmt.Errorf("rebuild %s: %w", dir, err)
+		}
+		InheritTrust(d.RepoPath, dir)
+	}
+
+	base := "disp-" + d.Slug
+	if base == "disp-" {
+		base = "disp-" + d.ID
+	}
+	name := uniqueName(base)
+	if err := newSession(name, dir, resumeCommand(d.ID, sid, prompt)); err != nil {
+		return "", "", err
+	}
+
+	d.TmuxSession = name
+	d.Status = state.StatusLaunching
+	d.StatusReason = "resuming its session"
+	d.WaitingOnTasks = false
+	if err := state.Save(d); err != nil {
+		return ResumeStarted, name, err
+	}
+	return ResumeStarted, name, nil
+}
+
+// SessionIDOf is the Claude Code session id to resume: the one the hook bound
+// to the record, or — for a record from before that binding, or one whose
+// SessionStart was never attributed — the transcript's own filename, which
+// Claude Code names after the session. "" when neither exists.
+func SessionIDOf(d *state.Dispatch) string {
+	if d == nil {
+		return ""
+	}
+	if d.SessionID != "" {
+		return d.SessionID
+	}
+	if d.TranscriptPath == "" {
+		return ""
+	}
+	base := filepath.Base(d.TranscriptPath)
+	return strings.TrimSuffix(base, filepath.Ext(base))
+}

--- a/internal/dispatch/resume_test.go
+++ b/internal/dispatch/resume_test.go
@@ -1,0 +1,256 @@
+//go:build !windows
+
+package dispatch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"claude-dispatcher/internal/state"
+)
+
+// stubSupervisor swaps every supervisor call Resume makes and records the
+// session it was asked to start.
+type stubSupervisor struct {
+	alive   map[string]bool
+	idle    bool
+	known   bool
+	killed  []string
+	started struct{ name, dir, cmd string }
+}
+
+func stubSessions(t *testing.T, s *stubSupervisor) {
+	t.Helper()
+	pAlive, pIdle, pKill, pUniq, pNew := sessionAlive, sessionIdle, killSession, uniqueName, newSession
+	t.Cleanup(func() {
+		sessionAlive, sessionIdle, killSession, uniqueName, newSession = pAlive, pIdle, pKill, pUniq, pNew
+	})
+	sessionAlive = func(name string) bool { return s.alive[name] }
+	sessionIdle = func(string) (bool, bool) { return s.idle, s.known }
+	killSession = func(name string) error {
+		s.killed = append(s.killed, name)
+		s.alive[name] = false
+		return nil
+	}
+	uniqueName = func(base string) string { return base }
+	newSession = func(name, dir, cmd string) error {
+		s.started.name, s.started.dir, s.started.cmd = name, dir, cmd
+		return nil
+	}
+}
+
+// finished builds a record for a dispatcher whose session is over, with a
+// transcript on disk for --resume to find.
+func finished(t *testing.T, repo string) *state.Dispatch {
+	t.Helper()
+	wt := filepath.Join(t.TempDir(), "worktrees", "acme", "payment-retry")
+	if err := ensureWorktree(repo, wt, "feature/payment-retry"); err != nil {
+		t.Fatal(err)
+	}
+	transcript := filepath.Join(t.TempDir(), "sess-abc.jsonl")
+	if err := os.WriteFile(transcript, []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	d := &state.Dispatch{
+		ID: state.NewID(), Feature: "Payment Retry", Slug: "payment-retry",
+		RepoPath: repo, RepoName: "acme", Branch: "feature/payment-retry",
+		WorktreePath: wt, TranscriptPath: transcript, SessionID: "sess-abc",
+		TmuxSession: "disp-payment-retry", Prompt: "retry the payments",
+		Status: state.StatusExited, StatusReason: "session ended",
+	}
+	if err := state.Save(d); err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// The whole point of the feature: a dispatcher whose session ended can be put
+// back to work on its own transcript, in its own worktree, with a follow-up
+// prompt — and the record leaves "exited" so the lifecycle hook will listen to
+// the resumed session again.
+func TestResumeStartsTheRecordedSession(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	repo := initRepo(t)
+	sup := &stubSupervisor{alive: map[string]bool{}}
+	stubSessions(t, sup)
+
+	d := finished(t, repo)
+	mode, session, err := Resume(d, "now add the retry cap")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != ResumeStarted {
+		t.Errorf("mode = %q, want %q", mode, ResumeStarted)
+	}
+	if session != sup.started.name || session == "" {
+		t.Errorf("returned session %q, started %q", session, sup.started.name)
+	}
+	if sup.started.dir != d.WorktreePath {
+		t.Errorf("resumed in %q, want the dispatch's own worktree %q", sup.started.dir, d.WorktreePath)
+	}
+	for _, want := range []string{"--resume", "'sess-abc'", "'now add the retry cap'", "CLAUDE_DISPATCHER_ID=" + d.ID} {
+		if !strings.Contains(sup.started.cmd, want) {
+			t.Errorf("resume command %q is missing %q", sup.started.cmd, want)
+		}
+	}
+	if d.Status != state.StatusLaunching {
+		t.Errorf("record left at %q — the hook ignores a done record, so a resumed one must move off it", d.Status)
+	}
+	if d.TmuxSession != session {
+		t.Errorf("record still points at the old session %q", d.TmuxSession)
+	}
+	// And it is on disk, not just in memory: the cockpit re-reads records.
+	saved := state.LoadAll()
+	if len(saved) != 1 || saved[0].TmuxSession != session {
+		t.Errorf("saved record = %#v", saved)
+	}
+}
+
+// Resuming with nothing to say is a real ask — "give it back to me" — and must
+// not pass an empty argument claude would read as a first message.
+func TestResumeWithoutAPromptPassesNone(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	sup := &stubSupervisor{alive: map[string]bool{}}
+	stubSessions(t, sup)
+
+	if _, _, err := Resume(finished(t, initRepo(t)), ""); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(sup.started.cmd, "''") {
+		t.Errorf("empty prompt passed as an argument: %q", sup.started.cmd)
+	}
+}
+
+// The worktree is reclaimed when a clean dispatcher is killed, and the
+// transcript is findable only from the directory the session ran in — so a
+// resume has to put it back at the same path.
+func TestResumeRebuildsAReclaimedWorktree(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	repo := initRepo(t)
+	sup := &stubSupervisor{alive: map[string]bool{}}
+	stubSessions(t, sup)
+
+	d := finished(t, repo)
+	if !CleanupWorktree(d.RepoPath, d.WorktreePath) {
+		t.Fatal("the fixture worktree should have been clean enough to remove")
+	}
+	if _, _, err := Resume(d, ""); err != nil {
+		t.Fatal(err)
+	}
+	if got := worktreeBranch(t, d.WorktreePath); got != "feature/payment-retry" {
+		t.Errorf("rebuilt worktree is on %q", got)
+	}
+	if sup.started.dir != d.WorktreePath {
+		t.Errorf("resumed in %q, want %q", sup.started.dir, d.WorktreePath)
+	}
+}
+
+// A session left running is never resumed over the top of itself: two claude
+// processes appending to one transcript is worse than the thing it fixes. The
+// caller is told to attach instead.
+func TestResumeLeavesABusySessionAlone(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	sup := &stubSupervisor{alive: map[string]bool{"disp-payment-retry": true}, idle: false, known: true}
+	stubSessions(t, sup)
+
+	d := finished(t, initRepo(t))
+	mode, session, err := Resume(d, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != ResumeLive || session != "disp-payment-retry" {
+		t.Errorf("mode = %q session = %q, want the live session handed back", mode, session)
+	}
+	if sup.started.name != "" {
+		t.Error("a second session was started over a running one")
+	}
+	if len(sup.killed) != 0 {
+		t.Errorf("a running session was killed: %v", sup.killed)
+	}
+}
+
+// The shell a dispatch drops to when claude exits is not a session doing
+// anything: it is reclaimed rather than left behind as an orphan.
+func TestResumeReclaimsTheIdleShell(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	sup := &stubSupervisor{alive: map[string]bool{"disp-payment-retry": true}, idle: true, known: true}
+	stubSessions(t, sup)
+
+	if _, _, err := Resume(finished(t, initRepo(t)), ""); err != nil {
+		t.Fatal(err)
+	}
+	if len(sup.killed) != 1 || sup.killed[0] != "disp-payment-retry" {
+		t.Errorf("killed = %v, want the idle shell reclaimed", sup.killed)
+	}
+	if sup.started.name == "" {
+		t.Error("nothing was started")
+	}
+}
+
+// A backend that cannot see into a session (the Windows console one) must not
+// have it killed on a guess.
+func TestResumeLeavesAnUnknownSessionAlone(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	sup := &stubSupervisor{alive: map[string]bool{"disp-payment-retry": true}, idle: false, known: false}
+	stubSessions(t, sup)
+
+	mode, _, err := Resume(finished(t, initRepo(t)), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != ResumeStarted {
+		t.Errorf("mode = %q, want a new session started alongside", mode)
+	}
+	if len(sup.killed) != 0 {
+		t.Errorf("killed %v on a guess", sup.killed)
+	}
+}
+
+// Nothing is invented: with no session id, or with the transcript gone, there
+// is nothing to resume and the human is told so rather than handed a fresh
+// session wearing the old one's name.
+func TestResumeRefusesWhatItCannotResume(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	sup := &stubSupervisor{alive: map[string]bool{}}
+	stubSessions(t, sup)
+
+	// A repo each: one branch cannot be checked out in two worktrees at once.
+	noSession := finished(t, initRepo(t))
+	noSession.SessionID, noSession.TranscriptPath = "", ""
+	if _, _, err := Resume(noSession, ""); err == nil || !strings.Contains(err.Error(), "nothing to resume") {
+		t.Errorf("no session id: err = %v", err)
+	}
+
+	gone := finished(t, initRepo(t))
+	if err := os.Remove(gone.TranscriptPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := Resume(gone, ""); err == nil || !strings.Contains(err.Error(), "transcript") {
+		t.Errorf("missing transcript: err = %v", err)
+	}
+	if sup.started.name != "" {
+		t.Error("a session was started for something that cannot be resumed")
+	}
+}
+
+// A record from before the hook bound session ids still has its transcript, and
+// Claude Code names that file after the session — so the id is recoverable.
+func TestSessionIDOfFallsBackToTheTranscript(t *testing.T) {
+	cases := []struct {
+		d    *state.Dispatch
+		want string
+	}{
+		{&state.Dispatch{SessionID: "abc"}, "abc"},
+		{&state.Dispatch{TranscriptPath: "/p/-Users-me-repo/9f8e.jsonl"}, "9f8e"},
+		{&state.Dispatch{SessionID: "abc", TranscriptPath: "/p/x/def.jsonl"}, "abc"},
+		{&state.Dispatch{}, ""},
+		{nil, ""},
+	}
+	for _, c := range cases {
+		if got := SessionIDOf(c.d); got != c.want {
+			t.Errorf("SessionIDOf(%#v) = %q, want %q", c.d, got, c.want)
+		}
+	}
+}

--- a/internal/supervisor/supervisor_unix.go
+++ b/internal/supervisor/supervisor_unix.go
@@ -21,6 +21,11 @@ func KillSession(name string) error               { return tmux.KillSession(name
 func UniqueName(base string) string               { return tmux.UniqueName(base) }
 func SetStatusHint(name string)                   { tmux.SetStatusHint(name) }
 
+// SessionIdle reports whether a session is sitting at its shell with nothing
+// running — the state a dispatch session is left in once claude exits. known is
+// false when the backend cannot tell, which is never the same answer as "idle".
+func SessionIdle(name string) (idle, known bool) { return tmux.SessionIdle(name) }
+
 // EnsureBackKey binds the prefix-free "back to the cockpit" key (Ctrl-\).
 func EnsureBackKey() { tmux.EnsureDetachKey() }
 

--- a/internal/supervisor/supervisor_unix_test.go
+++ b/internal/supervisor/supervisor_unix_test.go
@@ -26,6 +26,19 @@ func TestUniqueNameFallsBackWhenFree(t *testing.T) {
 	}
 }
 
+// A session that does not exist is not an idle one. Resume reads "unknown" as
+// "leave it alone", so answering idle here would have it kill and replace
+// sessions it cannot see.
+func TestSessionIdleIsUnknownForAMissingSession(t *testing.T) {
+	idle, known := SessionIdle("definitely-not-a-real-session-xyz")
+	if known {
+		t.Error("a session that does not exist cannot be reported on")
+	}
+	if idle {
+		t.Error("unknown must never read as idle")
+	}
+}
+
 func TestNonMutatingCallsAreSafe(t *testing.T) {
 	// None of these should panic whether or not tmux is installed.
 	if HasSession("definitely-not-a-real-session-xyz") {

--- a/internal/supervisor/supervisor_windows.go
+++ b/internal/supervisor/supervisor_windows.go
@@ -212,6 +212,13 @@ func UniqueName(base string) string {
 	return name
 }
 
+// SessionIdle cannot be answered by this backend: the registry tracks the
+// cmd.exe that hosts the session, and that process is alive both while claude
+// runs and while the trailing `pause` holds the window open afterwards. It
+// reports "unknown" rather than guessing, and the caller leaves the old console
+// alone and starts a new one — see dispatch.Resume.
+func SessionIdle(name string) (idle, known bool) { return false, false }
+
 // SetStatusHint and EnsureBackKey are tmux status-line / key-binding concerns
 // with no console-window analogue; they are no-ops on Windows. Focus reporting
 // is the console's own business rather than something we can switch on for it,

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -85,6 +85,38 @@ func KillSession(name string) error {
 	return exec.Command("tmux", "kill-session", "-t", "="+name).Run()
 }
 
+// shellCommands are the pane commands that mean "nothing is running here": the
+// login shell a dispatch session drops to once claude exits (see
+// launchCommand). A login shell reports as "-bash", hence the leading dash trim.
+var shellCommands = map[string]bool{
+	"sh": true, "bash": true, "zsh": true, "fish": true,
+	"dash": true, "ksh": true, "csh": true, "tcsh": true, "login": true,
+}
+
+// SessionIdle reports whether every pane of a session is sitting at a shell —
+// that is, whether the claude process it was launched with has ended.
+//
+// known is false when tmux could not answer (no such session, no tmux). The
+// distinction matters to the caller: "idle" licenses reusing the session, and
+// "unknown" must never be read as either — a session we cannot see into is one
+// we leave alone.
+func SessionIdle(name string) (idle, known bool) {
+	out, err := exec.Command("tmux", "list-panes", "-t", "="+name, "-F", "#{pane_current_command}").Output()
+	if err != nil {
+		return false, false
+	}
+	lines := strings.Fields(string(out))
+	if len(lines) == 0 {
+		return false, false
+	}
+	for _, cmd := range lines {
+		if !shellCommands[strings.TrimPrefix(cmd, "-")] {
+			return false, true
+		}
+	}
+	return true, true
+}
+
 // AttachCmd returns the command that hands the terminal over to a session.
 // Inside an existing tmux client we switch rather than nest.
 func AttachCmd(name string) *exec.Cmd {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -87,11 +87,16 @@ func KillSession(name string) error {
 
 // shellCommands are the pane commands that mean "nothing is running here": the
 // login shell a dispatch session drops to once claude exits (see
-// launchCommand). A login shell reports as "-bash", hence the leading dash trim.
+// launchCommand). A login shell reports as "-bash", hence the leading dash trim
+// in paneIdle.
 var shellCommands = map[string]bool{
 	"sh": true, "bash": true, "zsh": true, "fish": true,
 	"dash": true, "ksh": true, "csh": true, "tcsh": true, "login": true,
 }
+
+// paneIdle reports whether a pane's current command is a shell waiting for
+// input rather than a process doing something.
+func paneIdle(cmd string) bool { return shellCommands[strings.TrimPrefix(cmd, "-")] }
 
 // SessionIdle reports whether every pane of a session is sitting at a shell —
 // that is, whether the claude process it was launched with has ended.
@@ -110,7 +115,7 @@ func SessionIdle(name string) (idle, known bool) {
 		return false, false
 	}
 	for _, cmd := range lines {
-		if !shellCommands[strings.TrimPrefix(cmd, "-")] {
+		if !paneIdle(cmd) {
 			return false, true
 		}
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1,0 +1,30 @@
+package tmux
+
+import "testing"
+
+// SessionIdle decides whether a dispatch session's claude process has ended and
+// its name can be taken back, so what counts as "a shell" is the whole of it. A
+// login shell reports with a leading dash, and anything that is not a shell is
+// something running.
+func TestShellCommandsCoverALoginShell(t *testing.T) {
+	idle := paneIdle
+	for _, sh := range []string{"zsh", "-zsh", "bash", "-bash", "sh", "fish"} {
+		if !idle(sh) {
+			t.Errorf("%q should read as an idle shell", sh)
+		}
+	}
+	for _, busy := range []string{"claude", "node", "vim", "git", "python3"} {
+		if idle(busy) {
+			t.Errorf("%q should read as something running", busy)
+		}
+	}
+}
+
+// A session tmux cannot answer for is unknown, never idle: the caller reclaims
+// an idle session and leaves an unknown one alone.
+func TestSessionIdleIsUnknownForAMissingSession(t *testing.T) {
+	idle, known := SessionIdle("definitely-not-a-real-tmux-session-xyz")
+	if known || idle {
+		t.Errorf("SessionIdle(missing) = idle:%v known:%v", idle, known)
+	}
+}


### PR DESCRIPTION
## The bug

Once a dispatcher's session ended, the dispatcher left the cockpit for good.

`collectFleet` built rows only for `blocked`/`needs`/`review`/`working`
records, and `floorState` answered `""` for a record that exited without a
merge — so a shipped dispatcher, a killed one, and one that simply exited were
all dropped on the floor. The product panel could not stand in for it: SHIPPED
is a ship log, built only from records with a merge or a deploy behind them and
grouped by the day the feature went live, so a kill, a dispatcher that never
opened a PR, and a feature marked shipped by hand appeared on it nowhere.

The record, the branch, the worktree and the transcript were all still on disk
with nothing anywhere able to reach them. On this machine that is **29 of 32
records** — 17 shipped, 12 stopped — invisible.

Nothing could have resumed one anyway. The single affordance that said it did —
`enter` on a shipped feature, over copy promising *"resumes session `<id>` with
its full context"* — called `launchCmd`, which starts an entirely new claude
session on the same feature name.

## What this does

- **Finished records are collected as history rows** and kept out of the
  in-flight table. Every "is anything in flight" question in the cockpit is
  `fleetAll`'s length, so history leaking into it would make an idle machine
  look busy.
- **`h` on triage** swaps the live table for the finished dispatchers, newest
  first, with `f` reaching the same filter. It works with nothing in flight,
  where the dispatch form used to own the whole screen — which is exactly when
  a human goes looking for history.
- **`H` on the product panel** is a fifth tab: every finished dispatcher in the
  product, shipped or not, with what became of each.
- **`⏎` resumes.** `dispatch.Resume` puts the worktree back if it was reclaimed
  — the transcript is findable only from the directory the session ran in —
  starts `claude --resume <session id>` there with an optional follow-up
  prompt, and hands you the session.
- The resume overlay's copy is now true either way: with a recorded session it
  says which one it reopens; without one it offers a fresh dispatch as what it
  is.

## What it will not do

- **Invent a session.** No recorded id and no transcript to read one from means
  nothing to resume, and it says so.
- **Resume a session over the top of itself.** Two claude processes appending
  to one transcript is worse than the bug, so a busy session is handed back to
  attach to instead. A backend that cannot see into a session — the Windows
  console one — has nothing killed on a guess.

Resumed records move off done/exited to launching: the lifecycle hook treats
done as terminal for everything but proof of life, and would otherwise swallow
everything the resumed session says.

## Testing

`make check` (build, vet, golangci-lint, race tests). New coverage: history
collection from real records, the live/history split, the `h` toggle including
over an empty fleet, resume acts, the product H tab, overlay honesty, and
`dispatch.Resume` end to end against stubbed supervisor calls — worktree
rebuild, busy/idle/unknown session handling, and the refusals. Also verified by
hand: a real `Resume` against a real tmux server rebuilt the reclaimed worktree
on its branch and started the session, and the history table was rendered
against this machine's own 29 finished records.