### PR TITLE
Make the product history tab usable on a portfolio that has one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,13 @@
       worktree path and the cockpit's record map are both keyed by it, so a
       second concurrent dispatch of a live name would put two sessions in one
       checkout. Launch refuses it; re-dispatching a *finished* feature is
-      still fine and reuses the worktree left behind.
+      still fine and reuses the worktree left behind. "Live" is two facts
+      (`liveDispatch`), and the second is the one that bites: a live tmux
+      session is **not** a live dispatcher, because `launchCommand` ends
+      `; exec ${SHELL}` on purpose and every finished dispatch keeps its
+      session as an idle login shell. `supervisor.SessionIdle` tells them
+      apart; its *unknown* (a backend that cannot see into a session) is
+      neither, and keeps the refusal rather than guessing.
   - *Product* is the grouping lens: the cockpit list and the dispatch form's
     repo picker group by the `[products]` config, most urgent group first;
     unmapped repos fall under "other". No separate group concept.
@@ -107,6 +113,12 @@
   a real stage and every figure is what it found — the list is a description of
   that function, not decoration over it, so a stage added there gets a step here
   (a test asserts the two sets match). Any key skips it; the load continues.
+  Panels get a height as well as a width: the product panel's history tab is as
+  long as the product's past, and it is the lines *under* the list — the session
+  id and the key that reopens it — that a fixed-height column drops first, so it
+  windows around the cursor and counts what it hides rather than stopping mute.
+  `prodDay` normalises to **local** before truncating: forge timestamps are UTC
+  and the clock's are local, and a day compared across the two is never equal.
 - `internal/ship` — shipping stats (Claude-stamped = Co-Authored-By trailer).
 - `internal/version` — the build's version (stamped by goreleaser via
   `-X claude-dispatcher/internal/version.Version`), the cached, best-effort

--- a/internal/cockpit/collect_products.go
+++ b/internal/cockpit/collect_products.go
@@ -23,6 +23,12 @@ import (
 	"claude-dispatcher/internal/state"
 )
 
+// historyMax bounds how many finished dispatchers one product's history tab
+// carries. The tab is a fixed-height column and the list is as long as the
+// product's whole past, so it has to stop somewhere; what it drops is counted
+// and said out loud rather than left to read as the whole story.
+const historyMax = 40
+
 func collectProducts(ctx *collectCtx, s *snapshot) {
 	cfg := ctx.cfg
 	ghUp := gh.Available()
@@ -150,6 +156,7 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 	s.productStats = map[string]productStat{}
 	s.shipped = map[string][]shippedDay{}
 	s.productHistory = map[string][]historyItem{}
+	s.historyOlder = map[string]int{}
 	s.productVelocity = map[string][]velTile{}
 	s.team = map[string][]teamRow{}
 	s.teamVerdict = map[string]string{}
@@ -379,11 +386,19 @@ func collectProducts(ctx *collectCtx, s *snapshot) {
 			}
 			return hist[i].it.id < hist[j].it.id
 		})
-		items := make([]historyItem, 0, len(hist))
+		// Bounded, because the panel is a fixed-height column and this list is as
+		// long as the product's whole past — a portfolio a year old would rebuild
+		// hundreds of rows on every frame to show a dozen. What is dropped is
+		// counted, so the tab can say so instead of stopping without comment.
+		items := make([]historyItem, 0, mini(len(hist), historyMax))
 		for _, h := range hist {
+			if len(items) == historyMax {
+				break
+			}
 			items = append(items, h.it)
 		}
 		s.productHistory[p] = items
+		s.historyOlder[p] = len(hist) - len(items)
 
 		// ---- velocity tiles ------------------------------------------------
 		deploys7 := 0
@@ -426,7 +441,26 @@ func prodLiveAt(rec *state.Dispatch) (time.Time, bool) {
 }
 
 // prodDay truncates t to local midnight.
