### PR TITLE
Put a dispatch on the table the moment it is asked for

### DIFF
--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -144,11 +144,26 @@ func replyCmd(feature, text string) tea.Cmd {
 	}
 }
 
+// launchedMsg is a finished launch attempt, carrying the feature it was for as
+// well as the notice.
+//
+// It is not an actionMsg, and the difference is the feature. Every other action
+// works on a record that already exists, so a notice is the whole result. A
+// launch is the one that starts before its record does: the cockpit has put a
+// placeholder row on the table (see pending.go) and that row is now either
+// wrong — nothing launched — or superseded. Neither can be settled from a
+// notice string, so the outcome names what it was about.
+type launchedMsg struct {
+	feature string
+	notice  string
+	failed  bool
+}
+
 // launchCmd dispatches a new feature into repoName with prompt.
 func launchCmd(cfg *config.Config, repoName, feature, prompt string) tea.Cmd {
 	return func() tea.Msg {
 		if cfg == nil {
-			return actionMsg{notice: "no config — cannot dispatch"}
+			return launchedMsg{feature: feature, notice: "no config — cannot dispatch", failed: true}
 		}
 		var found *repos.Repo
 		for _, r := range repos.Discover(cfg) {
@@ -159,13 +174,13 @@ func launchCmd(cfg *config.Config, repoName, feature, prompt string) tea.Cmd {
 			}
 		}
 		if found == nil {
-			return actionMsg{notice: "repo not found: " + repoName}
+			return launchedMsg{feature: feature, notice: "repo not found: " + repoName, failed: true}
 		}
 		d, err := dispatchpkg.Launch(*found, feature, prompt)
 		if err != nil {
-			return actionMsg{notice: "launch failed: " + err.Error()}
+			return launchedMsg{feature: feature, notice: "launch failed: " + err.Error(), failed: true}
 		}
-		return actionMsg{notice: "dispatched \"" + d.Feature + "\" → " + d.RepoName}
+		return launchedMsg{feature: feature, notice: "dispatched \"" + d.Feature + "\" → " + d.RepoName}
 	}
 }
 

