### PR TITLE
Shift is not a namespace: undo is ctrl+z, U upgrades

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,14 @@
   `supervisor.AttachSwitches`), the recheck waits for the terminal focus
   event instead. Focus alone never triggers it: a full forge re-read on every
   alt-tab is how the gh quota gets burned.
+- **`U` is the upgrade key and nothing else's; undo is ctrl+z.** Shift is not
+  a namespace. `handleKey` resolves `U` globally, before any lens is asked, so
+  a lens that wants its own capital U never sees the key — the assignment
+  editor's "start over" was exactly that, dead since the upgrade key landed,
+  and is ctrl+u now. And undo, the key you hit fastest and without looking,
+  must not be one slipped shift from upgrading the machine in place, so it is
+  a chord. That also frees `u` for the editor's unassign, which the global
+  undo used to steal whenever a triage act had left something undoable.
 - **Decisions are read where they were written, never invented.** The
   DECISIONS lens has two sources: an adr-tools folder, and a heading that
   names a set of decisions in the repo's own markdown (`CLAUDE.md`,

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Every act the table offers is wired to the live session — the key hints show o
 
 - **`enter`** attach the tmux session at full fidelity (`Ctrl-\` to come back). Coming back **rechecks** rather than redraws: you have just spent minutes driving that session by hand, so the forge is read again instead of replayed from cache, and any session that died without getting a `SessionEnd` out stops being reported as working
 - **`y`** on a PR waiting to merge: `gh pr merge --squash --auto`, then mark live. Elsewhere it marks the record shipped, and it is hidden entirely when the dispatcher has produced no commits
-- **`x`** kill the session · **`s`** skip to the back of the table · **`u`** undo
+- **`x`** kill the session · **`s`** skip to the back of the table · **`ctrl+z`** undo
 - **`d`** open the prompt · **`f`** filter the table · **`enter` on a backlog ticket** dispatches it
 - **`h`** the finished dispatchers, and **`enter`** on one resumes its session — `claude --resume` on the same transcript, in the same worktree, so it comes back knowing what it already did
 
@@ -243,7 +243,7 @@ Anything unmapped is grouped under `unassigned`, which is what a fresh install s
 | `h` | history — every dispatcher whose session is over; `enter` resumes one |
 | `enter` | attach the selected dispatcher's tmux session · open what is selected |
 | `y` · `x` · `s` | ship (squash-merge) · kill · skip to the back |
-| `d` · `u` | dispatch · put back the last thing you cleared |
+| `d` · `ctrl+z` | dispatch · put back the last thing you cleared |
 | `,` · `:` · `?` | settings · command palette · all keys |
 | `U` | upgrade to the published build and come straight back |
 | `q` | quit |

--- a/internal/cockpit/cluster.go
+++ b/internal/cockpit/cluster.go
@@ -261,9 +261,11 @@ func (m model) updateCluster(k string) (model, tea.Cmd, bool) {
 	case "u":
 		mm, cmd := m.clAssign(m.clTargets(), "")
 		return mm, cmd, true
-	case "U":
+	case "ctrl+u":
 		// Start over: every repo out of every product. Destructive enough to
-		// deserve its own capital key rather than sharing `u`.
+		// deserve its own key rather than sharing `u`, and a chord rather than
+		// the capital it used to be — `U` never arrived here at all, because
+		// handleKey resolves it as the upgrade key before any lens is asked.
 		var all []string
 		for _, r := range rows {
 			all = append(all, r.name)

--- a/internal/cockpit/cluster_test.go
+++ b/internal/cockpit/cluster_test.go
@@ -112,6 +112,53 @@ func TestClAssignAndUnassignPersist(t *testing.T) {
 	}
 }
 
+// The editor's two unassign keys have to survive the global router, which gets
+// every key first. "Start over" was a capital U and never arrived: handleKey
+// resolves U as the upgrade key before any lens is asked, so the one key the
+// help sheet promised here opened an upgrade confirm instead. And `u` was
+// stolen from this screen whenever a triage act had left an undo behind.
+func TestClUnassignKeysSurviveTheGlobalRouter(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// A fresh editor per key: clAssign writes through the working map, which a
+	// copied model shares with the one it was copied from.
+	fresh := func() model {
+		m := clFixture(t)
+		m.lens = "products"
+		m.clMap = map[string]string{"acme-api": "acme", "acme-web": "acme", "orbit-billing": "orbit"}
+		m.undo = "ship widget" // a pending undo must not eat this screen's `u`
+		return m
+	}
+
+	// `u` takes the cursor row out of its product and nothing else.
+	m := press(fresh(), "u")
+	if m.undo != "ship widget" {
+		t.Error("u undid a triage act instead of unassigning a repo")
+	}
+	if got := m.clMap["acme-api"]; got != "" {
+		t.Errorf("u left acme-api in %q", got)
+	}
+	if m.clMap["acme-web"] != "acme" {
+		t.Error("u unassigned more than the row it was on")
+	}
+
+	// ctrl+u is start over: every repo out of every product.
+	m = press(fresh(), "ctrl+u")
+	for _, r := range m.clRepos() {
+		if r.product != "" {
+			t.Errorf("start over left %s in %q", r.name, r.product)
+		}
+	}
+	if !strings.Contains(m.notice, "every repo unassigned") {
+		t.Errorf("start over notice = %q", m.notice)
+	}
+
+	// U is the upgrade key here as everywhere — never a second unassign.
+	m = press(fresh(), "U")
+	if m.clMap["acme-api"] != "acme" || m.clMap["orbit-billing"] != "orbit" {
+		t.Error("U unassigned something in the editor")
+	}
+}
+
 // Naming is a text field, so it must take a whole burst — the same hole that
 // once made every input in this cockpit dead to typing at speed.
 func TestClNamingTakesABurstAndCreatesTheProduct(t *testing.T) {

--- a/internal/cockpit/cq_keys.go
+++ b/internal/cockpit/cq_keys.go
@@ -15,9 +15,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 )
 
-// cqUndoEntry is the last row `u` can put back. It restores the table row only:
-// the act's command has already run, so `u` un-hides a dispatcher, it does not
-// un-kill a session or un-merge a PR.
+// cqUndoEntry is the last row ctrl+z can put back. It restores the table row
+// only: the act's command has already run, so ctrl+z un-hides a dispatcher, it
+// does not un-kill a session or un-merge a PR.
 type cqUndoEntry struct{ id, label string }
 
 // ---- derived state ----------------------------------------------------------
@@ -172,7 +172,7 @@ func (m model) cqStartFlash(r fleetRow, a cqAct) (model, tea.Cmd) {
 }
 
 // cqFlashDone ends the confirmation: unless the act keeps the row, it leaves
-// the table, the handled count goes up and `u` can put it back. It clears by
+// the table, the handled count goes up and ctrl+z can put it back. It clears by
 // id, never by position, so a refresh that reordered the table mid-flash cannot
 // clear the wrong row.
 func (m model) cqFlashDone() (model, tea.Cmd) {
@@ -209,13 +209,21 @@ func cqWithout(ids []string, drop string) []string {
 func isLensDigit(k string) bool { return len(k) == 1 && k[0] >= '1' && k[0] <= '6' }
 
 // updateFloorQueue is the triage lens's whole key surface. handled is false only
-// for the keys allowed to leave this screen (the lens digits, ':', 'u', '?',
+// for the keys allowed to leave this screen (the lens digits, ':', ctrl+z, '?',
 // 'q'), which handleKey then routes as usual; nothing else escapes, because the
 // v2 list keys (/, space, F, D, tab, r, t, M, p) went with the list.
 func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
-	// A flash is a promise that something happened. Nothing gets through it.
+	// A flash is a promise that something happened. Nothing gets through it —
+	// including undo, which would otherwise race the cqUndo the flash is about
+	// to record.
 	if m.cqFlash != "" {
 		return m, nil, true
+	}
+	// Undo leaves ahead of the prompt check, unlike the letters below it: a
+	// chord cannot be typed into a sentence, so there is no half-written
+	// dispatch for it to steal a keystroke from. `u` had to wait its turn.
+	if k == "ctrl+z" {
+		return m, nil, false
 	}
 
 	if m.cqPromptOn() {
@@ -301,7 +309,7 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 	// Only navigation leaves this screen. ',', '+', 'tab' and every v2 list key
 	// are swallowed: the palette is the way to settings and to a repo-first
 	// dispatch, and the form is the way to a new one.
-	if isLensDigit(k) || k == ":" || k == "u" || k == "?" || k == "q" {
+	if isLensDigit(k) || k == ":" || k == "?" || k == "q" {
 		return m, nil, false
 	}
 	return m, nil, true

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -156,7 +156,7 @@ func TestCQActFlashClearsAndUndoes(t *testing.T) {
 		t.Fatalf("cleared=%d undo=%+v", m.cqCleared, m.cqUndo)
 	}
 
-	m = press(m, "u")
+	m = press(m, "ctrl+z")
 	if got := fleetFeatures(m); got != "one,two,three" {
 		t.Errorf("undo should put the row back at the front, got %s", got)
 	}

--- a/internal/cockpit/fleet_view.go
+++ b/internal/cockpit/fleet_view.go
@@ -472,6 +472,6 @@ func (m model) cqFooterHelp() string {
 		// footer only names keys that work right now.
 		return strings.Join(append(parts, "j/k move", "h back to the fleet", "? keys"), " · ")
 	}
-	parts = append(parts, "j/k move", "f filter", "h history", "d dispatch", "u undo", "? keys")
+	parts = append(parts, "j/k move", "f filter", "h history", "d dispatch", "ctrl+z undo", "? keys")
 	return strings.Join(parts, " · ")
 }

--- a/internal/cockpit/history_test.go
+++ b/internal/cockpit/history_test.go
@@ -180,7 +180,7 @@ func TestEnterOnAHistoryRowResumes(t *testing.T) {
 func TestHistoryFooterOffersOnlyWhatWorks(t *testing.T) {
 	m := press(cqModel(t), "h")
 	got := m.footerHelp()
-	for _, gone := range []string{"y ", "x kill", "s skip", "u undo"} {
+	for _, gone := range []string{"y ", "x kill", "s skip", "undo"} {
 		if strings.Contains(got, gone) {
 			t.Errorf("history footer offers %q: %s", gone, got)
 		}

--- a/internal/cockpit/interactions2_test.go
+++ b/internal/cockpit/interactions2_test.go
@@ -259,14 +259,38 @@ func TestHandleKeyConfirmCancel(t *testing.T) {
 
 func TestUndoKey(t *testing.T) {
 	m := newModel()
-	m.lens = "products" // on triage an empty queue types 'u' into the draft
+	m.lens = "products"
 	m.undo = "ship widget"
-	mm, _ := m.handleKey("u")
+	mm, _ := m.handleKey("ctrl+z")
 	if mm.(model).undo != "" {
-		t.Error("u should clear a pending undo")
+		t.Error("ctrl+z should clear a pending undo")
 	}
 	if !strings.Contains(mm.(model).notice, "undone") {
 		t.Errorf("notice = %q", mm.(model).notice)
+	}
+}
+
+// Undo is a chord because `U` upgrades the machine in place: the two must not
+// be one slipped shift apart. `u` is the assignment editor's unassign now, and
+// must not undo anything anywhere.
+func TestUndoIsAChordNotAShiftFromUpgrade(t *testing.T) {
+	m := newModel()
+	m.lens = "products"
+	m.undo = "ship widget"
+	if got := press(m, "u").undo; got != "ship widget" {
+		t.Errorf("u undid something: undo = %q", got)
+	}
+
+	// The one thing the chord buys over `u`: it works while the dispatch prompt
+	// owns the keyboard, because a chord cannot be part of a sentence.
+	m = newModel()
+	m.width, m.height = 190, 44
+	if !m.cqPromptOn() {
+		t.Fatal("expected the empty fleet to leave the prompt holding the keyboard")
+	}
+	m.undo = "ship widget"
+	if mm := press(m, "ctrl+z"); mm.undo != "" || !strings.Contains(mm.notice, "undone") {
+		t.Errorf("ctrl+z did not reach undo at the prompt: undo=%q notice=%q", mm.undo, mm.notice)
 	}
 }
 

--- a/internal/cockpit/keys.go
+++ b/internal/cockpit/keys.go
@@ -237,7 +237,11 @@ func (m model) handleKey(k string) (tea.Model, tea.Cmd) {
 		m.helpOpen = true
 		return m, nil
 	}
-	if k == "u" && (m.cqUndo != nil || m.undo != "") {
+	// ctrl+z, not `u`: `U` upgrades the machine in place, and undo — the key you
+	// hit fastest, without looking — must not be one slipped shift away from it.
+	// The chord also frees `u` for the assignment editor's unassign, which the
+	// pending-undo check here used to steal whenever something was undoable.
+	if k == "ctrl+z" && (m.cqUndo != nil || m.undo != "") {
 		if cu := m.cqUndo; cu != nil {
 			// Puts the row back at the front. The act's command already ran, so
 			// this un-hides an ask; it does not un-kill a session.
@@ -265,9 +269,11 @@ func (m model) handleKey(k string) (tea.Model, tea.Cmd) {
 		m.dispatchForm = newDispatchForm(m.cfg)
 		return m, m.dispatchForm.filter.Focus()
 	}
-	// Shift-U, not `u`: `u` is undo, and the two must never be one slip apart in
-	// the same hand. Bound globally rather than per-lens because the version it
-	// acts on is in the footer, which every lens carries.
+	// `U` is the upgrade key and nothing else's: bound globally rather than
+	// per-lens because the version it acts on is in the footer, which every lens
+	// carries — so any lens that wanted a capital U of its own would never see
+	// it (the assignment editor's "start over" was exactly that, and is a chord
+	// now).
 	if k == "U" {
 		return m.startUpgrade()
 	}

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -152,7 +152,7 @@ type model struct {
 	fleetCursor int
 	fleetSelID  string
 
-	cqUndo *cqUndoEntry // the last cleared row, restorable with `u`
+	cqUndo *cqUndoEntry // the last cleared row, restorable with ctrl+z
 
 	// pending is what this cockpit has asked for and not yet seen a record for.
 	// It is the only view state that is not derived from the records, and it has

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -31,7 +31,7 @@ var helpSections = []struct {
 		{"x", "kill it · the branch and any dirty worktree survive"},
 		{"s", "skip · send it to the back, it comes round again"},
 		{"d", "dispatch · pick a repo, say what it does"},
-		{"u", "put back the last thing you cleared"},
+		{"ctrl+z", "put back the last thing you cleared"},
 	}},
 	{section: "what has finished", keys: []struct{ k, d string }{
 		{"h", "history · every dispatcher whose session is over, and back again"},
@@ -53,7 +53,7 @@ var helpSections = []struct {
 		{"n", "new product — names it and moves the marked repos in"},
 		{"space", "mark a repo · enter moves every marked one"},
 		{"tab", "between the repo list and the products"},
-		{"u / U", "take repos back out of a product · start over"},
+		{"u / ctrl+u", "take repos back out of a product · start over"},
 	}},
 	{section: "the other lenses", keys: []struct{ k, d string }{
 		{"j / k", "up and down the list"},

--- a/internal/cockpit/view.go
+++ b/internal/cockpit/view.go
@@ -112,7 +112,7 @@ func (m model) footerView() string {
 	left := fg(cDim, m.footerHelp())
 	notice := m.notice
 	if m.undo != "" {
-		notice += "  ·  u to undo"
+		notice += "  ·  ctrl+z to undo"
 	}
 	right := ""
 	if notice != "" {
@@ -146,7 +146,7 @@ func (m model) footerHelp() string {
 		if m.clNaming {
 			return "type the name · enter creates it · esc cancels"
 		}
-		return "j/k move · tab pane · space mark · enter assign · u unassign · n new · a done"
+		return "j/k move · tab pane · space mark · enter assign · u unassign · ctrl+u start over · n new · a done"
 	}
 	if h, ok := footerByLens[m.lens]; ok {
 		return h


### PR DESCRIPTION
`U` is resolved in `handleKey`, globally, before any lens is asked. Two keys were lost to that.

**Undo sat on `u`** — one slipped shift from the key that installs a new build and re-execs the cockpit. The comment above the upgrade key already argued the two must never be one slip apart in the same hand; they were.

**The assignment editor's "start over"** (every repo out of every product) was a capital `U`, and has been dead since the upgrade key landed: the help sheet promised `u / U`, and pressing U opened an upgrade confirm instead. Nothing in the editor could ever see it.

## What changed

- Undo is **ctrl+z** — globally, and in the triage lens it escapes *ahead* of the dispatch prompt. `u` had to wait for the form to give the keyboard back, because a letter can always be part of a sentence; a chord cannot, so undo now works while a prompt is half-written.
- The editor's start over is **ctrl+u** — a chord rather than a capital, for the reason above.
- With `u` free, the editor's **unassign** finally gets it outright. The global undo used to intercept `u` whenever a triage act had left something undoable, so unassign silently became "undo" on a screen that has nothing to do with triage.
- Footer (`ctrl+z to undo`, `ctrl+z undo`, `ctrl+u start over`), help sheet, README and the decisions section in `CLAUDE.md` follow the keys.

## Tests

- `TestUndoIsAChordNotAShiftFromUpgrade` — `u` undoes nothing anywhere; ctrl+z reaches undo even with the dispatch prompt holding the keyboard.
- `TestClUnassignKeysSurviveTheGlobalRouter` — driven through `handleKey`, so it fails if the global router ever swallows one of them again: `u` unassigns the cursor row and leaves the pending undo alone, ctrl+u empties every product, `U` unassigns nothing.

`make check` green (build, vet, golangci-lint, race suite).