### PR TITLE
Dispatching: a row on the table the moment you ask, and the sentence you typed

### DIFF
--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/state"
 )
@@ -344,6 +346,72 @@ func TestCQFormSubmitWithoutARepo(t *testing.T) {
 	}
 	if !m.cqDispatch || m.dxWhat != "fix" {
 		t.Error("a failed submit must keep the form and what was typed")
+	}
+}
+
+// The dispatcher must be told what was typed, not what the branch is called.
+//
+// WHAT is read twice — as a name, which is capped to five slug words because it
+// names the branch, the worktree and the tmux session, and as the brief, which
+// is the only description of the work that ever reaches the session. Submit
+// composed the brief from the capped name, so every word past the fifth was
+// dropped at the form: before the record, before claude started, and with no
+// other copy of the sentence anywhere. Real records carry the prompt
+// "dispatching immediate look up when", cut mid-clause.
+func TestCQFormDispatchesTheSentenceNotTheName(t *testing.T) {
+	const what = "dispatching immediate look up when the branch already has a dispatcher"
+
+	var gotFeature, gotPrompt string
+	prev := dxLaunch
+	dxLaunch = func(_ *config.Config, _, feature, prompt string) tea.Cmd {
+		gotFeature, gotPrompt = feature, prompt
+		return nil
+	}
+	t.Cleanup(func() { dxLaunch = prev })
+
+	m := cqModel(t)
+	m.cfg = &config.Config{Roots: []string{seedRepoRoot(t, "alpha-api")}}
+	m = press(m, "d")
+	m.dxField, m.dxWhat, m.dxGoal = dxWhatF, what, "the pr is merged"
+	m, _ = m.dxSubmit()
+
+	// The name is still the branch's own words: that is what keeps the record,
+	// the branch, the worktree and the session saying one thing.
+	if want := "dispatching immediate look up when"; gotFeature != want {
+		t.Errorf("feature = %q, want %q", gotFeature, want)
+	}
+	// The brief is not.
+	if first := strings.SplitN(gotPrompt, "\n", 2)[0]; first != what {
+		t.Errorf("prompt line 1 = %q\nwant %q", first, what)
+	}
+	if !strings.Contains(gotPrompt, "done when: the pr is merged") {
+		t.Errorf("prompt lost DONE WHEN:\n%s", gotPrompt)
+	}
+}
+
+// dxDispatch is the seam the two readings part at: cap the name, never the
+// brief. A sentence inside the cap must come back whole from both.
+func TestDXDispatchCapsTheNameOnly(t *testing.T) {
+	long := "rebuild the deploy watcher so it stops polling a workflow that already finished"
+	feature, prompt := dxDispatch("  "+long+"  ", "", true)
+	if words := strings.Fields(feature); len(words) != 5 {
+		t.Errorf("feature = %q, want 5 words", feature)
+	}
+	if !strings.HasPrefix(prompt, long+"\n") {
+		t.Errorf("prompt = %q, want it to open with the whole sentence", prompt)
+	}
+
+	// Short enough to survive the cap: both readings agree, and neither invents
+	// punctuation or drops a word.
+	feature, prompt = dxDispatch("retry backoff", "", true)
+	if feature != "retry backoff" || !strings.HasPrefix(prompt, "retry backoff\n") {
+		t.Errorf("short WHAT: feature = %q, prompt = %q", feature, prompt)
+	}
+
+	// Nothing typed is still nothing: submit's "say what it should do" test
+	// reads the feature, so it must stay empty rather than become whitespace.
+	if feature, _ := dxDispatch("   ", "", true); feature != "" {
+		t.Errorf("blank WHAT gave feature %q", feature)
 	}
 }
 