+//
+// The conversion to local is load-bearing, not tidiness. Timestamps arrive here
+// in two zones — the forge's merge and deploy times are UTC (gh hands them over
+// that way), the clock's are local — and Date() reads whichever zone the value
+// carries. A UTC midnight and a local midnight are different INSTANTS
+// everywhere but Greenwich, so every comparison built on this was between two
+// days that could never be equal:
+//
+//   - prodSameDay(liveAt, now) decides "live today" in the portfolio table.
+//     liveAt is always UTC, now is always local, so off UTC the column read 0
+//     however much had shipped — 0 for all fourteen products on the portfolio
+//     this was found on, against a real 9 and 1.
+//   - the same subtraction indexes the 7d sparkline, sliding every bar by the
+//     offset and dropping the oldest day off the end of the window.
+//   - prodDayLabel groups the shipped tab, so one afternoon's features could
+//     land under both "today" and their own date.
+//
+// A day is the human's day. Normalising here fixes all three at their source.
 func prodDay(t time.Time) time.Time {
+	t = t.Local()
 	y, m, d := t.Date()
 	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
 }

--- a/internal/cockpit/data.go
+++ b/internal/cockpit/data.go
@@ -70,6 +70,7 @@ var (
 	teamVerdict     = map[string]string{}
 	shipped         = map[string][]shippedDay{}
 	productHistory  = map[string][]historyItem{}
+	historyOlder    = map[string]int{}
 	productVelocity = map[string][]velTile{}
 )
 

--- a/internal/cockpit/history_test.go
+++ b/internal/cockpit/history_test.go
@@ -326,3 +326,153 @@ func TestResumeOverlayIsHonestWithoutASession(t *testing.T) {
 		t.Errorf("notice = %q", empty.notice)
 	}
 }
