### PR TITLE
Let the cask install where it is installed, not only on a Mac

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -47,11 +47,24 @@ homebrew_casks:
       status hook.
     # Unsigned binary: clear the quarantine attribute so Gatekeeper does not
     # block first run.
+    #
+    # The guard is `OS.mac?` — a Ruby question, answered without running
+    # anything — and not a probe for xattr itself, because the cask ships the
+    # Linux build too (goreleaser emits an `on_linux` block, and Homebrew
+    # installs casks on Linux), so this postflight also runs on Linuxbrew,
+    # which is how the README tells a Windows user to install under WSL2.
+    # There, /usr/bin/xattr does not exist; a cask's `system_command` is
+    # SystemCommand.run! (must_succeed), so the missing binary comes back as
+    # exit 127 and raises — the probe that was meant to be the guard was
+    # itself what failed the install, and every WSL install died in
+    # postflight. must_succeed: false keeps the same promise on macOS: a
+    # quarantine we could not strip is a first-run warning, never a failed
+    # install.
     hooks:
       post:
         install: |
-          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/claude-dispatcher"]
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/claude-dispatcher"], must_succeed: false
           end
 
 # Windows native package managers. Both mirror the Homebrew tap pattern: a

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc
 
 ## Windows
 
-**Recommended: run under WSL2.** The full experience — real `tmux`, in-place attach, reply-without-attaching, the whole cockpit — depends on `tmux` as the process supervisor, and `tmux` is a Linux tool. Install a WSL2 distro (Ubuntu is fine), then use the **Linux** build exactly as documented above (`brew` via Linuxbrew, or `make install`). This is the recommended way to run the dispatcher on a Windows machine.
+**Recommended: run under WSL2.** The full experience — real `tmux`, in-place attach, reply-without-attaching, the whole cockpit — depends on `tmux` as the process supervisor, and `tmux` is a Linux tool. Install a WSL2 distro (Ubuntu is fine), then use the **Linux** build exactly as documented above (`brew` via Linuxbrew, or `make install`). Inside the distro, `brew install innovology/tap/claude-dispatcher` is the same command as on a Mac and installs the same cask — Homebrew installs casks on Linux, and the tap's cask carries the Linux build alongside the macOS one, so `U` upgrades it in place there too. This is the recommended way to run the dispatcher on a Windows machine.
 
 **Native preview (winget / scoop).** A native Windows build is published for early access once the publishers below are configured. It is honestly a preview: without `tmux` there is no shared session multiplexer, so **each dispatch opens in its own console window**, and **in-place attach (window focus) and reply (console input injection) are best-effort and still being hardened** — the `tmux`-grade session model for Windows is still being built. For the real cockpit experience today, use WSL2, and watch the cockpit as the native session model lands.
 

--- a/cask_test.go
+++ b/cask_test.go
@@ -1,0 +1,96 @@
+package main
+
+// The Homebrew cask is the one thing this repo ships that no other test can
+// reach: goreleaser writes it at release time and Homebrew runs it on someone
+// else's machine, so a mistake in it is discovered by a stranger's failed
+// install rather than by CI. This test reads the config the cask is generated
+// from and enforces the one rule that has already been broken once.
+//
+// The rule: a cask hook runs on every OS the cask covers, and this cask covers
+// Linux — goreleaser emits an `on_linux` block from the linux archives, which
+// is exactly how a Windows user installs under WSL2 (the README's recommended
+// route). So a hook that shells out to a macOS-only tool must ask `OS.mac?`
+// first, in Ruby, without spawning anything.
+//
+// What it must not do is probe for the tool by running it: a cask's
+// `system_command` is Homebrew's SystemCommand.run!, which raises
+// ErrorDuringExecution on a non-zero exit, and a missing executable comes back
+// as exit 127. The probe that was meant to be the guard was itself what failed
+// every WSL install in postflight.
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCaskHooksGuardMacOnlyCommands(t *testing.T) {
+	raw, err := os.ReadFile(".goreleaser.yml")
+	// The Nix build ships only the Go sources (see nix/package.nix), and runs
+	// the suite from that copy — there is no release config there to read.
+	if errors.Is(err, fs.ErrNotExist) {
+		t.Skip("no .goreleaser.yml alongside the sources — nix builds ship only the Go files")
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bodies := hookBodies(string(raw))
+	if len(bodies) == 0 {
+		t.Fatal("no cask hooks found — either the config moved or this test stopped reading it")
+	}
+	for _, body := range bodies {
+		guarded := false
+		for _, line := range strings.Split(body, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "if OS.mac?" {
+				guarded = true
+			}
+			if strings.Contains(line, "system_command") && !guarded {
+				t.Errorf("cask hook runs %q before asking OS.mac? — this hook also runs on Linuxbrew, "+
+					"where a missing executable raises out of system_command and fails the install:\n%s", line, body)
+			}
+		}
+	}
+}
+
+// hookBodies returns the block scalars under the cask's `hooks:` mapping —
+// the Ruby that Homebrew will run. Hand-rolled rather than parsed: the repo
+// has no YAML dependency and this needs none, because the shape it reads
+// (a `hooks:` key, then `<name>: |` block scalars beneath it) is the only
+// shape goreleaser accepts.
+func hookBodies(config string) []string {
+	var bodies []string
+	lines := strings.Split(config, "\n")
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "hooks:" {
+			continue
+		}
+		hooksIndent := indentOf(line)
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == "" {
+				continue
+			}
+			if indentOf(lines[j]) <= hooksIndent {
+				break // out of the hooks mapping
+			}
+			if !strings.HasSuffix(strings.TrimSpace(lines[j]), ": |") {
+				continue
+			}
+			var body []string
+			blockIndent := indentOf(lines[j])
+			for k := j + 1; k < len(lines); k++ {
+				if strings.TrimSpace(lines[k]) != "" && indentOf(lines[k]) <= blockIndent {
+					break
+				}
+				body = append(body, lines[k])
+			}
+			bodies = append(bodies, strings.Join(body, "\n"))
+		}
+	}
+	return bodies
+}
+
+func indentOf(line string) int { return len(line) - len(strings.TrimLeft(line, " ")) }

