### PR TITLE
Group by the config the human just edited, not by a stale copy

### DIFF
--- a/internal/cockpit/assign_product_test.go
+++ b/internal/cockpit/assign_product_test.go
@@ -1,0 +1,129 @@
+package cockpit
+
+// assign_product_test.go pins the one promise the assignment editor makes: what
+// it saves is what every lens then groups by. It was broken in both directions —
+// the save never reached the running cockpit, and a dispatch carried the product
+// it was launched under regardless of what the config said afterwards — so a repo
+// assigned to a product appeared under it on the products lens while triage went
+// on calling the same work unassigned.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/state"
+)
+
+// The editor writes the config file, and the cockpit re-reads nothing: the
+// object it hands every collector is the one loaded at startup. Assigning has to
+// publish into it, or the reload that follows regroups by the mapping the human
+// just replaced.
+func TestClPersistPublishesToTheRunningConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+
+	mm, cmd := m.clAssign([]string{"acme-api"}, "acme")
+	if cmd == nil {
+		t.Fatal("assigning should return a save command")
+	}
+	cmd()
+
+	if got := mm.cfg.ProductFor("acme-api"); got != "acme" {
+		t.Errorf("the cockpit's own config still says %q — the next reload regroups by the old mapping", got)
+	}
+	// The same object the collectors read, not a copy left behind by the save.
+	ctx := &collectCtx{cfg: mm.cfg}
+	if got := ctx.productFor(&state.Dispatch{RepoName: "acme-api"}); got != "acme" {
+		t.Errorf("triage resolves %q for a repo just assigned to acme", got)
+	}
+}
+
+// Unassigning has to reach the running config too, or a repo taken out of a
+// product goes on being counted in it until the cockpit is restarted.
+func TestClUnassignPublishesToTheRunningConfig(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.cfg = &config.Config{Products: map[string][]string{"acme": {"acme-api"}}}
+
+	mm, cmd := m.clAssign([]string{"acme-api"}, "")
+	if cmd != nil {
+		cmd()
+	}
+	if got := mm.cfg.ProductFor("acme-api"); got != "" {
+		t.Errorf("the cockpit's own config still has acme-api under %q", got)
+	}
+}
+
+// A write that fails must leave the cockpit grouping by what is still on disk.
+// Publishing regardless would put the screen and the file permanently at odds,
+// under a notice saying nothing had been saved.
+func TestClPersistDoesNotPublishAFailedSave(t *testing.T) {
+	// A file where the config directory has to go: every write below fails.
+	blocker := filepath.Join(t.TempDir(), "home")
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", blocker)
+
+	m := clFixture(t)
+	mm, cmd := m.clAssign([]string{"acme-api"}, "acme")
+	msg, ok := cmd().(actionMsg)
+	if !ok || msg.notice == "" {
+		t.Fatalf("a failed save must say so, got %#v", msg)
+	}
+	if got := mm.cfg.ProductFor("acme-api"); got != "" {
+		t.Errorf("nothing was written, but the cockpit now groups acme-api under %q", got)
+	}
+}
+
+// The record's product is what it was launched under. The config is what the
+// human has said since, so it wins — otherwise reassigning a repo moves it on
+// the products lens (which reads the config) and leaves every dispatch of it
+// where it was on triage (which read the record).
+func TestProductForFollowsTheConfigNotTheRecord(t *testing.T) {
+	ctx := &collectCtx{cfg: &config.Config{
+		Products: map[string][]string{"shop": {"shop-api"}, "warehouse": {}},
+	}}
+
+	rec := &state.Dispatch{RepoName: "shop-api", Product: "warehouse"}
+	if got := ctx.productFor(rec); got != "shop" {
+		t.Errorf("a repo reassigned to shop resolves %q", got)
+	}
+	// Taken out of every product: the record remembering one does not put it back.
+	loose := &state.Dispatch{RepoName: "loose-repo", Product: "shop"}
+	if got := ctx.productFor(loose); got != "unassigned" {
+		t.Errorf("an unassigned repo resolves %q, want unassigned", got)
+	}
+}
+
+// The two lenses must resolve a record the same way or they will disagree again
+// the next time the mapping changes: one function, both callers.
+func TestTriageAndProductsGroupARecordAlike(t *testing.T) {
+	cfg := &config.Config{Products: map[string][]string{"shop": {"shop-api"}}}
+	ctx := &collectCtx{cfg: cfg, records: []*state.Dispatch{
+		{ID: "1", RepoName: "shop-api", Product: "retired", Feature: "one"},
+		{ID: "2", RepoName: "loose", Feature: "two"},
+	}}
+	var s snapshot
+	collectProducts(ctx, &s)
+
+	// shop-api's dispatch counts towards shop, not towards the product the
+	// record was launched under — the same answer triage's productFor gives.
+	if got := ctx.productFor(ctx.records[0]); got != "shop" {
+		t.Errorf("triage puts the shop-api dispatch in %q", got)
+	}
+	for _, p := range s.products {
+		switch p.name {
+		case "shop":
+			if p.inflight != 1 {
+				t.Errorf("shop should carry the shop-api dispatch, inflight = %d", p.inflight)
+			}
+		case "unassigned":
+			if p.inflight != 1 {
+				t.Errorf("unassigned should carry the loose dispatch, inflight = %d", p.inflight)
+			}
+		}
+	}
+}