+
+// ---- fitting the tab into the screen it has ---------------------------------
+
+// The list grows with the product's whole past and the detail block sits under
+// it, so on a real portfolio the session id and `enter resume it` — the way
+// back into a session, which is the point of the tab — went off the bottom
+// first. Nineteen finished dispatchers already did it at 28 rows.
+func TestHistoryDetailSurvivesAShortTerminal(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	products = []product{{name: "acme"}}
+	var items []historyItem
+	for i := 0; i < 30; i++ {
+		items = append(items, historyItem{
+			id: itoa(i), feature: "feature " + itoa(i), repo: "acme-hq",
+			ended: "stopped", at: itoa(i) + "h ago", session: "sess-" + itoa(i),
+			prompt: "do the thing",
+		})
+	}
+	productHistory = map[string][]historyItem{"acme": items}
+
+	for _, h := range []int{50, 34, 28, 24, 20} {
+		m := newModel()
+		m.width, m.height = 200, h
+		m.lens, m.rightTab = "product", "history"
+		out := m.View()
+		if !strings.Contains(out, "enter resume it") {
+			t.Errorf("at %d rows the way back into a session is off screen", h)
+		}
+		if !strings.Contains(out, "sess-0") {
+			t.Errorf("at %d rows the selected row's session is not shown", h)
+		}
+	}
+}
+
+// And the cursor has to stay with the reader. j moving a selection off a list
+// that never scrolls is worse than a short list: the row acted on is one nobody
+// can see.
+func TestHistoryWindowFollowsTheCursor(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+	products = []product{{name: "acme"}}
+	var items []historyItem
+	for i := 0; i < 30; i++ {
+		items = append(items, historyItem{
+			id: itoa(i), feature: "feature " + itoa(i), repo: "acme-hq",
+			ended: "stopped", at: "1h ago", session: "sess-" + itoa(i), prompt: "p",
+		})
+	}
+	productHistory = map[string][]historyItem{"acme": items}
+
+	m := newModel()
+	m.width, m.height = 200, 26
+	m.lens, m.rightTab = "product", "history"
+	for _, want := range []int{0, 12, 29} {
+		m.historyCursor = want
+		out := m.View()
+		if !strings.Contains(out, "feature "+itoa(want)+" ") && !strings.Contains(out, "sess-"+itoa(want)) {
+			t.Errorf("cursor at %d is not on screen", want)
+		}
+		if !strings.Contains(out, "enter resume it") {
+			t.Errorf("cursor at %d pushed the resume key off screen", want)
+		}
+	}
+	// What is scrolled past is counted, not silently dropped.
+	m.historyCursor = 29
+	if out := m.View(); !strings.Contains(out, "more above") {
+		t.Error("rows above the window are hidden without a count")
+	}
+	m.historyCursor = 0
+	if out := m.View(); !strings.Contains(out, "more below") {
+		t.Error("rows below the window are hidden without a count")
+	}
+}
+
+// historyWindow's own edges, where the off-by-ones live.
+func TestHistoryWindow(t *testing.T) {
+	rows := make([]string, 20)
+	for i := range rows {
+		rows[i] = "row " + itoa(i)
+	}
+	if got := historyWindow(rows, 0, 20); len(got) != 20 || got[0] != "row 0" {
+		t.Errorf("a list that fits was windowed anyway: %d rows", len(got))
+	}
+	top := historyWindow(rows, 0, 6)
+	if len(top) != 6 || top[0] != "row 0" {
+		t.Errorf("top window = %v", top)
+	}
+	if !strings.Contains(top[5], "15 more below") {
+		t.Errorf("bottom marker = %q, want the 15 rows it hides", top[5])
+	}
+	end := historyWindow(rows, 19, 6)
+	if end[len(end)-1] != "row 19" {
+		t.Errorf("the last row is not shown when it is selected: %q", end[len(end)-1])
+	}
+	if !strings.Contains(end[0], "more above") {
+		t.Errorf("top marker = %q", end[0])
+	}
+	if got := historyWindow(rows, 5, 0); len(got) != 3 {
+		t.Errorf("a zero budget produced %d rows, want the 3-line floor", len(got))
+	}
+}
+
+// The collection is bounded, because the tab rebuilds every row on every frame
+// and a product's past only grows. What is dropped is counted and said.
+func TestHistoryIsCappedAndSaysWhatItCut(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	saved := captureVars()
+	defer restoreVars(saved)
+
+	now := time.Now()
+	total := historyMax + 7
+	var recs []*state.Dispatch
+	for i := 0; i < total; i++ {
+		recs = append(recs, &state.Dispatch{
+			ID: itoa(i), Feature: "feature " + itoa(i), RepoName: "acme-hq", Product: "acme",
+			Status: state.StatusExited, StatusReason: "killed from cockpit",
+			CreatedAt: now.Add(-time.Duration(i+1) * time.Hour),
+			UpdatedAt: now.Add(-time.Duration(i) * time.Hour),
+		})
+	}
+	var s snapshot
+	cfg := &config.Config{Products: map[string][]string{"acme": {"acme-hq"}}}
+	collectProducts(&collectCtx{cfg: cfg, records: recs}, &s)
+
+	if got := len(s.productHistory["acme"]); got != historyMax {
+		t.Errorf("history carries %d rows, want the cap of %d", got, historyMax)
+	}
+	if got := s.historyOlder["acme"]; got != total-historyMax {
+		t.Errorf("older count = %d, want %d", got, total-historyMax)
+	}
+	// The cap drops the oldest, never the newest.
+	if s.productHistory["acme"][0].feature != "feature 0" {
+		t.Errorf("history starts at %q, want the most recent", s.productHistory["acme"][0].feature)
+	}
+
+	products, productHistory, historyOlder = s.products, s.productHistory, s.historyOlder
+	m := newModel()
+	m.width, m.height = 200, 50
+	m.lens, m.rightTab = "product", "history"
+	for i, p := range products {
+		if p.name == "acme" {
+			m.productCursor = i
+		}
+	}
+	m.historyCursor = historyMax - 1
+	if out := m.View(); !strings.Contains(out, "and 7 older") {
+		t.Error("the tab stops without saying how much older history there is")
+	}
+}

--- a/internal/cockpit/live.go
+++ b/internal/cockpit/live.go
@@ -58,6 +58,7 @@ type snapshot struct {
 	teamVerdict     map[string]string
 	shipped         map[string][]shippedDay
 	productHistory  map[string][]historyItem
+	historyOlder    map[string]int
 	productVelocity map[string][]velTile
 
 	decisions         map[string][]decision
@@ -451,6 +452,9 @@ func applySnapshot(s snapshot) {
 	}
 	if s.productHistory != nil {
 		productHistory = s.productHistory
+	}
+	if s.historyOlder != nil {
+		historyOlder = s.historyOlder
 	}
 }
 

