### PR TITLE
Let the product name finish on the triage table

### DIFF
--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -507,7 +507,7 @@ func TestCQFooterHelpFollowsTheCursor(t *testing.T) {
 // gives way as the terminal narrows, in the order the fit() tiers set.
 func TestFleetColumnsShedByWidth(t *testing.T) {
 	for _, w := range []int{60, 80, 110, 176} {
-		cols := fleetColumns(w)
+		cols := fleetColumns(w, fleetProductMin)
 		if cols.glyph == 0 || cols.feature < 1 || cols.age == 0 {
 			t.Errorf("@%d: a load-bearing column was shed: %+v", w, cols)
 		}
@@ -519,6 +519,47 @@ func TestFleetColumnsShedByWidth(t *testing.T) {
 		}
 		// The signal cell is the flex, so it takes whatever the fixed cells
 		// leave — the row must still be exactly w columns wide.
+		line := fleetLine(w, cols, cTransparent, [flCells]string{}, [flCells]string{})
+		if dispWidth(line) != w {
+			t.Errorf("@%d: a table line is %d columns wide", w, dispWidth(line))
+		}
+	}
+}
+
+// The PRODUCT cell grows to the longest label on the table when the row can
+// spare the width, and never past a quarter of it — the design's 12 clipped
+// every real product name ("Equestrian Passport", "Claude Dispatcher") on every
+// row forever, and a clipped identity has no second chance to be read.
+func TestFleetProductColumnFitsTheLongestName(t *testing.T) {
+	rows := []fleetRow{{product: "equestrian passport"}, {product: "aura"}}
+	want := fleetProductWidth(rows) // 19 + the 1ch gap
+	if want != 20 {
+		t.Fatalf("fleetProductWidth = %d, want 20", want)
+	}
+
+	// Wide enough to spare it: the label lands whole, gap included.
+	for _, w := range []int{130, 176} {
+		cols := fleetColumns(w, want)
+		if cols.product != want {
+			t.Errorf("@%d: product = %d, want %d", w, cols.product, want)
+		}
+		if got := truncate(cqLabel(rows[0].product), cols.product-1); got != "EQUESTRIAN PASSPORT" {
+			t.Errorf("@%d: label = %q", w, got)
+		}
+	}
+
+	// Short names leave the design's layout exactly as it was.
+	if cols := fleetColumns(130, fleetProductWidth([]fleetRow{{product: "aura"}})); cols.product != fleetProductMin {
+		t.Errorf("short names moved the column: %d", cols.product)
+	}
+
+	// And no width lets it take more than a quarter of the writable row, nor
+	// drop below the floor, nor break the row's column arithmetic.
+	for _, w := range []int{70, 80, 110, 130, 176} {
+		cols := fleetColumns(w, 40)
+		if cols.product < fleetProductMin || cols.product > maxi(fleetProductMin, cqInner(w)/4) {
+			t.Errorf("@%d: a greedy product cell took %d of %d", w, cols.product, cqInner(w))
+		}
 		line := fleetLine(w, cols, cTransparent, [flCells]string{}, [flCells]string{})
 		if dispWidth(line) != w {
 			t.Errorf("@%d: a table line is %d columns wide", w, dispWidth(line))

--- a/internal/cockpit/fleet_view.go
+++ b/internal/cockpit/fleet_view.go
@@ -46,7 +46,37 @@ type fleetCols struct {
 	glyph, product, feature, repo, stage, turn, sigPad, age int
 }
 
-// fleetColumns sizes the table for a terminal width.
+// fleetProductMin is the design's PRODUCT width, kept as the floor so a table
+// of short names is laid out exactly as it was. fleetProductShare caps how much
+// of the writable width the cell may claim when it grows past that: a quarter,
+// so the three columns that answer what/why/how-long always keep the other
+// three quarters between them.
+const (
+	fleetProductMin   = 12
+	fleetProductShare = 4
+)
+
+// fleetProductWidth is the PRODUCT cell the rows in front of the human would
+// need to print their labels in full — the longest of them plus the 1ch gap the
+// cell reserves. fleetColumns takes it as a want, not an instruction.
+//
+// It is sized from the labels on the table rather than left at the design's
+// fixed 12 because a product name is the one cell on a row with no shorter true
+// form: a feature or a signal reads on into the detail panel, but "EQUESTRIAN
+// PASSPORT" clipped to "EQUESTRIAN…" is clipped on every row, on every poll,
+// forever — and two products that share a first eleven characters are then the
+// same cell.
+func fleetProductWidth(rows []fleetRow) int {
+	nat := 0
+	for _, r := range rows {
+		nat = maxi(nat, dispWidth(cqLabel(r.product)))
+	}
+	return nat + 1
+}
+
+// fleetColumns sizes the table for a terminal width. want is the PRODUCT width
+// the rows would like (fleetProductWidth); it is granted only as far as the
+// width allows.
 //
 // The design has no responsive story — its eight cells assume a browser window
 // — so the columns shed on the repo's own fit() breakpoints rather than a third
@@ -62,11 +92,12 @@ type fleetCols struct {
 // 1.3 : 1 : 1.4 is computed into fixed widths and exactly one column is left
 // flex. With a single flex cell it absorbs the remainder exactly and the row
 // stays column-exact whatever its position in the seg list.
-func fleetColumns(w int) fleetCols {
+func fleetColumns(w, want int) fleetCols {
 	cols := fleetCols{glyph: 3, sigPad: 3, age: 6}
 	showRepo := w >= 110
 	if w >= 70 {
-		cols.product = 12
+		roof := maxi(fleetProductMin, cqInner(w)/fleetProductShare)
+		cols.product = mini(maxi(want, fleetProductMin), roof)
 	}
 	if showRepo {
 		cols.stage, cols.turn = 9, 4
@@ -331,8 +362,10 @@ const fleetMinRows = 3
 // viewFleet is the table and the panel.
 func (m model) viewFleet(w, h int) string {
 	inner := cqInner(w)
-	cols := fleetColumns(w)
 	rows := m.fleetRows()
+	// Sized from the filtered rows — the ones actually on the table. The header
+	// goes through the same cols, so the two cannot drift.
+	cols := fleetColumns(w, fleetProductWidth(rows))
 	sel := clampCursor(m.fleetCursor, len(rows))
 	rule := flG(fg(cRule, strings.Repeat("─", inner)))
 


### PR DESCRIPTION
## What

The triage table's `PRODUCT` cell was a fixed 12 columns, truncated to 11. Every real product name in the config was clipped on every row at every terminal width:

```
  ○  EQUESTRIAN…  rider profile export      …
  ·  CLAUDE DISP…  product column on triage  …
```

and two products sharing a first eleven characters rendered as the same cell.

## Why this cell and not the others

A feature or a signal reads on into the detail panel under the table. A product name is pure identity — there is no shorter true form of it, and it is clipped identically on every row, on every poll, forever.

## How

- `fleetProductWidth(rows)` — the width the labels on the table would need in full (longest label + the 1ch gap the cell already reserves).
- `fleetColumns(w, want)` takes that as a *want*, not an instruction: granted up to a quarter of the writable width (`fleetProductShare`), so the three columns that answer what / why / how-long always keep the other three quarters between them.
- `fleetProductMin` (the design's 12) stays the floor, so a table of short names is laid out exactly as it was. The header goes through the same `cols`, so the two cannot drift.
- Sized from the *filtered* rows — the ones actually in front of the human.

After, at 130 columns:

```
     PRODUCT             FEATURE                     REPO                 STAGE    TURN   SIGNAL                AGE
  ○  EQUESTRIAN PASSPORT rider profile export        equestrian-passport  act         2   approve a permission   4m
  ·  CLAUDE DISPATCHER   product column on triage    claude-dispatcher    observe     1   PR #44 green          30s
```

## Tests

`TestFleetProductColumnFitsTheLongestName` covers all three halves of the rule: the long label lands whole where the width allows, short names leave the column at the design's 12, and no width lets it take more than a quarter of the row or break the row's column arithmetic. `TestFleetColumnsShedByWidth` and the render sweeps still pass.