--- a/internal/cockpit/actions_test.go
+++ b/internal/cockpit/actions_test.go
@@ -224,8 +224,8 @@ func TestReplyCmdNoSession(t *testing.T) {
 
 func TestLaunchCmdNoConfig(t *testing.T) {
 	msg := launchCmd(nil, "repo", "feature", "prompt")()
-	am, ok := msg.(actionMsg)
-	if !ok || !strings.Contains(am.notice, "no config") {
+	lm, ok := msg.(launchedMsg)
+	if !ok || !lm.failed || lm.feature != "feature" || !strings.Contains(lm.notice, "no config") {
 		t.Errorf("launchCmd(nil cfg) = %#v", msg)
 	}
 }
@@ -234,8 +234,8 @@ func TestLaunchCmdRepoNotFound(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{Roots: []string{dir}}
 	msg := launchCmd(cfg, "nonexistent-repo", "feature", "prompt")()
-	am, ok := msg.(actionMsg)
-	if !ok || !strings.Contains(am.notice, "repo not found") {
+	lm, ok := msg.(launchedMsg)
+	if !ok || !lm.failed || lm.feature != "feature" || !strings.Contains(lm.notice, "repo not found") {
 		t.Errorf("launchCmd(repo not found) = %#v", msg)
 	}
 }
@@ -254,8 +254,8 @@ func TestLaunchCmdEnsureBranchFails(t *testing.T) {
 	cfg := &config.Config{Roots: []string{root}}
 
 	msg := launchCmd(cfg, "fake-repo", "new feature", "do something")()
-	am, ok := msg.(actionMsg)
-	if !ok || !strings.Contains(am.notice, "launch failed") {
+	lm, ok := msg.(launchedMsg)
+	if !ok || !lm.failed || lm.feature != "new feature" || !strings.Contains(lm.notice, "launch failed") {
 		t.Errorf("launchCmd(broken repo) = %#v", msg)
 	}
 }

--- a/internal/cockpit/backlog.go
+++ b/internal/cockpit/backlog.go
@@ -380,6 +380,10 @@ func (m model) updateBacklog(k string) (model, tea.Cmd) {
 			m.notice = t.id + " names no repo — dispatch it from the form"
 		default:
 			m.notice = ""
+			// A dispatch from here lands on a lens that does not list it, so the
+			// placeholder is what makes it findable the moment the human presses 1
+			// to go and look — see pending.go.
+			m = m.markPending(m.pendingFor(t.repo, backlogFeature(t), t.prompt))
 			return m, launchCmd(m.cfg, t.repo, backlogFeature(t), t.prompt)
 		}
 	case "ctrl+d":
@@ -400,6 +404,7 @@ func (m model) updateBacklog(k string) (model, tea.Cmd) {
 				noRepo++
 				continue
 			}
+			m = m.markPending(m.pendingFor(bt.repo, backlogFeature(bt), bt.prompt))
 			cmds = append(cmds, launchCmd(m.cfg, bt.repo, backlogFeature(bt), bt.prompt))
 		}
 		m.picked = map[string]bool{}

--- a/internal/cockpit/dispatchform.go
+++ b/internal/cockpit/dispatchform.go
@@ -161,6 +161,10 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 			prompt := strings.TrimSpace(df.prompt.Value())
 			m.dispatchForm = nil
 			m.notice = "dispatching \"" + feature + "\"…"
+			// This overlay closes onto whichever lens was behind it, so the
+			// dispatch has to be on the triage table by the time the human gets
+			// there — see pending.go.
+			m = m.markPending(m.pendingFor(repo, feature, prompt)).fleetSync()
 			return m, launchCmd(m.cfg, repo, feature, prompt)
 		default:
 			var cmd tea.Cmd

--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -412,6 +412,13 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 		notice += " · auto"
 	}
 	m.notice = notice
+	// The row goes on the table now, not when the launch comes back. The form is
+	// closing over the table it was drawn on top of, and without this the human
+	// watches their dispatch land on an unchanged screen — or, with nothing else
+	// in flight, on a blank form, because that is what this lens shows when the
+	// table is empty. fleetSync re-keys the cursor over the row that just moved
+	// down; on an empty table it lands the cursor on the new row itself.
+	m = m.markPending(m.pendingFor(row.repo, feature, prompt)).fleetSync()
 	return m, dxLaunch(m.cfg, row.repo, feature, prompt)
 }
 

--- a/internal/cockpit/fleet.go
+++ b/internal/cockpit/fleet.go
@@ -303,6 +303,15 @@ func fleetRunRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 	// get-url`: collectFloor resolved it for this record moments ago.
 	forge := floorBy[rec.Feature].forge
 	signal, stalled := cqShipDetail(forge, rec)
+	// The record exists and no hook has fired for it: it was launched, and
+	// nothing has been heard from the session since. cqShipDetail has nothing to
+	// say about a dispatcher with no PR, so the cell would be blank — which on
+	// the row the human is watching most closely reads as "no news", when the
+	// news is that it is still starting. It says the same words the placeholder
+	// said a moment ago, because it is the same wait continuing.
+	if signal == "" && rec.Status == state.StatusLaunching {
+		signal = startingSignal
+	}
 
 	tone, why := "normal", s.saidBy[rec.Feature]
 	if stalled {
@@ -422,6 +431,13 @@ func (m model) fleetAll() []fleetRow {
 		if !placed[r.id] && !m.cqSuppressed[r.id] {
 			out = append(out, r)
 		}
+	}
+	// A dispatch that has been asked for and has no record yet leads the table.
+	// It is the newest thing on the screen and the one the human is looking for,
+	// having just pressed the key that made it; and it has nothing to be ranked
+	// by yet, so there is no order it could take its place in. See pending.go.
+	if pend := m.pendingRows(); len(pend) > 0 {
+		out = append(pend, out...)
 	}
 	return out
 }

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -148,6 +148,12 @@ type model struct {
 
 	cqUndo *cqUndoEntry // the last cleared row, restorable with `u`
 
+	// pending is what this cockpit has asked for and not yet seen a record for.
+	// It is the only view state that is not derived from the records, and it has
+	// to be: for the seconds a launch takes there are no records to derive from.
+	// See pending.go.
+	pending []pendingDispatch
+
 	// ---- triage lens: the structured dispatch form -------------------------
 	// The floor's freeform draft became four fields: where it lands, what it
 	// does, when it is done, and whether it needs you between steps. See
@@ -256,7 +262,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// and cleared set back onto it before anything renders, then re-key the
 		// cursor onto the row it was on — a rank that changed in this refresh
 		// would otherwise move the selection under the reader's hands.
-		return m.cqReconcile().fleetSync(), boot
+		//
+		// The pending notes are retired first, because retiring one can hand the
+		// cursor over to the row that replaced it, and fleetSync is what acts on
+		// that. See prunePending.
+		return m.prunePending().cqReconcile().fleetSync(), boot
 
 	case bootProgressMsg:
 		// Re-arming only while the screen is up is what stops a skipped boot
@@ -314,6 +324,24 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, loadSnapshotCmd(m.cfg)
 		}
 		return m, nil
+
+	case launchedMsg:
+		// A launch is the one action whose row was on screen before the action
+		// finished, so its outcome has a placeholder to answer to. A failure
+		// takes the row away with the notice that explains it — leaving a row
+		// saying "starting session" under a notice saying it did not start would
+		// be the screen contradicting itself. A success keeps the row and marks
+		// it launched; the snapshot this queues is what hands over to the record.
+		m.notice = msg.notice
+		if msg.failed {
+			m = m.dropPending(msg.feature)
+		} else {
+			m = m.settlePending(msg.feature)
+		}
+		if m.cfg != nil {
+			return m.fleetSync(), loadSnapshotCmd(m.cfg)
+		}
+		return m.fleetSync(), nil
 
 	case attachReturnedMsg:
 		m.notice = ""

--- a/internal/cockpit/pending.go
+++ b/internal/cockpit/pending.go
@@ -1,0 +1,229 @@
+package cockpit
+
+// pending.go covers the window between asking for a dispatch and the cockpit
+// having anything to show for it.
+//
+// Dispatching is not instant, and none of it happens on the UI goroutine.
+// launchCmd rescans the repo roots; dispatch.Launch then fetches the default
+// branch as the remote sees it, materialises a worktree, inherits the repo's
+// trust decision and starts a tmux session. Only after all of that does it
+// write the record — and the record is what every list in this cockpit is built
+// from. Until it lands there is literally nothing to draw, so the dispatch the
+// human just asked for was invisible for as long as the fetch and the worktree
+// took, and then appeared as though it had always been there.
+//
+// On a cockpit with nothing else in flight it was worse than invisible. viewCQ
+// falls back to the dispatch form whenever the table is empty, so submitting
+// put an empty form back on the screen: the same view the human had just filled
+// in, wiped, with a notice above it. The one reading available is "that did not
+// work", and the honest answer — it is starting — was on screen nowhere.
+//
+// A pending dispatch is the cockpit's own note of what it just asked for. It
+// draws in the table like anything else, says "starting session" where a real
+// row says what it wants, and offers no acts, because there is no session to
+// attach to and no record to kill yet. It lives exactly as long as it is the
+// only evidence there is — see prunePending.
+
+import (
+	"time"
+
+	dispatchpkg "claude-dispatcher/internal/dispatch"
+)
+
+// startingSignal is what a dispatcher says while it is starting and has not
+// reported in.
+//
+// It covers both halves of that wait — before the record exists (a pending row)
+// and after it exists but before any hook has fired for it (a record still in
+// state.StatusLaunching) — because to the human they are one wait with one
+// answer: it is starting, and nothing has come back from it yet. The halves
+// differ only in which of our own artefacts exists, which is not a distinction
+// worth two words in a table cell.
+const startingSignal = "starting session"
+
+// pendingDispatch is a dispatch this cockpit has asked for and has not yet seen
+// a record for. Everything in it is known at the moment of asking; nothing here
+// is read back from disk, which is the point — it exists precisely because
+// there is nothing on disk to read.
+type pendingDispatch struct {
+	feature string
+	repo    string
+	product string
+	branch  string
+	prompt  string
+	// since is when it was asked for, and is what the AGE column counts from.
+	since time.Time
+	// settled says the launch has finished and reported success, so a record for
+	// it now exists. It does not mean the table has caught up — see prunePending.
+	settled bool
+}
+
+// pendingID is the row id a pending dispatch carries. It is namespaced so it
+// can never collide with a record id: the cursor, the skip order and the
+// suppressed set are all keyed by id, and a placeholder must not inherit the
+// UI state of a real dispatcher (or leave any behind when it goes).
+func pendingID(feature string) string { return "pending:" + feature }
+
+// pendingFor builds the note from what the launch was given. The branch is
+// composed the way dispatch.Launch composes it rather than copied from the
+// form, so every caller gets the branch that will actually appear, not the
+// branch one particular screen previewed.
+func (m model) pendingFor(repo, feature, prompt string) pendingDispatch {
+	product := ""
+	if m.cfg != nil {
+		product = m.cfg.ProductFor(repo)
+	}
+	if product == "" {
+		// The same word collectCtx.productFor files an unmapped repo under, so
+		// the placeholder and the row that replaces it sit in one column.
+		product = clUnassigned
+	}
+	return pendingDispatch{
+		feature: feature,
+		repo:    repo,
+		product: product,
+		branch:  "feature/" + dispatchpkg.Slugify(feature),
+		prompt:  prompt,
+		since:   time.Now(),
+	}
+}
+
+// markPending records an ask. A second ask under a name already pending
+// replaces the first rather than stacking a second row: the feature name is the
+// key throughout this product — dispatch.Launch refuses a name already live —
+// so two rows would be two claims about one thing.
+func (m model) markPending(p pendingDispatch) model {
+	out := make([]pendingDispatch, 0, len(m.pending)+1)
+	for _, q := range m.pending {
+		if q.feature != p.feature {
+			out = append(out, q)
+		}
+	}
+	m.pending = append(out, p)
+	return m
+}
+
+// dropPending forgets an ask outright. This is the failure path: a launch that
+// reported an error produced no record and never will, so the row has to go
+// with the notice that says why.
+func (m model) dropPending(feature string) model {
+	out := m.pending[:0:0]
+	for _, p := range m.pending {
+		if p.feature != feature {
+			out = append(out, p)
+		}
+	}
+	m.pending = out
+	return m
+}
+
+// settlePending marks an ask as launched. The row stays: the record exists now,
+// but the table is still the one built before it did, and dropping the
+// placeholder here would blank the row for however long the next snapshot takes
+// — which is the disappearance this whole file exists to prevent.
+func (m model) settlePending(feature string) model {
+	for i := range m.pending {
+		if m.pending[i].feature == feature {
+			m.pending[i].settled = true
+		}
+	}
+	return m
+}
+
+// prunePending retires the notes a fresh snapshot has made unnecessary. It runs
+// on every snapshot, before the cursor is re-keyed.
+//
+// Two things retire a note, and they are different questions:
+//
+//   - the table now carries a row for that feature — the record landed and is
+//     saying more than we could. The cursor moves across with it, because the
+//     human's selection was on this dispatcher, not on this row object;
+//   - the launch reported success and a snapshot has since been built. The
+//     records were re-read in that build, so whatever the table now shows for
+//     this feature (including nothing, for a session that ended immediately) is
+//     the record's own answer, and ours must stop competing with it.
+//
+// A note whose launch has not reported yet survives every snapshot: nothing has
+// happened to make it untrue.
+func (m model) prunePending() model {
+	if len(m.pending) == 0 {
+		return m
+	}
+	rowFor := make(map[string]string, len(fleet))
+	for _, r := range fleet {
+		rowFor[r.feature] = r.id
+	}
+	out := m.pending[:0:0]
+	for _, p := range m.pending {
+		id, onTable := rowFor[p.feature]
+		if !onTable && !p.settled {
+			out = append(out, p)
+			continue
+		}
+		if onTable && m.fleetSelID == pendingID(p.feature) {
+			m.fleetSelID = id
+		}
+	}
+	m.pending = out
+	return m
+}
+
+// pendingRows is the placeholder rows the table should draw right now.
+//
+// A note whose feature is already on the table is skipped rather than drawn,
+// so the two can never both be up: prunePending is what retires it, and this is
+// what makes an unpruned moment harmless.
+func (m model) pendingRows() []fleetRow {
+	if len(m.pending) == 0 {
+		return nil
+	}
+	onTable := make(map[string]bool, len(fleet))
+	for _, r := range fleet {
+		onTable[r.feature] = true
+	}
+	out := make([]fleetRow, 0, len(m.pending))
+	for _, p := range m.pending {
+		if onTable[p.feature] {
+			continue
+		}
+		out = append(out, pendingRow(p))
+	}
+	return out
+}
+
+// pendingRow draws the note as a table row.
+//
+// It is a "run" row: it is not asking for anything, so it must not sit in the
+// half of the table that means someone is waiting on you, and it must not be
+// counted among the rows that do. Every cell is either known from the ask or
+// left empty — there is no stage to infer, no turn to count, no context to
+// read, and no PR — and the empty ones render as the same dashes and blanks a
+// real row shows when its source has nothing to say.
+func pendingRow(p pendingDispatch) fleetRow {
+	goal, goalLabel := "", "goal"
+	if s := cqFirstSentence(p.prompt); s != "" {
+		// The same quote, under the same label, that cqGoal will show the moment
+		// the record takes over — so the panel does not appear to change its mind
+		// about what this dispatcher was asked to do.
+		goal, goalLabel = s, "prompt"
+	}
+	return fleetRow{
+		id:        pendingID(p.feature),
+		kind:      "run",
+		rank:      fleetRank("run", "normal", false),
+		product:   p.product,
+		feature:   p.feature,
+		repo:      p.repo,
+		ref:       p.branch,
+		signal:    startingSignal,
+		tone:      "normal",
+		why:       "Starting: its worktree and session are being made. Nothing has reported back yet.",
+		goal:      goal,
+		goalLabel: goalLabel,
+		// No acts. Attach would have no session to hand over, and kill would have
+		// no record to mark — an offered key that cannot act is the defect this
+		// lens keeps finding in its own design.
+		moved:  p.since,
+		waited: p.since,
+	}
+}

--- a/internal/cockpit/pending_test.go
+++ b/internal/cockpit/pending_test.go
@@ -1,0 +1,204 @@
+package cockpit
+
+// pending_test.go guards the window a dispatch used to spend invisible: from
+// the key that starts it to the record that proves it started. See pending.go.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/state"
+)
+
+// stubLaunch swaps the form's hand-off so a submit can be driven all the way
+// through without starting a real worktree or tmux session, and reports what it
+// was passed.
+func stubLaunch(t *testing.T) *struct{ repo, feature, prompt string } {
+	t.Helper()
+	got := &struct{ repo, feature, prompt string }{}
+	prev := dxLaunch
+	dxLaunch = func(_ *config.Config, repo, feature, prompt string) tea.Cmd {
+		got.repo, got.feature, got.prompt = repo, feature, prompt
+		return nil
+	}
+	t.Cleanup(func() { dxLaunch = prev })
+	return got
+}
+
+// submitting is a model that has just dispatched "retry backoff" into a seeded
+// repo, with nothing else in flight.
+func submitting(t *testing.T) model {
+	t.Helper()
+	stubLaunch(t)
+	m := newModel()
+	m.width, m.height = 130, 40
+	m.cfg = &config.Config{Roots: []string{seedRepoRoot(t, "alpha-api")}}
+	m = press(m, "d")
+	m.dxField, m.dxWhat, m.dxGoal = dxWhatF, "retry backoff", "ci is green"
+	m, _ = m.dxSubmit()
+	return m
+}
+
+// The whole complaint: a dispatch went in and nothing appeared until the launch
+// had finished fetching, building a worktree and starting tmux. It is on the
+// table on the same keystroke now.
+func TestDispatchAppearsBeforeItHasLaunched(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	fleet = nil
+
+	m := submitting(t)
+
+	rows := m.fleetRows()
+	if len(rows) != 1 {
+		t.Fatalf("fleetRows() = %d rows, want the dispatch that was just asked for", len(rows))
+	}
+	r := rows[0]
+	if r.feature != "retry backoff" || r.repo != "alpha-api" {
+		t.Errorf("row = %q in %q", r.feature, r.repo)
+	}
+	if r.signal != startingSignal {
+		t.Errorf("signal = %q, want %q", r.signal, startingSignal)
+	}
+	if r.ref != "feature/retry-backoff" {
+		t.Errorf("ref = %q, want the branch it will appear on", r.ref)
+	}
+	// It is not asking for anything, so it must not be counted among the rows
+	// that are — the headline above the table is read as a count of demands.
+	if wants, _, _ := fleetCount(rows); wants != 0 {
+		t.Errorf("a starting dispatcher wants you %d times", wants)
+	}
+	// And it offers no keys, because there is nothing behind them yet.
+	if len(r.acts) != 0 {
+		t.Errorf("acts = %v, want none until there is a session", r.acts)
+	}
+
+	// The triage lens shows the dispatch form whenever the table is empty, so
+	// before this the screen went straight back to a blank form — the reading
+	// the human is least able to tell apart from a failure.
+	if m.cqPromptOn() {
+		t.Error("the form is still up over a table that now has a row on it")
+	}
+	if !strings.Contains(m.viewCQ(m.width, 30), "retry backoff") {
+		t.Error("the triage lens does not draw the dispatch that was just made")
+	}
+}
+
+// A launch that failed leaves no record and never will, so the row goes with
+// the notice that says so — a screen still promising "starting session" under
+// "launch failed" would be contradicting itself.
+func TestFailedLaunchTakesTheRowBack(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	fleet = nil
+
+	m := submitting(t)
+	if len(m.pending) != 1 {
+		t.Fatalf("pending = %d before the launch reports", len(m.pending))
+	}
+
+	next, _ := m.Update(launchedMsg{feature: "retry backoff", notice: "launch failed: no remote", failed: true})
+	m = next.(model)
+	if len(m.fleetRows()) != 0 || len(m.pending) != 0 {
+		t.Errorf("the row survived a failed launch: %d rows, %d pending", len(m.fleetRows()), len(m.pending))
+	}
+	if m.notice != "launch failed: no remote" {
+		t.Errorf("notice = %q", m.notice)
+	}
+}
+
+// A launch that succeeded keeps its row until the table can speak for itself.
+// Dropping it on the success message would blank the row again for as long as
+// the next snapshot takes, which is the same disappearance in a smaller window.
+func TestSuccessfulLaunchKeepsTheRowUntilTheRecordLands(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	fleet = nil
+
+	m := submitting(t)
+	next, _ := m.Update(launchedMsg{feature: "retry backoff", notice: "dispatched \"retry backoff\" → alpha-api"})
+	m = next.(model)
+	if len(m.fleetRows()) != 1 {
+		t.Fatalf("the row vanished on a successful launch: %d rows", len(m.fleetRows()))
+	}
+	m.fleetSelID = pendingID("retry backoff")
+
+	// The record lands: the table now carries a real row for the same feature.
+	fleet = []fleetRow{{id: "rec-1", kind: "run", rank: 3, feature: "retry backoff", repo: "alpha-api", signal: startingSignal}}
+	m = m.prunePending().fleetSync()
+
+	rows := m.fleetRows()
+	if len(rows) != 1 || rows[0].id != "rec-1" {
+		t.Fatalf("want exactly the record's row, got %d rows: %+v", len(rows), rows)
+	}
+	if len(m.pending) != 0 {
+		t.Errorf("the placeholder outlived the record it stood in for")
+	}
+	// The human's selection was on this dispatcher, not on this row object.
+	if m.fleetSelID != "rec-1" {
+		t.Errorf("fleetSelID = %q, want the row that replaced the placeholder", m.fleetSelID)
+	}
+}
+
+// The other end of the same wait: the record exists, no hook has fired for it,
+// and cqShipDetail has nothing to say about a dispatcher with no PR. A blank
+// SIGNAL there reads as "no news" on the row being watched hardest.
+func TestLaunchingRecordSaysItIsStarting(t *testing.T) {
+	rec := &state.Dispatch{
+		ID: "rec-1", Feature: "retry backoff", RepoName: "alpha-api",
+		Branch: "feature/retry-backoff", Status: state.StatusLaunching,
+		UpdatedAt: time.Now(),
+	}
+	r, _ := fleetRunRow(&collectCtx{}, &snapshot{}, map[string]dispatch{}, map[string]int{}, rec)
+	if r.signal != startingSignal {
+		t.Errorf("signal = %q, want %q", r.signal, startingSignal)
+	}
+
+	// And it stops saying it the moment the session reports in.
+	rec.Status = state.StatusWorking
+	r, _ = fleetRunRow(&collectCtx{}, &snapshot{}, map[string]dispatch{}, map[string]int{}, rec)
+	if r.signal == startingSignal {
+		t.Error("a working dispatcher is still claiming to be starting")
+	}
+}
+
+// A note that has been asked for but not reported on survives a snapshot: the
+// launch is still running and nothing has happened to make it untrue.
+func TestUnreportedPendingSurvivesASnapshot(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	fleet = nil
+
+	m := submitting(t)
+	m = m.prunePending()
+	if len(m.pending) != 1 {
+		t.Error("a launch still in flight had its row pruned")
+	}
+
+	// Once it has reported success, the next snapshot is the hand-over: the
+	// records were re-read in it, so whatever the table says about this feature
+	// — including nothing — is the record's answer and outranks ours.
+	m = m.settlePending("retry backoff").prunePending()
+	if len(m.pending) != 0 {
+		t.Error("a launched dispatch is still being described by its placeholder")
+	}
+}
+
+// Two dispatches under one name are one dispatch: Launch refuses the second, so
+// two rows would be two claims about one thing.
+func TestPendingIsKeyedByFeature(t *testing.T) {
+	m := newModel()
+	m = m.markPending(pendingDispatch{feature: "one", repo: "a"})
+	m = m.markPending(pendingDispatch{feature: "two", repo: "a"})
+	m = m.markPending(pendingDispatch{feature: "one", repo: "b"})
+	if len(m.pending) != 2 {
+		t.Fatalf("pending = %d, want one per feature name", len(m.pending))
+	}
+	if m.pending[1].feature != "one" || m.pending[1].repo != "b" {
+		t.Errorf("the second ask under a live name did not replace the first: %+v", m.pending)
+	}
+}


