### PR TITLE
Stop the upgrade key blinding the build it installs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,17 @@
   upgrades it. `U` in the cockpit runs that command and re-execs. A
   declaratively-installed Nix build is never upgraded imperatively — only an
   entry in the imperative profile's `manifest.json` proves it may be.
+  - **A cached answer belongs to the build that recorded it.** `U` upgrades in
+    place and re-execs, so the build that comes back would otherwise read a
+    cache naming the release it was upgraded *from* — "latest v3.1.3" read by
+    v3.2.3 compares as "you are current" and hides everything published since,
+    for the rest of the TTL. The cache carries the `Build` that wrote it and a
+    different one re-asks; that is also why a failed check only carries forward
+    an answer this build recorded.
+  - **`U` with nothing on offer checks rather than reciting the cache**
+    (`version.Recheck`). The ambient answer is hours old by design, and a human
+    presses `U` precisely when they think it is behind. Finding a release goes
+    straight to the confirm — they pressed it to upgrade, not to be told.
 
 ## Build
 `make build` / `make vet` / `make install` (binary to ~/.local/bin — the init

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ package manager so you can watch it work, then restarts itself in place —
 same terminal, same tmux pane. Your dispatchers are tmux sessions and are not
 touched by any of this.
 
+The corner is fed by a cached check (a few hours old at most, so the cockpit
+does not chatter at GitHub). Pressing `U` when it shows nothing does not repeat
+that cache — it goes and looks, and if a release did go out in the meantime it
+takes you straight to the same confirm. So `U` is always worth a press, and
+"`v3.2.3` is the latest" is only ever said about a check that just ran.
+
 Which command it runs is read from the running binary's own path, not guessed
 from your OS:
 

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -68,6 +68,11 @@ type model struct {
 	// it, "" when up to date, unknown, or running unstamped.
 	upgradeTo string
 
+	// upgradeChecking is a U-triggered lookup in flight. It keeps a second press
+	// from opening a second network call while the first is still out — the
+	// notice already says we are looking.
+	upgradeChecking bool
+
 	shipCursor    int
 	historyCursor int
 	resumeOpen    bool
@@ -305,8 +310,30 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(trackRefreshCmd(m.cfg), refreshTick(), upgradeCheckCmd())
 
 	case upgradeMsg:
-		if version.IsOutdated(msg.latest) {
+		m.upgradeChecking = false
+		switch {
+		case msg.latest == "":
+			// No answer came back. Nothing is learned, so nothing already known
+			// is thrown away — but a human who asked is told we could not look,
+			// rather than left reading a corner that says nothing.
+			if msg.forced {
+				m.notice = "could not reach GitHub — the check will retry"
+			}
+		case version.IsOutdated(msg.latest):
 			m.upgradeTo = msg.latest
+			if msg.forced {
+				// They pressed U to upgrade, not to be told an upgrade exists.
+				// The confirm bar still asks before anything runs.
+				m.notice = ""
+				return m.startUpgrade()
+			}
+		default:
+			// A checked answer that is not ahead of us retires any older offer:
+			// the nag must not outlive the release that raised it.
+			m.upgradeTo = ""
+			if msg.forced {
+				m.notice = version.Display() + " is the latest"
+			}
 		}
 		return m, nil
 

--- a/internal/cockpit/upgrade.go
+++ b/internal/cockpit/upgrade.go
@@ -13,7 +13,13 @@ import (
 )
 
 // upgradeMsg carries the newest published release tag to the UI goroutine.
-type upgradeMsg struct{ latest string }
+// forced marks the answer a human asked for by pressing U, which is the only
+// one that gets to speak: the poll's check is ambient and says nothing unless
+// it has an upgrade to offer.
+type upgradeMsg struct {
+	latest string
+	forced bool
+}
 
 // upgradeCheckCmd looks up the newest release off the UI goroutine. The lookup
 // is cache-gated inside the version package, so firing it on every poll costs a
@@ -24,6 +30,13 @@ func upgradeCheckCmd() tea.Cmd {
 		return nil
 	}
 	return func() tea.Msg { return upgradeMsg{latest: version.Latest()} }
+}
+
+// upgradeRecheckCmd is the same lookup with the cache stepped over. It is what
+// U runs when nothing newer is known: the cached answer is good for hours, and
+// "you are on the latest" is the one thing we must not say on its word alone.
+func upgradeRecheckCmd() tea.Cmd {
+	return func() tea.Msg { return upgradeMsg{latest: version.Recheck(), forced: true} }
 }
 
 // upgradeRanMsg reports how the package manager got on, once the terminal
@@ -63,8 +76,17 @@ func (m model) startUpgrade() (model, tea.Cmd) {
 		return m, nil
 	}
 	if m.upgradeTo == "" {
-		m.notice = version.Display() + " is the latest"
-		return m, nil
+		// Knowing of nothing newer is not the same as there being nothing newer.
+		// The ambient answer is up to checkTTL old, and a human presses U because
+		// they think a release is out — so go and look rather than reciting a
+		// file. The answer comes back as a forced upgradeMsg, which either opens
+		// the confirm below or says we are current, having actually checked.
+		if m.upgradeChecking {
+			return m, nil
+		}
+		m.upgradeChecking = true
+		m.notice = "checking for a newer build…"
+		return m, upgradeRecheckCmd()
 	}
 	if !m.install.CanUpgrade() {
 		m.notice = m.install.Note

--- a/internal/cockpit/upgrade_test.go
+++ b/internal/cockpit/upgrade_test.go
@@ -138,8 +138,8 @@ func TestUpgradeKeyAsksFirst(t *testing.T) {
 	}
 }
 
-// TestUpgradeKeyRefusesWhatItCannotDo covers the three ways U is a no-op, each
-// of which has to say something rather than nothing.
+// TestUpgradeKeyRefusesWhatItCannotDo covers the two ways U is a no-op, each of
+// which has to say something rather than nothing.
 func TestUpgradeKeyRefusesWhatItCannotDo(t *testing.T) {
 	// Nix-managed: a real upgrade exists, but not one we may run.
 	stampVersion(t, "2.1.1")
@@ -155,14 +155,6 @@ func TestUpgradeKeyRefusesWhatItCannotDo(t *testing.T) {
 		t.Errorf("notice does not explain the refusal: %q", m.notice)
 	}
 
-	// Already current.
-	m = newModel()
-	m.width, m.height, m.install = 190, 44, brewInstall
-	m = press(press(m, "4"), "U")
-	if m.confirm != nil || !strings.Contains(m.notice, "latest") {
-		t.Errorf("up-to-date build: confirm=%v notice=%q", m.confirm, m.notice)
-	}
-
 	// A dev build has no release to be behind.
 	stampVersion(t, "dev")
 	m = newModel()
@@ -171,6 +163,93 @@ func TestUpgradeKeyRefusesWhatItCannotDo(t *testing.T) {
 	m = press(press(m, "4"), "U")
 	if m.confirm != nil || !strings.Contains(m.notice, "dev build") {
 		t.Errorf("dev build: confirm=%v notice=%q", m.confirm, m.notice)
+	}
+}
+
+// TestUpgradeKeyLooksBeforeClaimingToBeCurrent: knowing of nothing newer is not
+// the same as there being nothing newer — the ambient answer is up to six hours
+// old, and after an in-place upgrade it is older than the build reading it. U
+// goes and asks, and only then says we are current.
+func TestUpgradeKeyLooksBeforeClaimingToBeCurrent(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height, m.install = 190, 44, brewInstall
+	m = press(m, "4")
+
+	m, cmd := m.startUpgrade()
+	if cmd == nil {
+		t.Fatal("U answered from the cache instead of checking")
+	}
+	if !m.upgradeChecking || !strings.Contains(m.notice, "checking") {
+		t.Errorf("U does not say it is looking: checking=%v notice=%q", m.upgradeChecking, m.notice)
+	}
+	// A second press must not put a second call on the wire.
+	if _, again := m.startUpgrade(); again != nil {
+		t.Error("a second U fired a second check while the first was still out")
+	}
+
+	// The check comes back current: now the claim is one we have made.
+	next, _ := m.Update(upgradeMsg{latest: "v2.1.1", forced: true})
+	nm := next.(model)
+	if nm.confirm != nil || !strings.Contains(nm.notice, "is the latest") {
+		t.Errorf("checked-and-current: confirm=%v notice=%q", nm.confirm, nm.notice)
+	}
+	if nm.upgradeChecking {
+		t.Error("the check finished but the model still thinks one is in flight")
+	}
+
+	// It comes back unreachable: say so rather than leaving the press unanswered.
+	next, _ = m.Update(upgradeMsg{forced: true})
+	if nm = next.(model); !strings.Contains(nm.notice, "could not reach") {
+		t.Errorf("a check that could not run said %q", nm.notice)
+	}
+}
+
+// TestForcedCheckFindsOneAndAsks: the human pressed U to upgrade, not to be
+// told an upgrade exists. Finding one goes straight to the confirm bar — which
+// still asks, so nothing runs unattended.
+func TestForcedCheckFindsOneAndAsks(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height, m.install = 190, 44, brewInstall
+
+	next, _ := m.Update(upgradeMsg{latest: "v2.2.0", forced: true})
+	nm := next.(model)
+	if nm.upgradeTo != "v2.2.0" {
+		t.Errorf("the found release was not recorded: %q", nm.upgradeTo)
+	}
+	if nm.confirm == nil || nm.confirm.kind != "upgrade" {
+		t.Fatalf("U found a release and then made the human press it again: %+v", nm.confirm)
+	}
+	if !strings.Contains(nm.confirm.label, "v2.2.0") {
+		t.Errorf("confirm does not name what it found: %q", nm.confirm.label)
+	}
+}
+
+// TestPollCheckStaysAmbient: the once-a-minute check has no human waiting on
+// it. It may raise the offer and it may retire it, but it never speaks.
+func TestPollCheckStaysAmbient(t *testing.T) {
+	stampVersion(t, "2.1.1")
+	m := newModel()
+	m.width, m.height, m.install = 190, 44, brewInstall
+
+	next, _ := m.Update(upgradeMsg{latest: "v2.2.0"})
+	nm := next.(model)
+	if nm.upgradeTo != "v2.2.0" || nm.confirm != nil || nm.notice != "" {
+		t.Errorf("the poll interrupted: to=%q confirm=%v notice=%q", nm.upgradeTo, nm.confirm, nm.notice)
+	}
+
+	// A check that could not run keeps what is already known: an offer must not
+	// blink out because the network did.
+	next, _ = nm.Update(upgradeMsg{})
+	if got := next.(model).upgradeTo; got != "v2.2.0" {
+		t.Errorf("a failed check dropped the known upgrade: %q", got)
+	}
+
+	// A check that ran and found us current retires it.
+	next, _ = nm.Update(upgradeMsg{latest: "v2.1.1"})
+	if got := next.(model).upgradeTo; got != "" {
+		t.Errorf("the nag outlived the release that raised it: %q", got)
 	}
 }
 

--- a/internal/version/latest.go
+++ b/internal/version/latest.go
@@ -5,10 +5,12 @@ package version
 //
 // The answer changes a few times a week at most, while the cockpit polls every
 // minute, so the reply is cached on disk under the state dir and refetched only
-// once the cache is older than checkTTL. The call is unauthenticated (the repo
-// is public), short-timeout and best-effort: offline, rate-limited or firewalled
-// all degrade to "no signal" — the cockpit then shows the version with no
-// upgrade hint, never an error.
+// once the cache is older than checkTTL — or once a different build asks, an
+// answer being the property of whoever recorded it (see checkCache.Build).
+//
+// The call is unauthenticated (the repo is public), short-timeout and
+// best-effort: offline, rate-limited or firewalled all degrade to "no signal" —
+// the cockpit then shows the version with no upgrade hint, never an error.
 
 import (
 	"context"
@@ -34,26 +36,48 @@ var releasesURL = "https://api.github.com/repos/Innovology/claude-dispatcher/rel
 // Latest returns the newest published release tag, or "" when it is not known
 // (never checked, offline, or the check failed). It reads and writes a file and
 // may make a network call, so callers must run it off the UI goroutine.
-func Latest() string {
+func Latest() string { return check(false) }
+
+// Recheck asks the same question as Latest but goes to GitHub even when the
+// cached answer is still inside the TTL. It is what the U key runs: a human who
+// presses it is asking us to look, and answering "you are on the latest" from a
+// file written hours ago is a claim we have not checked.
+func Recheck() string { return check(true) }
+
+func check(force bool) string {
 	cached, ok := readCache()
-	if ok && time.Since(cached.CheckedAt) < checkTTL {
+	if ok && !force && cached.wroteBy(Version) && time.Since(cached.CheckedAt) < checkTTL {
 		return cached.Latest
 	}
 	tag := fetchLatest()
-	if tag == "" {
-		// A failed call teaches nothing new: keep whatever was last known, but
-		// still stamp the check so a broken network is retried on the TTL
+	if tag == "" && cached.wroteBy(Version) {
+		// A failed call teaches nothing new: keep whatever this build last knew,
+		// but still stamp the check so a broken network is retried on the TTL
 		// rather than on every poll.
 		tag = cached.Latest
 	}
-	writeCache(checkCache{Latest: tag, CheckedAt: time.Now()})
+	writeCache(checkCache{Latest: tag, CheckedAt: time.Now(), Build: Version})
 	return tag
 }
 
+// checkCache is the answer on disk, stamped with the build that recorded it.
+//
+// Build is what stops the cockpit's own upgrade key blinding it. `U` installs
+// the release the cache pointed at and re-execs, so the new build's very first
+// read finds an answer naming a release it is now ahead of — "latest v3.1.3"
+// read by v3.2.3 — which compares as "you are current" and hides the two
+// releases that shipped while the cockpit was open. The answer belongs to the
+// build that asked the question: a different build has to ask again.
 type checkCache struct {
 	Latest    string    `json:"latest"`
 	CheckedAt time.Time `json:"checked_at"`
+	Build     string    `json:"build"`
 }
+
+// wroteBy reports whether v is the build that recorded this answer. A cache
+// written before this field existed answers false and is re-fetched once, which
+// is the same thing it means: we cannot tell who wrote it.
+func (c checkCache) wroteBy(v string) bool { return c.Build != "" && c.Build == v }
 
 func cachePath() string { return filepath.Join(state.Dir(), "version-check.json") }
 

--- a/internal/version/latest_test.go
+++ b/internal/version/latest_test.go
@@ -31,10 +31,25 @@ func serveTag(t *testing.T, tag string, status int) *int32 {
 	return &hits
 }
 
-// seedCache writes the on-disk answer as if it had been fetched `age` ago.
+// seedCache writes the on-disk answer as if this build had fetched it `age`
+// ago. Stamping the running Version is what makes it a cache we are entitled to
+// read back; seedCacheFrom seeds one another build left behind.
 func seedCache(t *testing.T, tag string, age time.Duration) {
 	t.Helper()
-	writeCache(checkCache{Latest: tag, CheckedAt: time.Now().Add(-age)})
+	seedCacheFrom(t, tag, age, Version)
+}
+
+func seedCacheFrom(t *testing.T, tag string, age time.Duration, build string) {
+	t.Helper()
+	writeCache(checkCache{Latest: tag, CheckedAt: time.Now().Add(-age), Build: build})
+}
+
+// stampVersion runs the package as a released build for the duration of a test.
+func stampVersion(t *testing.T, v string) {
+	t.Helper()
+	orig := Version
+	Version = v
+	t.Cleanup(func() { Version = orig })
 }
 
 func TestLatestFetchesThenServesFromCache(t *testing.T) {
@@ -92,6 +107,75 @@ func TestLatestIsEmptyWhenNothingIsKnown(t *testing.T) {
 	}
 	if IsOutdated(Latest()) {
 		t.Fatal("an unknown latest reported the build as outdated")
+	}
+}
+
+// TestUpgradingDoesNotBlindTheNextBuild is the bug the U key introduced. The
+// cockpit upgrades in place and re-execs, so the build that comes back finds a
+// cached answer naming the release it was just upgraded *from* — v3.1.3 read by
+// v3.2.3, which compares as "you are current" and hides everything published
+// since. The answer belongs to the build that recorded it.
+func TestUpgradingDoesNotBlindTheNextBuild(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "v3.2.5", http.StatusOK)
+	// What the pre-upgrade cockpit left behind, well inside the TTL.
+	seedCacheFrom(t, "v3.1.3", time.Minute, "3.1.3")
+	stampVersion(t, "3.2.3")
+
+	if got := Latest(); got != "v3.2.5" {
+		t.Fatalf("Latest() = %q, want v3.2.5 — the new build inherited the old build's answer", got)
+	}
+	if !IsOutdated(Latest()) {
+		t.Fatal("two releases went out and the cockpit would show no upgrade")
+	}
+	// Having asked once, this build owns the answer and stops asking.
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1 — the re-read is not being cached", n)
+	}
+}
+
+// TestAnOlderBuildsAnswerIsNotKeptOnFailure: offline after an upgrade, the
+// stale-by-a-release answer is dropped rather than carried forward. "No signal"
+// shows nothing; keeping v3.1.3 would have the cockpit assert we are current.
+func TestAnOlderBuildsAnswerIsNotKeptOnFailure(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "", http.StatusInternalServerError)
+	seedCacheFrom(t, "v3.1.3", time.Minute, "3.1.3")
+	stampVersion(t, "3.2.3")
+
+	if got := Latest(); got != "" {
+		t.Fatalf("Latest() = %q, want \"\" — an answer from a build ago is not last-known-good", got)
+	}
+	// And the failure is still stamped by this build, so the retry waits for the
+	// TTL instead of firing on every poll.
+	if got := Latest(); got != "" {
+		t.Fatalf("second Latest() = %q, want \"\"", got)
+	}
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1 — a failed check is not being backed off", n)
+	}
+}
+
+// TestRecheckStepsOverAFreshCache: U asks us to look. A cache written a second
+// ago is exactly the case where the human knows something we do not.
+func TestRecheckStepsOverAFreshCache(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	hits := serveTag(t, "v3.2.5", http.StatusOK)
+	stampVersion(t, "3.2.3")
+	seedCache(t, "v3.2.3", time.Second)
+
+	if got := Latest(); got != "v3.2.3" {
+		t.Fatalf("Latest() = %q, want the cached v3.2.3", got)
+	}
+	if got := Recheck(); got != "v3.2.5" {
+		t.Fatalf("Recheck() = %q, want the refetched v3.2.5", got)
+	}
+	if n := atomic.LoadInt32(hits); n != 1 {
+		t.Fatalf("hit GitHub %d times, want 1 — only the forced check should have gone out", n)
+	}
+	// What it found is now the cached answer, so the poll behind it agrees.
+	if got := Latest(); got != "v3.2.5" {
+		t.Fatalf("Latest() after Recheck() = %q, want v3.2.5", got)
 	}
 }
 


### PR DESCRIPTION
## What was broken

The cockpit stopped noticing releases. On this machine, at diagnosis:

- running **v3.2.3** (homebrew cask), latest published **v3.2.5**
- `~/.local/state/claude-dispatcher/version-check.json` → `{"latest":"v3.1.3","checked_at":"…15:24:57+01:00"}`

The check never failed. v3.1.3 genuinely *was* the newest release at 14:24Z, when that cache was written. What happened next is that the human pressed `U`, brew installed v3.2.3, and the cockpit re-execed — inheriting a cached answer naming the release it had just been upgraded *from*. `IsOutdated("v3.1.3")` against 3.2.3 is false, so the corner went quiet, with two releases already out and ~3 hours of TTL still to run.

Every in-place upgrade does this, by construction. The answer that made us upgrade is, a second later, an answer about a build we no longer are. Before `U`, upgrades happened out of band and hours from a restart, so it never showed; the upgrade key made it systematic.

## The fix

**An answer belongs to the build that recorded it.** The cache carries the `Version` that wrote it, and a different build asks again — once, then it owns the answer, so there is no re-fetch loop. A failed check likewise only carries forward what *this* build last knew, so going offline after an upgrade shows no signal rather than a release we are already past.

**`U` with nothing on offer goes and looks** (`version.Recheck`, which steps over the TTL) instead of reciting a file that is hours old by design. It was the one moment we could be sure a human suspected otherwise, and the one answer we had not checked. A release it finds goes straight to the confirm — they pressed it to upgrade, not to be told one exists. The confirm still asks before anything runs; a second press while the first call is out is ignored; an unreachable GitHub says so rather than leaving the press unanswered.

The once-a-minute poll stays ambient and silent, but may now retire an offer as well as raise one — only ever on an answer that actually came back, so a network blip cannot blink out a known upgrade.

## Verified

Against the real poisoned cache from this machine, stamped as the build `U` installed:

```
cache on disk: latest="v3.1.3" build=""
before the fix, the footer asked: IsOutdated("v3.1.3") = false
Latest() now = "v3.2.7"  IsOutdated = true
```

In the running cockpit (stamped v3.2.3, same cache, real footer):

```
… 1…6 sections            v3.2.3 → v3.2.7 · see github.com/Innovology/claude-dispatcher/releases
```

And pressing `U` live on a build that really is current:

```
… 6 velocity · 1 triage                        v3.2.7 is the latest  ·  v3.2.7
```

— which is now a claim about a check that just ran.

Seven new tests cover it: the post-upgrade blind spot, the offline-after-upgrade case, the back-off that keeps a failed check off every poll, `Recheck` stepping over a fresh cache, and the cockpit paths (`U` checks before claiming, a forced find opens the confirm, a second press is ignored, the poll stays silent). `go vet`, `gofmt` and the full suite are clean.