--- a/internal/cockpit/prodday_test.go
+++ b/internal/cockpit/prodday_test.go
@@ -1,0 +1,101 @@
+package cockpit
+
+// prodday_test.go covers the day arithmetic the products lens counts by. Every
+// case here is run in a zone that is NOT UTC, because that is the whole bug: on
+// a UTC machine the broken and the fixed version agree.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/state"
+)
+
+// bst is far enough from UTC that a local midnight and a UTC midnight are
+// unmistakably different instants, in the direction a European user sees.
+var bst = time.FixedZone("test+01", 60*60)
+
+// A merge time comes off the forge in UTC and `now` off the clock in local, so
+// "did this go live today" compared two midnights an offset apart and answered
+// no every time. The portfolio table's LIVE TODAY column is that comparison.
+func TestProdSameDayAcrossZones(t *testing.T) {
+	local := time.Date(2026, 8, 16, 14, 30, 0, 0, bst)
+	forge := local.UTC() // the same instant, as gh would report it
+
+	if !prodSameDay(forge, local) {
+		t.Error("the same instant in two zones is not the same day")
+	}
+	// Early afternoon local is still the same UTC date here, so the two must
+	// agree — and an hour after local midnight is the case that used to slip a
+	// day, since it is still yesterday in UTC.
+	justAfterMidnight := time.Date(2026, 8, 16, 0, 30, 0, 0, bst)
+	if !prodSameDay(justAfterMidnight.UTC(), justAfterMidnight) {
+		t.Error("00:30 local is not its own day once converted to UTC")
+	}
+	// And genuinely different days must still read as different.
+	if prodSameDay(local.AddDate(0, 0, -1), local) {
+		t.Error("yesterday reads as today")
+	}
+}
+
+// prodDayLabel groups the shipped tab. Two features shipped the same local
+// afternoon must land under one heading, whichever zone their timestamps came
+// from.
+func TestProdDayLabelIsStableAcrossZones(t *testing.T) {
+	now := time.Date(2026, 8, 16, 14, 0, 0, 0, bst)
+	fromForge := time.Date(2026, 8, 16, 9, 0, 0, 0, time.UTC)
+	fromClock := time.Date(2026, 8, 16, 11, 0, 0, 0, bst)
+
+	a := prodDayLabel(prodDay(fromForge), now)
+	b := prodDayLabel(prodDay(fromClock), now)
+	if a != b {
+		t.Errorf("one afternoon produced two headings: %q and %q", a, b)
+	}
+	if a != "today" {
+		t.Errorf("today's ships are headed %q", a)
+	}
+	if got := prodDayLabel(prodDay(now.AddDate(0, 0, -1)), now); got != "yesterday" {
+		t.Errorf("yesterday is headed %q", got)
+	}
+}
+
+// The end of it, through the collector: a feature whose deploy time is a UTC
+// timestamp from earlier the same local day has to count towards LIVE TODAY.
+// The column read zero for every non-UTC user however much had shipped.
+func TestLiveTodayCountsAForgeTimestamp(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	// Mid-morning local, so "today" is unambiguous in both zones and the test
+	// cannot pass or fail on the hour it happens to run at.
+	now := time.Now()
+	if h := now.Hour(); h < 2 || h > 21 {
+		t.Skip("too close to midnight for the local/UTC dates to be comparable")
+	}
+	deployed := now.Add(-time.Hour).UTC()
+
+	cfg := &config.Config{Products: map[string][]string{"acme": {"acme-hq"}}}
+	var s snapshot
+	collectProducts(&collectCtx{cfg: cfg, records: []*state.Dispatch{{
+		ID: "rec", Feature: "csv export", RepoName: "acme-hq", Product: "acme",
+		Status: state.StatusDone, StatusReason: "deployed — live",
+		PRNumber: 4, PRState: "MERGED", PRMergedAt: &deployed, DeployedAt: &deployed,
+		CreatedAt: now.Add(-4 * time.Hour), UpdatedAt: deployed,
+	}}}, &s)
+
+	for _, p := range s.products {
+		if p.name != "acme" {
+			continue
+		}
+		if p.live != 1 {
+			t.Errorf("LIVE TODAY = %d, want 1 — a deploy an hour ago did not count", p.live)
+		}
+		// The sparkline's last bar is today; a deploy today must move it off the
+		// floor rather than land a day out.
+		if p.spark == "" || strings.HasSuffix(p.spark, "▁") {
+			t.Errorf("7d sparkline %q does not show today's deploy in its last bar", p.spark)
+		}
+		return
+	}
+	t.Fatal("no acme product collected")
+}