### PR DESCRIPTION
Follow-on to #42, which merged while this commit was mid-push and took only the
first of the two. This is the other one, rebased onto main.

## The complaint

You dispatch something and it disappears, turning up in the list later with
nothing to say it was starting.

## Why

Dispatching is not instant and none of it is on the UI goroutine. `launchCmd`
rescans the repo roots; `dispatch.Launch` fetches the default branch as the
remote sees it, materialises a worktree, inherits the repo's trust and starts a
tmux session — and *then* writes the record. The record is what every list here
is built from, so for that whole stretch there is nothing to draw. The row shows
up seconds later looking as though it had always been there.

With nothing else in flight it is worse than invisible: the triage lens falls
back to the dispatch form whenever the table is empty, so submitting puts an
**empty form** back on screen — the form you just filled in, wiped, with a
notice over it. The only available reading is "that did not work".

## The fix

A *pending dispatch*: the cockpit's own note of what it just asked for, on the
table on the same keystroke.

```
  ·  UNASSIGNED  immediate look up when dispa…  alpha-api    —          starting session      0s

  immediate look up when dispatching     UNASSIGNED · alpha-api · feature/immediate-look-up-when-dispatching · 0s
  Starting: its worktree and session are being made. Nothing has reported back yet.
  prompt  immediate look up when dispatching done when: the pr is merged
```

