### PR TITLE
Make the age move, and say which age it is

### DIFF
--- a/internal/cockpit/age_test.go
+++ b/internal/cockpit/age_test.go
@@ -1,0 +1,162 @@
+package cockpit
+
+// age_test.go covers the two things the triage table says about time: that its
+// ages move on their own, and that there are two of them.
+//
+// Both were defects. Every age on the screen was formatted from the clock at
+// the moment something happened to call View, and the only thing that regularly
+// did was the once-a-minute poll — so a column counting in seconds stood still
+// for a minute at a time and then jumped. And the one column it had answered
+// "how long since it moved", which is not the same question as "how long has
+// this been going" and cannot stand in for it.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/config"
+	"claude-dispatcher/internal/state"
+)
+
+// The clock tick is a redraw and nothing else: it re-arms itself, and it leaves
+// the model exactly as it found it. Anything it changed, or any load it kicked
+// off, would be work running once a second for as long as the cockpit is open.
+func TestAgeTickRedrawsAndDoesNothingElse(t *testing.T) {
+	m := cqModel(t)
+	next, cmd := m.Update(ageTickMsg{})
+	if cmd == nil {
+		t.Fatal("the clock tick must re-arm, or the screen ages once and then stops")
+	}
+	if !reflect.DeepEqual(next.(model), m) {
+		t.Error("the clock tick changed the model; it is supposed to cost a render and no more")
+	}
+	if msg := cmd(); msg != (ageTickMsg{}) {
+		t.Errorf("the tick re-armed with %#v, want another clock tick", msg)
+	}
+}
+
+// The ages on the table are read from the clock every time it is drawn, not
+// formatted once into the snapshot. This is the whole reported bug: a fleet
+// that has not changed on disk must still say a later time a second later.
+func TestAgesAreReadFromTheClockOnEveryRender(t *testing.T) {
+	saved := captureVars()
+	defer restoreVars(saved)
+
+	start := time.Now()
+	fleet = []fleetRow{{
+		id: "id-tick", kind: "run", rank: 3, product: "alpha",
+		feature: "ticker", repo: "alpha-api", signal: "working", tone: "normal",
+		moved: start, started: start.Add(-90 * time.Minute),
+	}}
+	cqLastOutput = start
+
+	m := newModel()
+	m.width, m.height = 130, 40
+
+	first := m.viewCQ(m.width, 30)
+	if !strings.Contains(first, "0s") {
+		t.Fatalf("a dispatcher that just wrote should read 0s:\n%s", first)
+	}
+
+	// Nothing is reloaded and no var is touched — only the clock moves.
+	time.Sleep(1100 * time.Millisecond)
+
+	want := cqAge(start) // what the clock says now, computed the same way
+	if want == "0s" {
+		t.Fatalf("the test clock did not advance: cqAge = %q", want)
+	}
+	second := m.viewCQ(m.width, 30)
+	if strings.Contains(second, "0s") {
+		t.Errorf("the age is frozen at 0s a second later:\n%s", second)
+	}
+	if !strings.Contains(second, want) {
+		t.Errorf("the age should read %q now:\n%s", want, second)
+	}
+	// The unattended line carries the same measurement and used to carry it as a
+	// string baked into the snapshot, which froze for a whole poll.
+	if !strings.Contains(cqUnattendedLine(), "last output "+want+" ago") {
+		t.Errorf("the last-output clause is stale: %q, want %q", cqUnattendedLine(), want)
+	}
+}
+
+// LAST and AGE are two columns because they are two facts. A session six
+// seconds from its last write and three hours into its run is the row that
+// proves it: one column could only ever have shown one of those numbers.
+func TestTableShowsLastActivityAndDispatcherAgeSeparately(t *testing.T) {
+	m := cqModel(t) // "three": moved 6s ago, started 3h ago
+	out := m.viewCQ(m.width, 30)
+
+	head := lineContaining(out, "SIGNAL")
+	if !strings.Contains(head, "LAST") || !strings.Contains(head, "AGE") {
+		t.Errorf("the column header names one age, not two: %q", head)
+	}
+
+	row := lineContaining(out, "three")
+	if !strings.Contains(row, "6s") {
+		t.Errorf("LAST should say 6s since it last wrote: %q", row)
+	}
+	if !strings.Contains(row, "3h") {
+		t.Errorf("AGE should say the dispatcher is 3h old: %q", row)
+	}
+	// And the panel spells out which is which, where the table has headers to
+	// do it.
+	where := cqWhere(fleet[2])
+	if !strings.Contains(where, "moved 6s ago") || !strings.Contains(where, "3h old") {
+		t.Errorf("the panel locator = %q", where)
+	}
+}
+
+// The collector must carry the instants, not their rendered ages: a string
+// formatted at load time is as stale as the load, which is what the clock tick
+// cannot fix.
+func TestCollectFleetCarriesInstantsNotRenderedAges(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_DISPATCHER_STATE", dir)
+
+	now := time.Now()
+	rec := &state.Dispatch{
+		ID: "ager", Feature: "age of dispatcher", RepoName: "shop-api", RepoPath: dir,
+		Status: state.StatusNeedsInput, StatusReason: "turn complete — waiting on you",
+		CreatedAt: now.Add(-2 * time.Hour), UpdatedAt: now.Add(-90 * time.Second),
+	}
+	if err := state.Save(rec); err != nil {
+		t.Fatal(err)
+	}
+
+	saved := captureVars()
+	defer restoreVars(saved)
+	s := loadSnapshot(&config.Config{})
+
+	var found *fleetRow
+	for i := range s.fleet {
+		if s.fleet[i].feature == "age of dispatcher" {
+			found = &s.fleet[i]
+		}
+	}
+	if found == nil {
+		t.Fatal("the dispatcher is missing from the fleet")
+	}
+	if !found.started.Equal(rec.CreatedAt) {
+		t.Errorf("started = %v, want the record's CreatedAt %v", found.started, rec.CreatedAt)
+	}
+	if found.moved.Before(rec.UpdatedAt) {
+		t.Errorf("moved = %v, want at least UpdatedAt %v", found.moved, rec.UpdatedAt)
+	}
+	// Two different answers off one record, which is the point of the pair.
+	if cqAge(found.moved) == cqAge(found.started) {
+		t.Errorf("both ages read %q — the columns are measuring the same thing",
+			cqAge(found.moved))
+	}
+}
+
+// lineContaining is the rendered line a marker falls on, ANSI and all.
+func lineContaining(out, marker string) string {
+	for _, ln := range strings.Split(out, "\n") {
+		if strings.Contains(ln, marker) {
+			return ln
+		}
+	}
+	return ""
+}

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -35,6 +35,7 @@ func installFleetFixture(t *testing.T) {
 				{k: "s", d: "skip"},
 			},
 			moved: now.Add(-4 * time.Minute), waited: now.Add(-4 * time.Minute),