--- a/internal/cockpit/product.go
+++ b/internal/cockpit/product.go
@@ -177,7 +177,12 @@ func productHunkColor(sign string) string {
 // tab strip, then the body of the tab that is up. It renders into whatever width
 // the products lens hands it — 46% of the terminal, or all of it when the
 // terminal is too narrow to hold both.
-func (m model) productPanel(cw int) []string {
+// ch is the height it has to fill. Only the history tab reads it, and it has
+// to: its list is as long as the product's past, and the lines that fall off
+// the bottom are the ones that matter — the session id and `enter resume it`
+// live under the list, so on a 28-row terminal the way back into a session was
+// already gone, while j went on moving a cursor nobody could see.
+func (m model) productPanel(cw, ch int) []string {
 	name := m.productFocusName()
 	var out []string
 
@@ -195,7 +200,7 @@ func (m model) productPanel(cw int) []string {
 	case "shipped":
 		out = append(out, m.productShippedBody(cw)...)
 	case "history":
-		out = append(out, m.productHistoryBody(cw)...)
+		out = append(out, m.productHistoryBody(cw, ch-len(out))...)
 	default:
 		out = append(out, m.productReviewBody(cw, name)...)
 	}
@@ -444,49 +449,86 @@ func (m model) productShippedBody(cw int) []string {
 // other screen in the cockpit — SHIPPED is a ship log and the triage table is
 // what is in flight — so without it the session, its transcript and its branch
 // were all still on disk with nothing anywhere able to reach them.
-func (m model) productHistoryBody(cw int) []string {
+// The detail block is built before the list and the list gets what is left of
+// ch, because the detail is the half that must never be pushed off: it names
+// the session and carries the key that reopens it. A product's history only
+// grows, so "it fits today" is not a property this can be built on.
+func (m model) productHistoryBody(cw, ch int) []string {
 	items := m.historyFlat()
-	var out []string
 	if len(items) == 0 {
-		out = append(out, fg(cFaint, "no dispatcher in this product has finished yet"))
-		return out
+		return []string{fg(cFaint, "no dispatcher in this product has finished yet")}
 	}
 	sel := clampCursor(m.historyCursor, len(items))
-	for i, h := range items {
+
+	h, _ := m.historySelected()
+	detail := []string{fg(cRule, strings.Repeat("─", cw))}
+	ref := h.pr
+	if ref == "" {
+		ref = "no pr"
+	}
+	detail = append(detail, fg(cMid, h.feature)+fg(cFaint, " · "+ref+" · "+h.ended))
+	// The session id is the handle resume works through, so its absence is
+	// stated rather than left as a blank.
+	if h.session == "" {
+		detail = append(detail, fg(cFaint, "no session recorded — enter dispatches it again"))
+	} else {
+		detail = append(detail, fg(cFaint, "session "+h.session))
+	}
+	for _, ln := range productWrap(h.prompt, cw) {
+		detail = append(detail, fg(cMid, ln))
+	}
+	detail = append(detail, fg(cDim, "enter resume it · o open pr"))
+
+	var rows []string
+	for i, it := range items {
 		bg, marker, featColor := "", " ", cFg
 		if i == sel {
 			bg, marker, featColor = cSel, "▸", cWhite
 		}
 		endedColor := cDim
-		if h.ended == "stopped" {
+		if it.ended == "stopped" {
 			endedColor = cFaint
 		}
-		out = append(out, row(cw, bg,
+		rows = append(rows, row(cw, bg,
 			c(marker, 2, cFaint),
-			flexc(h.feature, featColor),
-			c(h.repo, 16, cDim),
-			c(h.ended, 15, endedColor),
-			cr(h.at, 8, cFaint)))
+			flexc(it.feature, featColor),
+			c(it.repo, 16, cDim),
+			c(it.ended, 15, endedColor),
+			cr(it.at, 8, cFaint)))
+	}
+	if older := historyOlder[m.productFocusName()]; older > 0 {
+		rows = append(rows, fg(cFaint, "…and "+itoa(older)+" older"))
 	}
 
-	h, _ := m.historySelected()
-	out = append(out, fg(cRule, strings.Repeat("─", cw)))
-	ref := h.pr
-	if ref == "" {
-		ref = "no pr"
+	return append(historyWindow(rows, sel, ch-len(detail)), detail...)
+}
+
+// historyWindow returns the slice of rows that fits in budget lines and holds
+// the selected one, replacing the row it displaces at each cut with a count of
+// what lies beyond it. A list that simply stopped would read as the whole of a
+// product's past, and j would walk the cursor off a screen that never moved.
+func historyWindow(rows []string, sel, budget int) []string {
+	// Below three there is nothing left to say: one row and two markers.
+	if budget < 3 {
+		budget = 3
 	}
-	out = append(out, fg(cMid, h.feature)+fg(cFaint, " · "+ref+" · "+h.ended))
-	// The session id is the handle resume works through, so its absence is
-	// stated rather than left as a blank.
-	if h.session == "" {
-		out = append(out, fg(cFaint, "no session recorded — enter dispatches it again"))
-	} else {
-		out = append(out, fg(cFaint, "session "+h.session))
+	if len(rows) <= budget {
+		return rows
 	}
-	for _, ln := range productWrap(h.prompt, cw) {
-		out = append(out, fg(cMid, ln))
+	start := sel - budget/2
+	if start < 0 {
+		start = 0
 	}
-	out = append(out, fg(cDim, "enter resume it · o open pr"))
+	if start+budget > len(rows) {
+		start = len(rows) - budget
+	}
+	out := append([]string(nil), rows[start:start+budget]...)
+	if start > 0 {
+		out[0] = fg(cFaint, "↑ "+itoa(start+1)+" more above")
+	}
+	if end := start + budget; end < len(rows) {
+		out[len(out)-1] = fg(cFaint, "↓ "+itoa(len(rows)-end+1)+" more below")
+	}
 	return out
 }
 

--- a/internal/cockpit/products.go
+++ b/internal/cockpit/products.go
@@ -104,7 +104,7 @@ func (m model) viewProducts(w, h int) string {
 	// panel is the thing the human just asked for: it takes the whole width and
 	// the portfolio table waits behind esc.
 	if panelOpen && !fitv.showDetail {
-		return clampLines(productsPane(m.productPanel(maxi(w-2*pad, 1)), w), h)
+		return clampLines(productsPane(m.productPanel(maxi(w-2*pad, 1), h), w), h)
 	}
 
 	// Pane geometry: the open product panel is flex:0 0 46%, the focus summary
@@ -138,7 +138,7 @@ func (m model) viewProducts(w, h int) string {
 	rightInner := maxi(rightW-2*pad, 1)
 	right := m.productsRight(rightInner, pc)
 	if panelOpen {
-		right = m.productPanel(rightInner)
+		right = m.productPanel(rightInner, h)
 	}
 	rightBlock := productsPane(right, rightW)
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -103,7 +103,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		WorktreePath: worktree,
 		BaseSHA:      baseSHA,
 		Prompt:       prompt,
-		TmuxSession:  supervisor.UniqueName("disp-" + slug),
+		TmuxSession:  uniqueName("disp-" + slug),
 		Status:       state.StatusLaunching,
 		CreatedAt:    time.Now(),
 	}
@@ -115,7 +115,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	// the session's window open after claude exits so it stays available for
 	// inspection instead of vanishing.
 	cmd := launchCommand(d.ID, prompt)
-	if err := supervisor.NewSession(d.TmuxSession, worktree, cmd); err != nil {
+	if err := newSession(d.TmuxSession, worktree, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"
 		_ = state.Save(d)
@@ -135,13 +135,30 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 // cockpit. Re-dispatching a feature whose session has ended is still fine, and
 // deliberately reuses the worktree left behind.
 //
-// The live tmux session, not the record's status, is the test: a record can be
-// left stale by a crash, but a running session is ground truth.
+// The session, not the record's status, is the test: a record can be left stale
+// by a crash, but what is actually running is ground truth.
+//
+// It takes two facts about that session, and the second one was missing. A live
+// session is not a live dispatcher: launchCommand ends `; exec ${SHELL}` on
+// purpose, so the session outlives its claude by design and sits there as a
+// login shell for inspection. Every finished dispatch on a real machine still
+// had one, so this refused to re-dispatch any feature that had ever completed —
+// the exact case per-dispatch worktrees say is allowed, and the fallback the
+// history tab offers a row with no session left to resume.
+//
+// SessionIdle is what tells the two apart, and its "unknown" is neither: a
+// backend that cannot see into a session (the Windows console one) keeps the
+// conservative answer rather than letting a guess put two claudes in one
+// checkout.
 func liveDispatch(slug string) *state.Dispatch {
 	for _, d := range state.LoadAll() {
-		if d.Slug == slug && d.TmuxSession != "" && sessionAlive(d.TmuxSession) {
-			return d
+		if d.Slug != slug || d.TmuxSession == "" || !sessionAlive(d.TmuxSession) {
+			continue
 		}
+		if idle, known := sessionIdle(d.TmuxSession); known && idle {
+			continue // claude has ended; what is left is the shell it dropped to
+		}
+		return d
 	}
 	return nil
 }

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -195,9 +195,21 @@ func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
 	}
 
 	alive := map[string]bool{"disp-payment-retry": true}
-	restore := sessionAlive
+	// Both seams, because "live" is two facts now — the session exists, and
+	// something is still running in it. Leaving sessionIdle real also let the
+	// developer's own tmux server answer for a session this test invented.
+	busy := true
+	prevAlive, prevIdle, prevNew, prevUniq := sessionAlive, sessionIdle, newSession, uniqueName
 	sessionAlive = func(name string) bool { return alive[name] }
-	defer func() { sessionAlive = restore }()
+	sessionIdle = func(string) (bool, bool) { return !busy, true }
+	// Launch really does start a session, so the supervisor is stubbed too —
+	// without it a passing assertion below left disp-payment-retry-2 and -3 on
+	// the machine running the suite.
+	newSession = func(string, string, string) error { return nil }
+	uniqueName = func(base string) string { return base }
+	defer func() {
+		sessionAlive, sessionIdle, newSession, uniqueName = prevAlive, prevIdle, prevNew, prevUniq
+	}()
 
 	_, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go")
 	if err == nil {
@@ -212,6 +224,43 @@ func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
 	alive["disp-payment-retry"] = false
 	if got := liveDispatch("payment-retry"); got != nil {
 		t.Errorf("dead session still reported live: %#v", got)
+	}
+
+	// And the case that matters more, because it is the ordinary one: the
+	// session is still there but claude has ended and it is sitting at the
+	// login shell launchCommand drops to. Every finished dispatch looks like
+	// this, and treating it as live refused to re-dispatch any of them.
+	alive["disp-payment-retry"] = true
+	busy = false
+	if got := liveDispatch("payment-retry"); got != nil {
+		t.Errorf("a leftover login shell reported as a live dispatcher: %#v", got)
+	}
+	if _, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go"); err != nil {
+		t.Errorf("re-dispatching a finished feature was refused: %v", err)
+	}
+}
+
+// A backend that cannot see into a session — the Windows console one — must not
+// have a dispatcher declared dead on a guess. Unknown keeps the refusal.
+func TestLaunchRefusesWhenIdlenessIsUnknown(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	repo := initRepo(t)
+
+	rec := &state.Dispatch{
+		ID: state.NewID(), Feature: "Payment Retry", Slug: "payment-retry",
+		RepoPath: repo, RepoName: "acme", Branch: "feature/payment-retry",
+		TmuxSession: "disp-payment-retry", Status: state.StatusWorking,
+	}
+	if err := state.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+	prevAlive, prevIdle := sessionAlive, sessionIdle
+	sessionAlive = func(string) bool { return true }
+	sessionIdle = func(string) (bool, bool) { return true, false } // idle, but unknowably so
+	defer func() { sessionAlive, sessionIdle = prevAlive, prevIdle }()
+
+	if got := liveDispatch("payment-retry"); got == nil {
+		t.Error("an unreadable session was taken as proof its dispatcher had ended")
 	}
 }
 


### PR DESCRIPTION
Restarting a historical session from inside a product landed in #41. This is what stood between that and working on a portfolio that has some history in it — three defects, all found by pointing the real collectors at a real state directory rather than a fixture.

## The list pushed the way back out of the screen

The detail block sits under the list, and it is the half that matters: the session id, and `enter resume it`. The list is as long as the product's whole past and nothing bounded it, so the important half went off the bottom first.

Measured on this repo's own product, 19 finished dispatchers:

| terminal | `enter resume it` visible | history rows shown |
|---|---|---|
| 50 rows | yes | 19 / 19 |
| 34 rows | yes | 19 / 19 |
| **28 rows** | **no** | 19 / 19 |
| **24 rows** | **no** | **17 / 19** |
| **20 rows** | **no** | **13 / 19** |

Below 28 rows the tab could still be scrolled with `j` — onto rows nobody could see, with no way to resume the one under the cursor. "It fits today" was never a property to build on either: a product's history only grows.

The panel now gets a height as well as a width. The detail block is built first, the list gets what is left, and the window follows the cursor — replacing the row it displaces at each cut with `↑ N more above` / `↓ N more below`. The collection is bounded at 40 and reports what it dropped, so the tab says `…and 7 older` instead of stopping mute.

```
↑ 12 more above
  several improvements here: Use the claude_desi…claude-dispatch…stopped     6d ago
  next build                                     claude-dispatch…stopped     6d ago
▸ next minor build                               claude-dispatch…stopped     6d ago
  worktree                                       claude-dispatch…deployed    6d ago
↓ 6 more below
────────────────────────────────────────────────────────────────────────────────
next minor build · no pr · stopped
session dea4f7dc-5398-4f93-bebf-4b6aaf0f33c8
…
enter resume it · o open pr
```

## `prodDay` kept whichever zone it was handed

Merge and deploy times come off `gh` in UTC; the clock's are local. `Date()` reads whichever zone the value carries, and a UTC midnight and a local midnight are different **instants** everywhere but Greenwich — so every comparison built on it was between two days that could never be equal.

`prodSameDay(liveAt, now)` is the portfolio table's **LIVE TODAY** column. On this machine's real records, before and after the one-line fix:

```
                       before   after
AURA                        0       0   spark ▁▁█▁▁▁▁ → ▁█▁▁▁▁▁
Claude Dispatcher           0       9   spark ▁▁▁▁▁▁█
MarketMesh                  0       0   spark ▁▁▁▁▁█▂ → ▁▁▁▁█▂▁
SailCoach                   0       1   spark ▁▁▁▁▁▁█
Soundbooth                  0       0   spark ▁▁█▁▁█▁ → ▁█▁▁█▁▁
…all fourteen products read 0
```

Three things off one root cause: the column read zero however much had shipped, the same subtraction slid every 7d sparkline bar a day out (and pushed the oldest day off the end of the window), and `prodDayLabel` could file one afternoon under both `today` and its own date on the shipped tab. A day is the human's day; normalising to local fixes all three at the source.

## A leftover login shell counted as a live dispatcher

`launchCommand` ends `; exec ${SHELL}` on purpose, so a dispatch's tmux session outlives its claude by design and sits there as a login shell for inspection. **All twenty finished records on this machine still had one.** `liveDispatch` took a live session as proof of a live dispatcher, so the "one live dispatch per feature" guard refused to re-dispatch any feature that had ever completed normally — which is both the case per-dispatch worktrees explicitly allow, and the fallback the history tab offers a row with no session left to resume (`enter` → `launchCmd`).

`supervisor.SessionIdle`, which #41 already added for exactly this distinction inside `Resume`, is what tells the two apart. Its *unknown* — a backend that cannot see into a session, like the Windows console one — is neither, and keeps the conservative refusal rather than letting a guess put two claudes in one checkout.

## Test hygiene, found on the way

`TestLaunchRefusesDuplicateOfLiveFeature` faked `sessionAlive` but not `sessionIdle`, so the developer's own tmux server answered for a session the test had invented — it passed or failed depending on what was running on the machine. And `Launch` called `supervisor.NewSession` directly rather than through the seam `Resume` uses, so the moment the assertion above started succeeding it left `disp-payment-retry-2` and `-3` behind on this laptop. Both now go through the seams.

## Coverage

Every timezone test runs in a fixed non-UTC zone, because on a UTC machine the broken and the fixed version agree. All new tests were confirmed to fail against the unfixed code:

- `prodSameDay` across zones, `prodDayLabel` stability, and LIVE TODAY through the real collector.
- The detail block surviving 50/34/28/24/20 rows; the window following the cursor to the first, middle and last row; `historyWindow`'s own edges; the cap and its `…and N older`.
- `liveDispatch` against an idle leftover shell, a busy session, and an unreadable one.