- A **run** row, so it is never counted among the dispatchers waiting on you.
- **No acts** — nothing to attach to, no record to kill yet. An advertised key
  that cannot act is the defect this lens keeps finding in its own design.
- Every cell comes from the ask (product, repo, the branch it will appear on,
  the prompt). What is not knowable yet stays blank.

**The same words carry the rest of the wait.** A record in `StatusLaunching` has
had no hook fired for it. `cqShipDetail` says nothing about a dispatcher with no
PR, so SIGNAL was blank on the row being watched hardest — "no news", where the
news is that it is still starting. It says `starting session` too, and stops the
moment `SessionStart` moves the record on.

**The note lives exactly as long as it is the only evidence:**

| what happens | what the row does |
|---|---|
| launch fails | goes, with the notice that explains it — no row promising "starting session" under "launch failed" |
| launch succeeds | stays until a snapshot has been built since; dropping it on the success message would blank the row again for the length of the rebuild |
| the record's row arrives | replaced by it, and the cursor moves across — the selection was on this *dispatcher*, not on this row object |

`launchCmd` needed its own message for that. Every other action works on a
record that already exists, so a notice is the whole result; a launch is the one
that starts before its record does, and its outcome has a row to answer to.

Wired at all four launch sites: the triage form, the `+` overlay, and both
backlog dispatch keys.

## Verification

`go test ./... -race`, `go vet`, `gofmt`, `golangci-lint` — all clean.
`TestDispatchAppearsBeforeItHasLaunched` fails on the old code with
`fleetRows() = 0 rows`.

## Not done here

`dispatch.Launch` still writes its record *after* the fetch and the worktree.
Moving the write earlier would put a launching dispatch in front of every other
list too (and any second cockpit), but it means persisting a record for a launch
that can still fail — and `ReconcileSessions` deliberately never sweeps
`launching`. That is a change to the record's lifecycle, not to a view, so it is
left alone.