--- a/internal/version/install_test.go
+++ b/internal/version/install_test.go
@@ -35,6 +35,15 @@ func TestClassify(t *testing.T) {
 			want: MethodBrewFormula, cmd: "brew upgrade claude-dispatcher", canUpg: true,
 		},
 		{
+			// What a WSL2 install actually is: the tap ships one cask, and
+			// goreleaser gives it an `on_linux` block, so Linuxbrew stages it
+			// under its own Caskroom and `U` must offer the cask command there
+			// too — not the formula one it would get by guessing from GOOS.
+			name: "linuxbrew cask",
+			path: "/home/linuxbrew/.linuxbrew/Caskroom/claude-dispatcher/3.1.2/claude-dispatcher",
+			want: MethodBrewCask, cmd: "brew upgrade --cask claude-dispatcher", canUpg: true,
+		},
+		{
 			name: "linuxbrew formula",
 			path: "/home/linuxbrew/.linuxbrew/Cellar/claude-dispatcher/3.1.2/bin/claude-dispatcher",
 			want: MethodBrewFormula, cmd: "brew upgrade claude-dispatcher", canUpg: true,


### PR DESCRIPTION
## What was broken

`brew install innovology/tap/claude-dispatcher` failed on Linux — including WSL2, which the README recommends as *the* way to run the dispatcher on Windows.

The tap ships one cask, and goreleaser generates it with an `on_linux` block from the Linux archives (verified against a real `goreleaser release --snapshot` of this config), so Linuxbrew does resolve and stage it. What it could not survive was the postflight:

```ruby
postflight do
  if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", ...]
  end
end
```

A cask's `system_command` is `Cask::DSL::Base#system_command` → `SystemCommand.run!` → `must_succeed: true`. On Linux there is no `/usr/bin/xattr`; Homebrew's spawn fallback reports exit 127, and `run!` raises `ErrorDuringExecution` — the probe that was written to be the guard is what failed the install, before its `== 0` was ever evaluated.

Confirmed against the installed Homebrew rather than from reading alone:

```
$ brew ruby -e 'SystemCommand.run!("/usr/bin/definitely-not-here", args:["-h"])'
must_succeed raised: ErrorDuringExecution
$ brew ruby -e 'SystemCommand.run("/usr/bin/definitely-not-here", args:["-h"])'
must_succeed:false exit=127
```

A Homebrew formula is not the way out: goreleaser hard-deprecated `brews` in v2.16 (the release workflow pins `~> v2`), and its own note says casks are now the Linuxbrew answer too.

## The fix

- Guard the hook with `OS.mac?` — a Ruby question, answered without spawning anything, and the form goreleaser documents for this exact hook. `must_succeed: false` keeps what the probe was reaching for on macOS: a quarantine attribute we could not strip is a first-run warning, never a failed install. Generated cask from a snapshot run now reads `postflight do / if OS.mac? / … / end`.
- `cask_test.go` reads `.goreleaser.yml` and fails if a cask hook runs `system_command` before asking `OS.mac?` — nothing else in the suite can reach a file goreleaser writes and someone else's Homebrew runs. It fails on the old config and passes on the new one; it skips under Nix, whose build ships only the Go sources.
- `internal/version`: a Caskroom under `/home/linuxbrew` is a cask, so `U` on WSL offers `brew upgrade --cask`. No code change was needed — the path-based `Detect` already gets this right where a guess from GOOS would not — but the case is now in the table so it stays true.
- README: the WSL2 section says the `brew` command is the same one as on a Mac and installs the same cask.

`go test ./... -race`, `go vet`, `golangci-lint`, `gofmt` and `goreleaser check` all clean.

## Release

_no label_ — bug fix.