+			started: now.Add(-2 * time.Hour),
 		},
 		{
 			id: "id-two", kind: "queue", rank: 1, ask: "turn-done", product: "beta",
@@ -47,6 +48,7 @@ func installFleetFixture(t *testing.T) {
 				{k: "s", d: "skip"},
 			},
 			moved: now.Add(-time.Hour), waited: now.Add(-time.Hour),
+			started: now.Add(-time.Hour),
 		},
 		{
 			id: "id-three", kind: "run", rank: 3, product: "alpha",
@@ -56,7 +58,10 @@ func installFleetFixture(t *testing.T) {
 				{k: "⏎", d: "attach", ok: "attaching to alpha-web session…", keep: true},
 				{k: "x", d: "kill", ok: "killed \"three\""},
 			},
+			// Six seconds since it last wrote, going for three hours: the pair
+			// the two age columns exist to tell apart.
 			moved: now.Add(-6 * time.Second), waited: now.Add(-6 * time.Second),
+			started: now.Add(-3 * time.Hour),
 		},
 		{
 			// History: a session that is over. It is in the same collected slice
@@ -71,9 +76,10 @@ func installFleetFixture(t *testing.T) {
 				{k: "o", d: "open pr", ok: "opening the pull request for \"four\"…", keep: true},
 			},
 			moved: now.Add(-3 * time.Hour), waited: now.Add(-3 * time.Hour),
+			started: now.Add(-4 * time.Hour),
 		},
 	}