--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -213,7 +213,34 @@ func (m model) dxBranch() string {
 
 // ---- what the dispatcher is actually told -------------------------------------
 
-// dxPrompt composes the prompt. AUTO and DONE WHEN have no plumbing behind
+// dxDispatch turns the form into the two strings a launch needs: the name the
+// dispatch is filed under, and the prompt the dispatcher actually receives.
+//
+// They come from the same field and must never be the same string. WHAT is
+// asked for once and read twice: as a name it has to be short, because the slug
+// it makes names the branch, the worktree directory and the tmux session; as a
+// brief it has to be whole, because it is the only description of the work that
+// ever reaches the session.
+//
+// Submitting used to name the feature from the capped slug and then compose the
+// prompt from that *same capped value*, so the cap meant to bound three
+// filesystem-facing names silently truncated the brief as well. Everything past
+// the fifth word was discarded at the form, before the record was written and
+// before claude was started — the sentence had no other copy, so it was gone.
+// The dispatcher then received its own de-hyphenated branch name as its
+// instructions: real records carry the prompt "dispatching immediate look up
+// when", which stops mid-clause on the word the condition was about to follow.
+//
+// Two returns, from two readings of one field, is what keeps that honest: the
+// cap applies to the name and stops there.
+func dxDispatch(what, goal string, auto bool) (feature, prompt string) {
+	what = strings.TrimSpace(what)
+	return dxFeatureName(what), dxPrompt(what, goal, auto)
+}
+
+// dxPrompt composes the prompt. what is the sentence as it was typed, in full:
+// the feature name is an abbreviation of it, and abbreviating a brief is not the
+// same thing as abbreviating a name. AUTO and DONE WHEN have no plumbing behind
 // them — the launch command is claude with a prompt, with no permission flags
 // and no watchdog — so they are instructions, and this is the only place they
 // exist. Keep the copy inside what a prompt can promise.
@@ -363,14 +390,13 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 		m.notice = "nothing matches — widen the filter"
 		return m, nil
 	}
-	feature := dxFeatureName(m.dxWhat)
+	goal := strings.TrimSpace(m.dxGoal)
+	feature, prompt := dxDispatch(m.dxWhat, goal, m.dxAuto)
 	if feature == "" {
 		m.dxField = dxWhatF
 		m.notice = "say what it should do"
 		return m, nil
 	}
-	goal := strings.TrimSpace(m.dxGoal)
-	prompt := dxPrompt(feature, goal, m.dxAuto)
 	branch, auto := m.dxBranch(), m.dxAuto
 
 	m = m.dxReset()
@@ -386,8 +412,17 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 		notice += " · auto"
 	}
 	m.notice = notice
-	return m, launchCmd(m.cfg, row.repo, feature, prompt)
+	return m, dxLaunch(m.cfg, row.repo, feature, prompt)
 }
+
+// dxLaunch is the launch dxSubmit hands off to, named as a variable so a test
+// can read what the form actually passes without starting a real dispatcher.
+//
+// The hand-off is where the truncated prompt got out, and it was invisible to
+// every test the form had: those assert the form's own state, and the form's
+// state was correct — m.dxWhat held the whole sentence the entire time. Only the
+// two arguments leaving this function were wrong, and nothing looked at them.
+var dxLaunch = launchCmd
 
 // ---- view strings -------------------------------------------------------------
 