--- a/internal/cockpit/cluster.go
+++ b/internal/cockpit/cluster.go
@@ -137,6 +137,18 @@ func (m model) clAssign(repos []string, product string) (model, tea.Cmd) {
 // clPersist rewrites [products] from the working copy. Products are rebuilt
 // wholesale rather than patched: a repo belongs to exactly one product, so the
 // map is the truth and a merge could leave a repo in two.
+//
+// A save that works is also published into the cockpit's own config, because
+// that object — loaded once at startup and never re-read — is what every
+// collector groups by. This used to write a *copy* and leave m.cfg alone, so the
+// file on disk was right and the running cockpit went on grouping by the mapping
+// the human had just replaced: the assignment appeared in this editor's working
+// copy and nowhere else, and triage went on calling the repo unassigned until
+// the cockpit was restarted.
+//
+// The write is synchronous, like the settings editor's, so the config in memory
+// and the config on disk are never two different things: a failed write leaves
+// both as they were and says so.
 func (m model) clPersist() tea.Cmd {
 	if m.cfg == nil {
 		return func() tea.Msg { return actionMsg{notice: "no config — nothing saved"} }
@@ -153,12 +165,11 @@ func (m model) clPersist() tea.Cmd {
 	}
 	cfg := *m.cfg
 	cfg.Products = next
-	return func() tea.Msg {
-		if err := config.Save(&cfg); err != nil {
-			return actionMsg{notice: "could not save products: " + err.Error()}
-		}
-		return actionMsg{notice: ""} // reloads the snapshot so every lens regroups
+	if err := config.Save(&cfg); err != nil {
+		return func() tea.Msg { return actionMsg{notice: "could not save products: " + err.Error()} }
 	}
+	m.cfg.Products = next
+	return func() tea.Msg { return actionMsg{notice: ""} } // reloads the snapshot so every lens regroups
 }
 
 // ---- keys -------------------------------------------------------------------

--- a/internal/cockpit/collect_products.go
+++ b/internal/cockpit/collect_products.go
@@ -39,31 +39,18 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 		}
 	}
 
-	// Known product keys from config.
-	known := map[string]bool{}
-	for p := range cfg.Products {
-		known[p] = true
-	}
-
-	// prodOf maps a record onto a product key, folding anything unmapped into
-	// "unassigned".
-	prodOf := func(rec *state.Dispatch) string {
-		p := rec.Product
-		if p == "" {
-			p = cfg.ProductFor(rec.RepoName)
-		}
-		if p == "" || !known[p] {
-			return "unassigned"
-		}
-		return p
-	}
-
+	// Records group by ctx.productFor, the same rule triage uses. This was a
+	// second copy of it here, and copies drift: it read the product recorded on
+	// the dispatch while the repo grid two blocks down read the config, so one
+	// lens could show a repo under the product it had just been assigned to while
+	// the count beside it still belonged to the old one.
 	recsByProduct := map[string][]*state.Dispatch{}
 	openByRepo := map[string]int{}
 	recBranch := map[string]bool{}
 	recPR := map[string]bool{}
 	for _, rec := range ctx.records {
-		recsByProduct[prodOf(rec)] = append(recsByProduct[prodOf(rec)], rec)
+		p := ctx.productFor(rec)
+		recsByProduct[p] = append(recsByProduct[p], rec)
 		if rec.Status != state.StatusDone && rec.Status != state.StatusExited {
 			openByRepo[rec.RepoName]++
 		}

--- a/internal/cockpit/live.go
+++ b/internal/cockpit/live.go
@@ -91,8 +91,22 @@ type collectCtx struct {
 	repos   []repos.Repo
 }
 
-// productFor maps a record onto the same product key collectProducts uses,
-// folding anything unmapped into "unassigned".
+// productFor maps a record onto a product key, folding anything unmapped into
+// "unassigned". It is the ONE rule the whole cockpit groups records by — triage
+// and the products lens both call it, so the two can never disagree about where
+// a dispatch belongs.
+//
+// The config decides, not the record. rec.Product is a copy of this same lookup
+// taken when the dispatch went out (dispatch.go), so the moment the human
+// reassigns a repo the two disagree — and the record is the one that is out of
+// date. Preferring it meant an assignment landed on the products lens (which
+// reads the config) while every dispatch of that repo stayed where it was on
+// triage, or fell out into "unassigned" when the product it named had since been
+// renamed away. The config is what the human just edited; it wins, and a repo it
+// maps to nothing is unassigned because that is what unassigning it means.
+//
+// The record is still the fallback when there is no config to ask at all — with
+// nothing loaded, what the dispatch was launched under is the only thing known.
 //
 // It reads the config rather than the package's productOrder/reposByProduct
 // vars on purpose. Collectors run in order and applySnapshot only publishes
@@ -101,19 +115,16 @@ type collectCtx struct {
 // up empty while work was in flight. A collector must derive from its ctx, not
 // from the state a later collector will produce.
 func (c *collectCtx) productFor(rec *state.Dispatch) string {
-	p := rec.Product
-	if p == "" && c.cfg != nil {
-		p = c.cfg.ProductFor(rec.RepoName)
-	}
-	if p == "" {
-		return "unassigned"
-	}
-	if c.cfg != nil {
-		if _, ok := c.cfg.Products[p]; !ok {
+	if c.cfg == nil {
+		if rec.Product == "" {
 			return "unassigned"
 		}
+		return rec.Product
 	}
-	return p
+	if p := c.cfg.ProductFor(rec.RepoName); p != "" {
+		return p
+	}
+	return "unassigned"
 }
 
 // forge reports the forge a repo path belongs to: "ado" for Azure DevOps

--- a/internal/cockpit/pure_helpers_test.go
+++ b/internal/cockpit/pure_helpers_test.go
@@ -334,20 +334,23 @@ func TestCollectCtxProductFor(t *testing.T) {
 		Products: map[string][]string{"shop": {"shop-api"}},
 	}}
 
-	if got := ctx.productFor(&state.Dispatch{Product: "shop"}); got != "shop" {
-		t.Errorf("recorded product: got %q, want shop", got)
-	}
 	if got := ctx.productFor(&state.Dispatch{RepoName: "shop-api"}); got != "shop" {
 		t.Errorf("mapped by repo name: got %q, want shop", got)
 	}
-	// A repo with no mapping, and a stale product no longer in the config,
-	// both fold into "unassigned" — the same key collectProducts uses, so the
-	// floor's groups line up with the products lens.
+	// A repo with no mapping, and a product recorded on the dispatch that the
+	// config no longer agrees with, both fold into "unassigned" — the same key
+	// collectProducts uses, so the floor's groups line up with the products lens.
 	if got := ctx.productFor(&state.Dispatch{RepoName: "not-mapped"}); got != "unassigned" {
 		t.Errorf("unmapped repo: got %q, want unassigned", got)
 	}
-	if got := ctx.productFor(&state.Dispatch{Product: "retired"}); got != "unassigned" {
+	if got := ctx.productFor(&state.Dispatch{RepoName: "not-mapped", Product: "retired"}); got != "unassigned" {
 		t.Errorf("product no longer in config: got %q, want unassigned", got)
+	}
+	// With no config at all there is nothing to ask, so what the dispatch was
+	// launched under is all there is to go on.
+	none := &collectCtx{}
+	if got := none.productFor(&state.Dispatch{RepoName: "shop-api", Product: "shop"}); got != "shop" {
+		t.Errorf("no config: got %q, want the recorded shop", got)
 	}
 }
 


### PR DESCRIPTION
Assigning a repo to a product showed up on the products lens and nowhere else — triage went on calling the same dispatch **unassigned**.

## What was wrong

Two copies of the repo→product mapping were being read, and both were older than the edit.

**1. The save never reached the running cockpit.** The config object is loaded once at startup (`run.go`) and never re-read. `clPersist` wrote a *copy* of it to disk and left `m.cfg` alone, so the file was right and the process was not: every collector — triage's `productFor`, the products roll-up, repo discovery, the dispatch form's picker — kept grouping by the mapping in place when the cockpit opened. The one thing that did move was the editor's own working copy (`clMap`), which is drawn inside the products lens. That is the reported asymmetry exactly.

**2. The record outranked the config.** `rec.Product` is the same lookup, taken when the dispatch went out. It was preferred over the config, so a repo moved between products kept every dispatch of it where it was, and one whose product had since been renamed away fell into `unassigned` permanently — restart or no restart.

`collectProducts` also carried its own transcription of the rule, which is how the two lenses could drift in the first place.

## The fix

- A save that works is published into the cockpit's own config. The write is synchronous, like the settings editor's, so memory and disk are never two different things — a failed write leaves both as they were and says so.
- The config decides where a dispatch belongs; a repo it maps to nothing is unassigned, because that is what unassigning means. The record is still the answer when there is no config to ask at all.
- `collectProducts` calls `productFor` like everything else. One rule, both lenses.

## Verified

`go vet` and the full suite pass, including `-race`. Four new tests in `assign_product_test.go` cover the publish, the unassign, a failed write that must not publish, and the two lenses agreeing.

Driven end-to-end in the real binary against a sandboxed config and state dir:

| step | before | after |
|---|---|---|
| assign `alpha-api` → `Alpha`, back to triage | `UNASSIGNED` | `ALPHA` |
| record claiming a product the config contradicts | took the record's word | `UNASSIGNED`, matching the products lens |
| `u` to unassign, back to triage | unchanged until restart | `UNASSIGNED` immediately |