-	cqLastOutput = "6s"
+	cqLastOutput = now.Add(-6 * time.Second)
 }
 
 func cqModel(t *testing.T) model {
@@ -522,12 +528,13 @@ func TestCQFooterHelpFollowsTheCursor(t *testing.T) {
 	}
 }
 
-// Four columns never shed: how bad, what, why and how long. Everything else
-// gives way as the terminal narrows, in the order the fit() tiers set.
+// Five columns never shed: how bad, what, why and both answers to how long.
+// Everything else gives way as the terminal narrows, in the order the fit()
+// tiers set.
 func TestFleetColumnsShedByWidth(t *testing.T) {
 	for _, w := range []int{60, 80, 110, 176} {
 		cols := fleetColumns(w, fleetProductMin)
-		if cols.glyph == 0 || cols.feature < 1 || cols.age == 0 {
+		if cols.glyph == 0 || cols.feature < 1 || cols.seen == 0 || cols.age == 0 {
 			t.Errorf("@%d: a load-bearing column was shed: %+v", w, cols)
 		}
 		if (w >= 70) != (cols.product > 0) {

--- a/internal/cockpit/cqrows.go
+++ b/internal/cockpit/cqrows.go
@@ -128,12 +128,21 @@ func cqLabel(p string) string {
 // The PR reference rides here and nowhere else on this screen. The v3 item
 // header that used to carry it is gone with the one-at-a-time queue, and a PR
 // number is the handle you would actually type into gh.
+// The panel has room for words the table's two age columns do not, so it spends
+// them: bare "4s · 3h" here would be two numbers with nothing saying which is
+// which, where the table has LAST and AGE standing over them.
 func cqWhere(r fleetRow) string {
-	parts := make([]string, 0, 4)
-	for _, p := range []string{cqLabel(r.product), r.repo, r.ref, cqAge(r.moved)} {
+	parts := make([]string, 0, 5)
+	for _, p := range []string{cqLabel(r.product), r.repo, r.ref} {
 		if p != "" {
 			parts = append(parts, p)
 		}
+	}
+	if a := cqAge(r.moved); a != "" {
+		parts = append(parts, "moved "+a+" ago")
+	}
+	if a := cqAge(r.started); a != "" {
+		parts = append(parts, a+" old")
 	}
 	return strings.Join(parts, " · ")
 }
@@ -243,8 +252,8 @@ func cqUnattendedLine() string {
 		return "nothing running unattended"
 	}
 	s := itoa(n) + " running unattended"
-	if cqLastOutput != "" {
-		s += " · last output " + cqLastOutput + " ago"
+	if a := cqAge(cqLastOutput); a != "" {
+		s += " · last output " + a + " ago"
 	}
 	// `w` no longer opens a view of its own — it narrows the table to the
 	// running rows — so the sentence advertises what the key now does.

--- a/internal/cockpit/data.go
+++ b/internal/cockpit/data.go
@@ -1,6 +1,10 @@
 package cockpit
 
-import "claude-dispatcher/internal/repos"
+import (
+	"time"
+
+	"claude-dispatcher/internal/repos"
+)
 
 // data.go declares every data var the lenses render. They start empty and are
 // only ever filled by applySnapshot (live.go) from the collectors, so nothing
@@ -30,13 +34,20 @@ var (
 //
 // fleet is every dispatcher in flight, ranked: the ones that want you first.
 //
-// cqLastOutput is a bare age ("6s"), or "" when no running session has a
-// transcript we could read — the view drops the clause rather than printing a
-// zero, so an unreadable transcript never reads as "silent for 0s".
+// cqLastOutput is when a running session last wrote anything, or the zero time
+// when none of them has a transcript we could read — the view drops the clause
+// rather than printing a zero, so an unreadable transcript never reads as
+// "silent for 0s".
+//
+// It is the instant and not the rendered age ("6s") it used to be. A string
+// formatted in the collector is only as fresh as the snapshot that carried it,
+// so it stood still between polls while the clock did not — the same standing
+// still the AGE column had, in a line that claims to report liveness. The view
+// formats it, once a second, from the clock (see ageEvery).
 
 var (
 	fleet        []fleetRow
-	cqLastOutput string
+	cqLastOutput time.Time
 )
 
 // ---- products ---------------------------------------------------------------

--- a/internal/cockpit/fleet.go
+++ b/internal/cockpit/fleet.go
@@ -93,9 +93,17 @@ type fleetRow struct {
 	acts []cqAct
 
 	// moved is the freshest of the transcript's mtime and the record's
-	// UpdatedAt: how long since ANYTHING happened, which is the one question the
-	// AGE column asks of every row. See fleetMoved.
+	// UpdatedAt: when this dispatcher was last seen doing anything. It is the
+	// LAST column. See fleetMoved.
 	moved time.Time
+	// started is when the dispatch was created, and is the AGE column: how long
+	// this dispatcher has been alive, which nothing it does resets.
+	//
+	// The two are different questions and a row can answer them very
+	// differently — "4s / 3h" is a session still going after three hours, "3h /
+	// 3h" is one that has said nothing since the moment it started. One column
+	// could only ever have shown one of those, and the pair is the reading.
+	started time.Time
 	// waited is the record's UpdatedAt, kept as the queue rows' tie-break sort
 	// key so the ask that has waited longest surfaces first.
 	waited time.Time
@@ -110,7 +118,7 @@ type fleetRow struct {
 // register collectFleet in loadSnapshot after collectFloor:
 //
 //	fleet        []fleetRow
-//	cqLastOutput string
+//	cqLastOutput time.Time
 func collectFleet(ctx *collectCtx, s *snapshot) {
 	// Floor rows keyed by feature. collectFloor resolved the forge for every
 	// record in this same load; re-deriving it here would mean a second
@@ -154,9 +162,9 @@ func collectFleet(ctx *collectCtx, s *snapshot) {
 
 	fleetSort(rows)
 	s.fleet = rows
-	if !lastOut.IsZero() {
-		s.cqLastOutput = cqAge(lastOut)
-	}
+	// The instant, not its age: rendering it here would freeze it at the age it
+	// had when this load ran. See cqLastOutput in data.go.
+	s.cqLastOutput = lastOut
 }
 
 // ---- rank and order -------------------------------------------------------------
@@ -307,6 +315,7 @@ func fleetQueueRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 		ctxKnown:  ctxKnown,
 		acts:      cqActs(rec, ask),
 		moved:     fleetMoved(rec),
+		started:   rec.CreatedAt,
 		waited:    rec.UpdatedAt,
 	}
 }
@@ -369,6 +378,7 @@ func fleetRunRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 		ctxKnown:  ctxKnown,
 		acts:      cqActs(rec, "running"),
 		moved:     moved,
+		started:   rec.CreatedAt,
 		waited:    rec.UpdatedAt,
 	}, mt
 }
@@ -402,6 +412,7 @@ func fleetPastRow(ctx *collectCtx, passes map[string]int, rec *state.Dispatch) f
 		goalLabel: goalLabel,
 		acts:      cqActs(rec, "past"),
 		moved:     fleetMoved(rec),
+		started:   rec.CreatedAt,
 		waited:    rec.UpdatedAt,
 	}
 }
@@ -422,16 +433,19 @@ func cqEnded(rec *state.Dispatch) string {
 	return "stopped"
 }
 
-// fleetMoved is how long since anything happened to a dispatcher: the freshest
-// of what it last wrote and when the hook last saved it.
+// fleetMoved is when a dispatcher was last seen doing anything: the freshest of
+// what it last wrote and when the hook last saved it.
 //
-// The AGE column asks one question of every row, so it must have one answer.
-// The design asks two — the record's age for a queue row, the transcript's for
-// a running one — which would put two different measurements in one column. The
-// max is right for both: for a blocked or turn-done dispatcher the transcript
-// stops moving at the same instant UpdatedAt does, so they agree; for a working
-// one the transcript is the only honest liveness signal (see cqLastWrite); and
-// it degrades to UpdatedAt when the transcript cannot be read at all.
+// The LAST column asks one question of every row, so it must have one answer,
+// and the max is right for all three kinds. For a blocked or turn-done
+// dispatcher the transcript stops moving at the same instant UpdatedAt does, so
+// they agree; for a working one the transcript is the only honest liveness
+// signal (see cqLastWrite); and it degrades to UpdatedAt when the transcript
+// cannot be read at all.
+//
+// What it is NOT is the dispatcher's age. That is CreatedAt, in its own column
+// next to this one, because activity and lifetime are two facts and neither
+// substitutes for the other — see fleetRow.started.
 func fleetMoved(rec *state.Dispatch) time.Time {
 	t := rec.UpdatedAt
 	if mt := cqLastWrite(rec.TranscriptPath); mt.After(t) {

--- a/internal/cockpit/fleet_view.go
+++ b/internal/cockpit/fleet_view.go
@@ -25,9 +25,14 @@ import "strings"
 
 // ---- columns ------------------------------------------------------------------
 
-// The eight cells of a table line, in draw order. The column header and every
+// The nine cells of a table line, in draw order. The column header and every
 // data row go through the same indices, which is the only way the two stay
 // column-exact.
+//
+// LAST and AGE are two columns rather than one composed cell ("4s·3h") because
+// the numbers are only worth having if they can be scanned down the table, and
+// a composite right-aligned against a ragged left-hand number cannot be. Two
+// right-aligned cells put every last-seen under every other last-seen.
 const (
 	flGlyph = iota
 	flProduct
@@ -36,6 +41,7 @@ const (
 	flStage
 	flTurn
 	flSignal
+	flSeen
 	flAge
 	flCells
 )
@@ -43,7 +49,7 @@ const (
 // fleetCols is one terminal width's column widths. A zero width means the
 // column is shed at this size.
 type fleetCols struct {
-	glyph, product, feature, repo, stage, turn, sigPad, age int
+	glyph, product, feature, repo, stage, turn, sigPad, seen, age int
 }
 
 // fleetProductMin is the design's PRODUCT width, kept as the floor so a table
@@ -85,15 +91,21 @@ func fleetProductWidth(rows []fleetRow) int {
 // still draws the full chain for the selected row); below 70 the product label
 // goes too, because a 12ch label is a fifth of a 60-column screen.
 //
-// Four columns never shed: the glyph, the feature, the signal and the age.
-// They are how bad, what, why and how long — the reason the table exists.
+// Five columns never shed: the glyph, the feature, the signal and both ages.
+// They are how bad, what, why and how long — the reason the table exists. The
+// two ages hold together at every width because they are read as a pair: "how
+// long since it moved" is a different fact with and without "how long it has
+// been going", and the narrow tier is exactly where a human is triaging on the
+// table alone rather than opening the panel.
 //
 // row() splits flex width evenly and has no ratio support, so the design's
 // 1.3 : 1 : 1.4 is computed into fixed widths and exactly one column is left
 // flex. With a single flex cell it absorbs the remainder exactly and the row
 // stays column-exact whatever its position in the seg list.
 func fleetColumns(w, want int) fleetCols {
-	cols := fleetCols{glyph: 3, sigPad: 3, age: 6}
+	// seen is 5 and age 6: both hold "365d" with a gap, and the wider one is
+	// last so the table's right edge keeps the design's margin.
+	cols := fleetCols{glyph: 3, sigPad: 3, seen: 5, age: 6}
 	showRepo := w >= 110
 	if w >= 70 {
 		roof := maxi(fleetProductMin, cqInner(w)/fleetProductShare)
@@ -102,7 +114,7 @@ func fleetColumns(w, want int) fleetCols {
 	if showRepo {
 		cols.stage, cols.turn = 9, 4
 	}
-	fixed := cols.glyph + cols.product + cols.stage + cols.turn + cols.sigPad + cols.age
+	fixed := cols.glyph + cols.product + cols.stage + cols.turn + cols.sigPad + cols.seen + cols.age
 	rem := maxi(0, cqInner(w)-fixed)
 
 	share := 13 + 14 // feature : signal
@@ -138,6 +150,7 @@ func fleetLine(w int, cols fleetCols, bg string, v, hex [flCells]string) string 
 	segs = append(segs,
 		c("", cols.sigPad, ""),
 		flexc(v[flSignal], hex[flSignal]),
+		cr(v[flSeen], cols.seen, hex[flSeen]),
 		cr(v[flAge], cols.age, hex[flAge]),
 		c("", pad, ""))
 	return row(w, bg, segs...)
@@ -151,9 +164,13 @@ func fleetLine(w int, cols fleetCols, bg string, v, hex [flCells]string) string 
 // calls it "pass" would re-advertise a meaning it does not have. It is four
 // characters, which is the design's own cell width.
 func fleetHeaderLine(w int, cols fleetCols) string {
+	// LAST is the last thing this dispatcher was seen doing; AGE is how long it
+	// has been alive. Neither header is "AGE" alone any more, because with two
+	// numbers on the row that one word would name whichever the reader assumed.
 	v := [flCells]string{
 		flProduct: "PRODUCT", flFeature: "FEATURE", flRepo: "REPO",
-		flStage: "STAGE", flTurn: "TURN", flSignal: "SIGNAL", flAge: "AGE",
+		flStage: "STAGE", flTurn: "TURN", flSignal: "SIGNAL",
+		flSeen: "LAST", flAge: "AGE",
 	}
 	var hex [flCells]string
 	for i := range hex {
@@ -219,7 +236,8 @@ func fleetDataLine(w int, cols fleetCols, r fleetRow, on bool) string {
 		flStage:   cqPhaseWord(r.stage),
 		flTurn:    turn,
 		flSignal:  r.signal,
-		flAge:     cqAge(r.moved),
+		flSeen:    cqAge(r.moved),
+		flAge:     cqAge(r.started),
 	}
 	hex := [flCells]string{
 		flGlyph:   rank,
@@ -229,6 +247,7 @@ func fleetDataLine(w int, cols fleetCols, r fleetRow, on bool) string {
 		flStage:   stageHex,
 		flTurn:    turnHex,
 		flSignal:  rank,
+		flSeen:    cFaint,
 		flAge:     cFaint,
 	}
 	return fleetLine(w, cols, bg, v, hex)

--- a/internal/cockpit/live.go
+++ b/internal/cockpit/live.go
@@ -16,6 +16,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"time"
 
 	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/gh"
@@ -36,7 +37,7 @@ type snapshot struct {
 	}
 
 	fleet        []fleetRow
-	cqLastOutput string
+	cqLastOutput time.Time
 
 	products       []product
 	reposByProduct map[string][]repoRef
@@ -334,9 +335,9 @@ func applySnapshot(s snapshot) {
 	if s.fleet != nil {
 		fleet = s.fleet
 	}
-	// Unconditionally, unlike every other field: "" means no running session has
-	// a readable transcript, which is an observation the view must show, and a
-	// stale age left in place would be a lie about liveness.
+	// Unconditionally, unlike every other field: the zero time means no running
+	// session has a readable transcript, which is an observation the view must
+	// show, and a stale instant left in place would be a lie about liveness.
 	cqLastOutput = s.cqLastOutput
 	if s.products != nil {
 		products = s.products

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -241,8 +241,11 @@ func (m model) Init() tea.Cmd {
 	// The first load is the one with a screen watching it: it reports each
 	// stage as it runs, and the model subscribes for those reports and ticks
 	// the animation. Every later load takes the plain path.
+	// ageTick rides with the poll rather than with the demo path above: it keeps
+	// the printed ages of real dispatchers honest, and a cockpit with no config
+	// has none to age.
 	load := loadSnapshotCmd(m.cfg)
-	cmds := []tea.Cmd{trackRefreshCmd(m.cfg), waitState(m.stateCh), refreshTick(), upgradeCheckCmd()}
+	cmds := []tea.Cmd{trackRefreshCmd(m.cfg), waitState(m.stateCh), refreshTick(), ageTick(), upgradeCheckCmd()}
 	if m.boot != nil {
 		load = bootLoadCmd(m.cfg, m.bootCh)
 		cmds = append(cmds, waitBoot(m.bootCh), bootTick())
@@ -303,6 +306,13 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// a release; the version package's own cache decides when that costs a
 		// network call.
 		return m, tea.Batch(trackRefreshCmd(m.cfg), refreshTick(), upgradeCheckCmd())
+
+	case ageTickMsg:
+		// Deliberately the emptiest arm in this switch. The model is returned
+		// exactly as it arrived: the tick's only effect is that returning at all
+		// gets View called again, and View reads the clock. Anything else done
+		// here would be work happening once a second.
+		return m, ageTick()
 
 	case upgradeMsg:
 		if version.IsOutdated(msg.latest) {

--- a/internal/cockpit/pending.go
+++ b/internal/cockpit/pending.go
@@ -223,7 +223,10 @@ func pendingRow(p pendingDispatch) fleetRow {
 		// No acts. Attach would have no session to hand over, and kill would have
 		// no record to mark — an offered key that cannot act is the defect this
 		// lens keeps finding in its own design.
-		moved:  p.since,
-		waited: p.since,
+		// Both ages count from the same instant, which is the truth about a
+		// dispatcher that has existed for as long as it has been silent.
+		moved:   p.since,
+		started: p.since,
+		waited:  p.since,
 	}
 }

--- a/internal/cockpit/refresh.go
+++ b/internal/cockpit/refresh.go
@@ -19,6 +19,27 @@ import (
 // than one could finish.
 const refreshEvery = 60 * time.Second
 
+// ageEvery paces the clock tick — the one message whose whole job is to make
+// the screen say a later time than it did a second ago.
+//
+// Nothing on a Bubble Tea screen ages by itself. View is called in response to
+// a message and at no other moment, so an age computed inside it is only ever
+// recomputed when something else happens to send one — and between keystrokes
+// the only thing that regularly does is the poll above, once a minute. The
+// triage table counts its ages in seconds (cqAge), so a row that had just
+// reported "4s" sat on "4s" until the next poll and then jumped most of a
+// minute. The reading was never wrong when it was drawn; it was drawn once and
+// then left there, which is worse, because a seconds column that is not moving
+// is the display a human trusts most.
+//
+// One second, because that is the resolution the column prints. The tick is as
+// cheap as its rate demands: it reads no file, makes no request, reconciles
+// nothing and rebuilds no snapshot — the handler re-arms it and returns the
+// model untouched, and the renderer's next frame re-reads the clock. Where
+// refreshTickMsg is a poll and pays for one, this is a redraw and pays for a
+// redraw.
+const ageEvery = time.Second
+
 type (
 	// snapshotMsg carries a freshly built snapshot to the UI goroutine.
 	snapshotMsg snapshot
@@ -26,6 +47,8 @@ type (
 	stateChangedMsg struct{}
 	// refreshTickMsg is the periodic poll.
 	refreshTickMsg struct{}
+	// ageTickMsg is the clock tick: a redraw and nothing else.
+	ageTickMsg struct{}
 	// trackedMsg fires after a track.Refresh pass (PR/deploy reconciliation).
 	trackedMsg struct{}
 	// bootProgressMsg carries one opening-screen step transition to the UI.
@@ -141,4 +164,8 @@ func waitState(ch chan struct{}) tea.Cmd {
 
 func refreshTick() tea.Cmd {
 	return tea.Tick(refreshEvery, func(time.Time) tea.Msg { return refreshTickMsg{} })
+}
+
+func ageTick() tea.Cmd {
+	return tea.Tick(ageEvery, func(time.Time) tea.Msg { return ageTickMsg{} })
 }


### PR DESCRIPTION
## What was wrong

The AGE column on the triage table counts in seconds and did not tick.

Bubble Tea calls `View` in response to a message and at no other moment, so an age computed inside `View` is only recomputed when something else happens to send one. Between keystrokes the only thing that regularly did was the 60s poll (`refreshEvery`). A row that read `4s` kept reading `4s` for the best part of a minute and then jumped. The figure was never wrong when it was drawn — it was drawn once and left there, which is worse, because a seconds column that is not moving is the display a human trusts most.

Two things were frozen underneath it:

- **The whole screen.** No message, no render.
- **`cqLastOutput`.** The collector formatted it to a string (`"6s"`) and the snapshot carried it, so the cockpit's one line about liveness was only ever as fresh as the last load — a clock tick alone could not have fixed it.

## The fix

**A clock tick** (`ageEvery`, 1s). The handler is deliberately the emptiest arm in the `Update` switch: it re-arms and returns the model exactly as it arrived. No file read, no request, no reconcile, no snapshot rebuild. Returning at all is what gets `View` called, and `View` reads the clock. Where `refreshTickMsg` is a poll and pays for one, this is a redraw and pays for a redraw — which is what "lightweight, it's all local" has to mean.

**`cqLastOutput` is an instant**, not a rendered age. The view formats it, once a second.

## Two ages, not one

`fleetMoved`'s own comment argued that one column must have one answer and picked "how long since anything happened". But that is not how old the dispatcher is, and neither substitutes for the other:

- `6s / 3h` — still working, three hours in.
- `3h / 3h` — has said nothing since the moment it started.

Neither reading was available before. So `LAST` (freshest of the transcript's mtime and the record's `UpdatedAt`) and `AGE` (the record's `CreatedAt`) are two columns:

```
     PRODUCT     FEATURE      REPO   STAGE    TURN   SIGNAL                 LAST   AGE
  ○  ALPHA       one          api    act         2   approve a permission     4m    2h
  ○  BETA        two          svc    ship        1   it finished a turn       1h    1h
  ·  ALPHA       three        web    observe     2                            6s    3h
```

Two right-aligned cells rather than one composed `6s·3h`: the numbers are only worth having if they scan down the table, and a composite right-aligned against a ragged left-hand number cannot be. Neither sheds at any width — the narrow tier is exactly where a human triages on the table alone. The detail panel spells them out in words (`moved 4m ago · 2h old`), where the table has headers to do it.

## Tests

`internal/cockpit/age_test.go`:

- the clock tick re-arms and leaves the model untouched (it must cost a render and no more);
- the same unchanged fleet renders a later age a second later — the reported bug, and it covers the unattended line's `last output` clause too;
- `LAST` and `AGE` report different facts off the same row;
- the collector carries the instants, not their rendered ages.

`make vet` and the full suite pass.