@@ -660,8 +695,11 @@ func dxRepoLine(inner int, r dxRepoRow, on bool) string {
 // WHAT used to become the feature name whole, so a pasted paragraph produced a
 // 75-word name, a 91-character slug and a 96-character tmux session. Naming the
 // feature from the same capped slug the branch uses keeps all four in agreement
-// — name, branch, worktree and session — and nothing is lost: the full sentence
-// is the first line of the prompt (see dxPrompt).
+// — name, branch, worktree and session — and nothing is lost, because the full
+// sentence is the first line of the prompt. That last clause is only true while
+// the prompt is composed from WHAT rather than from this function's return: it
+// was written when both came off one variable, and was false for as long as
+// that lasted. dxDispatch is where the two readings part company.
 func dxFeatureName(what string) string {
 	slug := dispatchpkg.Slugify(strings.TrimSpace(what))
 	if slug == "" {


### PR DESCRIPTION
Two commits, one dispatch. The first is the bug that made this dispatch's own
brief unreadable; the second is what it was asking for.

---

## 1. Put a dispatch on the table the moment it is asked for

**The complaint:** you dispatch something and it disappears, only turning up in
the list later, with nothing to say it is starting.

**Why.** Dispatching is not instant and none of it is on the UI goroutine.
`launchCmd` rescans the repo roots; `dispatch.Launch` fetches the default branch
as the remote sees it, materialises a worktree, inherits the repo's trust and
starts a tmux session — and *then* writes the record. The record is what every
list here is built from, so for that whole stretch there is nothing to draw. The
row appears seconds later looking as though it had always been there.

With nothing else in flight it is worse than invisible: the triage lens falls
back to the dispatch form whenever the table is empty, so submitting puts an
**empty form** back on screen. The form you just filled in, wiped, with a notice
over it. The only available reading is "that did not work".

**The fix.** A *pending dispatch* — the cockpit's own note of what it just asked
for, on the table on the same keystroke:

```
  ·  UNASSIGNED  immediate look up when dispa…  alpha-api    —          starting session      0s

  immediate look up when dispatching        UNASSIGNED · alpha-api · feature/immediate-look-up-when-dispatching · 0s
  Starting: its worktree and session are being made. Nothing has reported back yet.
  prompt  immediate look up when dispatching done when: the pr is merged
```

- A **run** row, so it is never counted among the dispatchers waiting on you.
- **No acts** — nothing to attach to, no record to kill. An advertised key that
  cannot act is the defect this lens keeps finding in its own design.
- Every cell comes from the ask (product, repo, the branch it will appear on,
  the prompt). Nothing knowable-later is invented.

**The same words carry the rest of the wait.** A record in `StatusLaunching` has
had no hook fired for it. `cqShipDetail` says nothing about a dispatcher with no
PR, so SIGNAL was blank on the row being watched hardest — which reads as "no
news" when the news is that it is still starting. It now says `starting session`
too, and stops the moment `SessionStart` moves the record on.

**It lives exactly as long as it is the only evidence:**

| what happens | what the row does |
|---|---|
| launch fails | goes, with the notice that explains it — no row promising "starting session" under "launch failed" |
| launch succeeds | stays until a snapshot has been built since; dropping it on the success message would blank the row again for the length of the rebuild |
| the record's row arrives | replaced by it, and the cursor moves across — the selection was on this *dispatcher*, not on this row object |

`launchCmd` needed its own message for that. Every other action works on a
record that already exists, so a notice is the whole result; a launch is the one
that starts before its record does, and its outcome has a row to answer to.

Wired at all four launch sites: the triage form, the `+` overlay, and both
backlog dispatch keys.

## 2. Dispatch the sentence that was typed, not the branch name

This dispatcher's entire prompt was:

```
dispatching immediate look up when

done when: when the pr is merged
```

Not a sentence — the first five words of one, byte-identical to the record's
`feature` field, which is the branch name with the hyphens taken out.

The form asks for WHAT once and reads it twice: **as a name** it must be short
(the slug names the branch, the worktree and the tmux session, so #34 capped it
at five words); **as a brief** it must be whole (it is the only description of
the work that reaches the session). Both readings came off one variable, so
capping the name silently capped the brief. Everything past the fifth word was
dropped at the form — before the record, before `claude` started, with no other
copy. #34's commit message promised the opposite; it was false from the moment
it was written.

`dxDispatch` is where the two readings part company. The hand-off goes through a
`dxLaunch` variable so a test can read what submit actually passes — that is the
gap this got through: every form test asserts the form's own state, and the
form's state was right the whole time.

## Verification

`go test ./... -race`, `go vet`, `gofmt`, `golangci-lint` — all clean.
New tests fail on the old code with exactly the symptoms above:

- `TestCQFormDispatchesTheSentenceNotTheName` → `prompt line 1 = "dispatching immediate look up when"`
- `TestDispatchAppearsBeforeItHasLaunched` → `fleetRows() = 0 rows`

## Not done here

`dispatch.Launch` still writes its record *after* the fetch and the worktree.
Moving the write earlier would put a launching dispatch in front of every other
list too (and any second cockpit), but it means persisting a record for a launch
that can still fail — and `ReconcileSessions` deliberately never sweeps
`launching`. That is a change to the record's lifecycle, not to a view, so it is
left alone.