### PR TITLE
Make the dispatch form's mode configure the session, not describe it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,22 @@
   (merge counts as live for repos with no deploy workflow). `d` in the
   cockpit is the manual override. Auto-done only advances while a cockpit
   is open (the tracker runs from the cockpit's poll loop).
+- **The dispatch form's MODE is Claude Code's permission mode, not a
+  sentence about one.** A dispatch is launched with `--permission-mode` —
+  `auto` (takes its own edits and safe commands), `manual` (asks before each
+  step) or `plan` — recorded on the dispatch, and passed again on `Resume`,
+  so a reopened dispatcher comes back the way it went out. Auto is the
+  default: a dispatcher is by definition work sent somewhere else to happen,
+  with nobody sitting on its permission prompt. The form's closing prompt
+  sentence stays, because the flag says what claude may do without asking and
+  the sentence says how far to take the work — "may edit without asking" is
+  not "commit, push and open the PR". This shipped as a two-position AUTO
+  switch with nothing behind it: whatever it said, the session opened in
+  whatever the human's own Claude Code defaults to and stopped on its first
+  permission prompt unattended. A claude too old to know a mode's current
+  spelling is given the older one (`acceptEdits`/`default`) and one with no
+  such flag gets none, because a rejected flag is not a degraded session —
+  it is a launch that never happens.
 - Commit attribution is by provenance (dispatch records its branch SHAs),
   NEVER by Co-Authored-By trailers — the user strips those from commits.
 - User is on a Claude subscription (not API billing): portfolio roll-up

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Switch with the number keys. Each lens is a different question about the same fa
 
 **`h` is what has already finished.** Shipped, killed, or simply exited — every dispatcher whose session is over, newest first, on the table the live fleet leaves. `enter` resumes one: the worktree comes back if it was reclaimed and the conversation picks up where it stopped, so a session ending is never the end of it.
 
-**With the fleet clear, the same screen becomes the prompt.** Give it a title — that is the branch — then the brief, which wraps for as long as it needs to be, and what "done" means. `tab` moves between the fields; `ctrl+d` dispatches.
+**With the fleet clear, the same screen becomes the prompt.** Give it a title — that is the branch — then the brief, which wraps for as long as it needs to be, what "done" means, and the mode it runs in: **auto** takes its own edits and safe commands, **manual** asks you before each step, **plan** changes nothing until you accept the plan. That is Claude Code's own `--permission-mode`, so the session really does open that way. `tab` moves between the fields, `space` cycles the mode, `ctrl+d` dispatches.
 
 ![Dispatching straight from an empty fleet](docs/dispatch.svg)
 

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -207,8 +207,9 @@ func resumeCmd(id, prompt string) tea.Cmd {
 	}
 }
 
-// launchCmd dispatches a new feature into repoName with prompt.
-func launchCmd(cfg *config.Config, repoName, feature, prompt string) tea.Cmd {
+// launchCmd dispatches a new feature into repoName with prompt, in the
+// permission mode the form chose.
+func launchCmd(cfg *config.Config, repoName, feature, prompt string, mode dispatchpkg.Mode) tea.Cmd {
 	return func() tea.Msg {
 		if cfg == nil {
 			return launchedMsg{feature: feature, notice: "no config — cannot dispatch", failed: true}
@@ -224,7 +225,7 @@ func launchCmd(cfg *config.Config, repoName, feature, prompt string) tea.Cmd {
 		if found == nil {
 			return launchedMsg{feature: feature, notice: "repo not found: " + repoName, failed: true}
 		}
-		d, err := dispatchpkg.Launch(*found, feature, prompt)
+		d, err := dispatchpkg.Launch(*found, feature, prompt, mode)
 		if err != nil {
 			return launchedMsg{feature: feature, notice: "launch failed: " + err.Error(), failed: true}
 		}

--- a/internal/cockpit/actions_test.go
+++ b/internal/cockpit/actions_test.go
@@ -15,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/state"
 )
 
@@ -223,7 +224,7 @@ func TestReplyCmdNoSession(t *testing.T) {
 }
 
 func TestLaunchCmdNoConfig(t *testing.T) {
-	msg := launchCmd(nil, "repo", "feature", "prompt")()
+	msg := launchCmd(nil, "repo", "feature", "prompt", dispatchpkg.ModeAuto)()
 	lm, ok := msg.(launchedMsg)
 	if !ok || !lm.failed || lm.feature != "feature" || !strings.Contains(lm.notice, "no config") {
 		t.Errorf("launchCmd(nil cfg) = %#v", msg)
@@ -233,7 +234,7 @@ func TestLaunchCmdNoConfig(t *testing.T) {
 func TestLaunchCmdRepoNotFound(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{Roots: []string{dir}}
-	msg := launchCmd(cfg, "nonexistent-repo", "feature", "prompt")()
+	msg := launchCmd(cfg, "nonexistent-repo", "feature", "prompt", dispatchpkg.ModeAuto)()
 	lm, ok := msg.(launchedMsg)
 	if !ok || !lm.failed || lm.feature != "feature" || !strings.Contains(lm.notice, "repo not found") {
 		t.Errorf("launchCmd(repo not found) = %#v", msg)
@@ -253,7 +254,7 @@ func TestLaunchCmdEnsureBranchFails(t *testing.T) {
 	}
 	cfg := &config.Config{Roots: []string{root}}
 
-	msg := launchCmd(cfg, "fake-repo", "new feature", "do something")()
+	msg := launchCmd(cfg, "fake-repo", "new feature", "do something", dispatchpkg.ModeAuto)()
 	lm, ok := msg.(launchedMsg)
 	if !ok || !lm.failed || lm.feature != "new feature" || !strings.Contains(lm.notice, "launch failed") {
 		t.Errorf("launchCmd(broken repo) = %#v", msg)

--- a/internal/cockpit/backlog.go
+++ b/internal/cockpit/backlog.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 )
 
 // backlogList filters the tickets by the active source filter. "all" is
@@ -384,7 +386,12 @@ func (m model) updateBacklog(k string) (model, tea.Cmd) {
 			// placeholder is what makes it findable the moment the human presses 1
 			// to go and look — see pending.go.
 			m = m.markPending(m.pendingFor(t.repo, backlogFeature(t), t.prompt))
-			return m, launchCmd(m.cfg, t.repo, backlogFeature(t), t.prompt)
+			// The backlog asks no questions — enter on a ticket is the whole
+			// interaction — so it dispatches in the default mode. That is the
+			// posture the ticket implies: work handed off to happen elsewhere,
+			// with nobody sitting on its permission prompt. Anything else is
+			// dispatched from a form that asks.
+			return m, launchCmd(m.cfg, t.repo, backlogFeature(t), t.prompt, dispatchpkg.DefaultMode)
 		}
 	case "ctrl+d":
 		// This used to announce a dispatch and launch nothing — the worst kind
@@ -405,7 +412,7 @@ func (m model) updateBacklog(k string) (model, tea.Cmd) {
 				continue
 			}
 			m = m.markPending(m.pendingFor(bt.repo, backlogFeature(bt), bt.prompt))
-			cmds = append(cmds, launchCmd(m.cfg, bt.repo, backlogFeature(bt), bt.prompt))
+			cmds = append(cmds, launchCmd(m.cfg, bt.repo, backlogFeature(bt), bt.prompt, dispatchpkg.DefaultMode))
 		}
 		m.picked = map[string]bool{}
 		var why []string

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/state"
 )
 
@@ -303,8 +304,8 @@ func TestFleetEmptyFilterStaysOnTheTable(t *testing.T) {
 func TestCQFormFallThrough(t *testing.T) {
 	m := cqModel(t)
 	m = press(m, "d")
-	if !m.cqDispatch || m.dxTouched() || !m.dxAuto {
-		t.Fatalf("d should open an empty form, auto on: %v %v %v", m.cqDispatch, m.dxTouched(), m.dxAuto)
+	if !m.cqDispatch || m.dxTouched() || m.dxMode != dispatchpkg.ModeAuto {
+		t.Fatalf("d should open an empty form in auto: %v %v %q", m.cqDispatch, m.dxTouched(), m.dxMode)
 	}
 
 	// Untouched: a lens digit still navigates rather than typing itself.
@@ -332,21 +333,34 @@ func TestCQFormFallThrough(t *testing.T) {
 func TestCQFormEnterWalksFieldsAndEscClears(t *testing.T) {
 	m := cqModel(t)
 	m = press(m, "d")
-	for _, want := range []dxFieldID{dxTitleF, dxWhatF, dxGoalF, dxAutoF} {
+	for _, want := range []dxFieldID{dxTitleF, dxWhatF, dxGoalF, dxModeF} {
 		m = press(m, "enter")
 		if m.dxField != want {
 			t.Fatalf("enter should advance to field %d, got %d", want, m.dxField)
 		}
 	}
-	// On AUTO, space is the switch rather than a character.
-	m = press(m, "space")
-	if m.dxAuto {
-		t.Error("space on AUTO should turn it off")
+	// On MODE, space is the switch rather than a character, and it walks all
+	// three positions back round to where it started.
+	for _, want := range []dispatchpkg.Mode{dispatchpkg.ModeManual, dispatchpkg.ModePlan, dispatchpkg.ModeAuto} {
+		m = press(m, "space")
+		if m.dxMode != want {
+			t.Fatalf("space on MODE should reach %q, got %q", want, m.dxMode)
+		}
+	}
+	// left walks the other way, so the third choice is never three keypresses.
+	m = press(m, "left")
+	if m.dxMode != dispatchpkg.ModePlan {
+		t.Errorf("left on MODE = %q, want plan", m.dxMode)
 	}
 
 	m = press(m, "esc")
 	if m.cqDispatch || m.dxTouched() || m.dxField != dxWhereF {
 		t.Error("esc should abandon the form and reset every field")
+	}
+	// Including the mode: the next form opens on the default, not on whatever
+	// the abandoned one had been cycled to.
+	if m.dxMode != dispatchpkg.DefaultMode {
+		t.Errorf("esc left the mode at %q, want the default back", m.dxMode)
 	}
 }
 
@@ -389,7 +403,7 @@ func TestCQFormDispatchesTheSentenceNotTheName(t *testing.T) {
 
 	var gotFeature, gotPrompt string
 	prev := dxLaunch
-	dxLaunch = func(_ *config.Config, _, feature, prompt string) tea.Cmd {
+	dxLaunch = func(_ *config.Config, _, feature, prompt string, _ dispatchpkg.Mode) tea.Cmd {
 		gotFeature, gotPrompt = feature, prompt
 		return nil
 	}
@@ -423,7 +437,7 @@ func TestCQFormDispatchesTheSentenceNotTheName(t *testing.T) {
 // typed, and the brief is WHAT in full, however long either one is.
 func TestDXDispatchNamesFromTitleBriefsFromWhat(t *testing.T) {
 	long := "rebuild the deploy watcher so it stops polling a workflow that already finished"
-	feature, prompt := dxDispatch("  deploy watcher  ", "  "+long+"  ", "", true)
+	feature, prompt := dxDispatch("  deploy watcher  ", "  "+long+"  ", "", dispatchpkg.ModeAuto)
 	if feature != "deploy watcher" {
 		t.Errorf("feature = %q, want the title as typed", feature)
 	}
@@ -434,7 +448,7 @@ func TestDXDispatchNamesFromTitleBriefsFromWhat(t *testing.T) {
 	// A title past the branch's five-word cap keeps its words on the record: the
 	// cap belongs to the slug, which is what has to be a path (see
 	// dispatch.SlugWords), not to the name every screen shows.
-	feature, _ = dxDispatch("stop polling a workflow that already finished", "x", "", true)
+	feature, _ = dxDispatch("stop polling a workflow that already finished", "x", "", dispatchpkg.ModeAuto)
 	if feature != "stop polling a workflow that already finished" {
 		t.Errorf("a long title was abbreviated on the record: %q", feature)
 	}
@@ -442,7 +456,7 @@ func TestDXDispatchNamesFromTitleBriefsFromWhat(t *testing.T) {
 	// Nothing nameable is still nothing: submit's "name it" test reads the
 	// feature, so it must stay empty rather than become whitespace.
 	for _, s := range []string{"   ", "!!!"} {
-		if feature, _ := dxDispatch(s, "x", "", true); feature != "" {
+		if feature, _ := dxDispatch(s, "x", "", dispatchpkg.ModeAuto); feature != "" {
 			t.Errorf("title %q gave feature %q", s, feature)
 		}
 	}

--- a/internal/cockpit/dispatchform.go
+++ b/internal/cockpit/dispatchform.go
@@ -1,11 +1,18 @@
 package cockpit
 
 // dispatchform.go is the in-cockpit "new dispatch" overlay: the classic
-// cockpit's repo → feature → prompt flow, ported into v2 so ad-hoc work can be
-// dispatched without a backlog ticket. Open it with `+` or the palette's
+// cockpit's repo → feature → mode → prompt flow, ported into v2 so ad-hoc work
+// can be dispatched without a backlog ticket. Open it with `+` or the palette's
 // "dispatch" / "new dispatch" command. Like settings, it lives behind a pointer
 // on the model so its textinputs keep focus state across value-receiver Update
 // copies. Submitting hands off to launchCmd, which does the real dispatch.
+//
+// MODE is a step of its own rather than a default this overlay picks quietly.
+// It is the session's permission mode — what a dispatcher may do without
+// asking — and it reaches the process as --permission-mode, so a form that
+// chose it on the human's behalf would be deciding that silently every time.
+// It opens on the default with the list in view, so taking the default is one
+// keypress and changing it is two.
 
 import (
 	"strings"
@@ -23,7 +30,9 @@ type dispatchStep int
 const (
 	dispatchRepo dispatchStep = iota
 	dispatchFeature
+	dispatchMode
 	dispatchPrompt
+	dispatchStepCount
 )
 
 // dispatchForm is the open new-dispatch overlay. Each step owns one textinput;
@@ -37,9 +46,17 @@ type dispatchForm struct {
 
 	filter  textinput.Model // step 1: filter repos by name/product
 	feature textinput.Model // step 2: feature name
-	prompt  textinput.Model // step 3: the prompt
+	modeSel int             // step 3: cursor into dispatchpkg.Modes()
+	prompt  textinput.Model // step 4: the prompt
 
 	errMsg string
+}
+
+// mode is the permission mode step 3 has landed on. The cursor is the state
+// and the mode is derived from it, so the two can never disagree.
+func (df *dispatchForm) mode() dispatchpkg.Mode {
+	all := dispatchpkg.Modes()
+	return all[clampCursor(df.modeSel, len(all))]
 }
 
 // newDispatchForm builds the overlay, discovering repos from cfg. It focuses
@@ -62,7 +79,16 @@ func newDispatchForm(cfg *config.Config) *dispatchForm {
 	prompt.Placeholder = "describe the work to dispatch…"
 	prompt.CharLimit = 500
 
-	return &dispatchForm{step: dispatchRepo, repos: rs, filter: filter, feature: feature, prompt: prompt}
+	// modeSel opens on the default's own index rather than on 0, so the offer
+	// order in dispatchpkg.Modes() can change without silently changing what a
+	// dispatch that took the default runs as.
+	sel := 0
+	for i, k := range dispatchpkg.Modes() {
+		if k == dispatchpkg.DefaultMode {
+			sel = i
+		}
+	}
+	return &dispatchForm{step: dispatchRepo, repos: rs, modeSel: sel, filter: filter, feature: feature, prompt: prompt}
 }
 
 // filtered returns the repos matching the current filter (by name or product).
@@ -136,21 +162,44 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 				df.errMsg = "feature name is required — history is navigated by feature"
 				return m, nil
 			}
-			df.step = dispatchPrompt
+			df.step = dispatchMode
 			df.feature.Blur()
-			return m, df.prompt.Focus()
+			return m, nil
 		default:
 			var cmd tea.Cmd
 			df.feature, cmd = df.feature.Update(m.inputMsg(k))
 			return m, cmd
 		}
 
-	case dispatchPrompt:
+	case dispatchMode:
+		// Nothing on this step types, so every key is navigation and anything
+		// unrecognised is swallowed rather than treated as text.
 		switch k {
 		case "esc":
 			df.step = dispatchFeature
-			df.prompt.Blur()
 			return m, df.feature.Focus()
+		case "up", "ctrl+k", "left":
+			if df.modeSel > 0 {
+				df.modeSel--
+			}
+			return m, nil
+		case "down", "ctrl+j", "right":
+			if df.modeSel < len(dispatchpkg.Modes())-1 {
+				df.modeSel++
+			}
+			return m, nil
+		case "enter":
+			df.step = dispatchPrompt
+			return m, df.prompt.Focus()
+		}
+		return m, nil
+
+	case dispatchPrompt:
+		switch k {
+		case "esc":
+			df.step = dispatchMode
+			df.prompt.Blur()
+			return m, nil
 		case "enter", "ctrl+d":
 			if strings.TrimSpace(df.prompt.Value()) == "" {
 				df.errMsg = "prompt is required"
@@ -159,13 +208,14 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 			repo := df.repo.Name
 			feature := strings.TrimSpace(df.feature.Value())
 			prompt := strings.TrimSpace(df.prompt.Value())
+			mode := df.mode()
 			m.dispatchForm = nil
-			m.notice = "dispatching \"" + feature + "\"…"
+			m.notice = "dispatching \"" + feature + "\" · " + string(mode) + "…"
 			// This overlay closes onto whichever lens was behind it, so the
 			// dispatch has to be on the triage table by the time the human gets
 			// there — see pending.go.
 			m = m.markPending(m.pendingFor(repo, feature, prompt)).fleetSync()
-			return m, launchCmd(m.cfg, repo, feature, prompt)
+			return m, launchCmd(m.cfg, repo, feature, prompt, mode)
 		default:
 			var cmd tea.Cmd
 			df.prompt, cmd = df.prompt.Update(m.inputMsg(k))
@@ -221,7 +271,8 @@ func (m model) viewDispatchForm(w, h int) string {
 
 	var lines []string
 	lines = append(lines, fg(cWhite, "new dispatch"))
-	lines = append(lines, fg(cDim, "step "+itoa(int(df.step)+1)+" of 3 · repo → feature → prompt · esc backs out"))
+	lines = append(lines, fg(cDim, "step "+itoa(int(df.step)+1)+" of "+itoa(int(dispatchStepCount))+
+		" · repo → feature → mode → prompt · esc backs out"))
 	lines = append(lines, "")
 
 	// Breadcrumb of what's already been chosen.
@@ -234,6 +285,9 @@ func (m model) viewDispatchForm(w, h int) string {
 	}
 	if df.step > dispatchFeature {
 		lines = append(lines, row(iw, "", c("feature", 10, cFaint), flexc("feature/"+slugPreview(df.feature.Value()), cMid)))
+	}
+	if df.step > dispatchMode {
+		lines = append(lines, row(iw, "", c("mode", 10, cFaint), flexc(string(df.mode()), cMid)))
 	}
 	if df.step > dispatchRepo {
 		lines = append(lines, "")
@@ -275,14 +329,33 @@ func (m model) viewDispatchForm(w, h int) string {
 		lines = append(lines, row(iw, "", c("feature", 10, cMid), flexc(df.feature.View(), cWhite)))
 		lines = append(lines, "")
 		lines = append(lines, blank(2)+fg(cFaint, "the branch will be ")+fg(cMid, "feature/"+slugPreview(df.feature.Value())))
-		lines = append(lines, blank(2)+fg(cFaint, "enter → prompt · esc → repo"))
+		lines = append(lines, blank(2)+fg(cFaint, "enter → mode · esc → repo"))
+
+	case dispatchMode:
+		lines = append(lines, fg(cMid, "mode")+fg(cFaint, "  what the session may do without asking"))
+		lines = append(lines, "")
+		all := dispatchpkg.Modes()
+		sel := clampCursor(df.modeSel, len(all))
+		for i, k := range all {
+			bg, marker, nameColor := cTransparent, " ", cFg
+			if i == sel {
+				bg, marker, nameColor = cSel, "▸", cWhite
+			}
+			lines = append(lines, row(iw, bg,
+				c(marker, 2, cMid),
+				c(string(k), 10, nameColor),
+				flexc(k.Hint(), cDim),
+			))
+		}
+		lines = append(lines, "")
+		lines = append(lines, blank(2)+fg(cFaint, "enter → prompt · esc → feature"))
 
 	case dispatchPrompt:
 		lines = append(lines, fg(cFaint, "prompt")+"  "+fg(cMid, df.repo.Name)+fg(cFaint, " · ")+fg(cMid, strings.TrimSpace(df.feature.Value())))
 		lines = append(lines, "")
 		lines = append(lines, df.prompt.View())
 		lines = append(lines, "")
-		lines = append(lines, blank(2)+fg(cFaint, "enter or ctrl+d dispatches · esc → feature"))
+		lines = append(lines, blank(2)+fg(cFaint, "enter or ctrl+d dispatches · esc → mode"))
 	}
 
 	if df.errMsg != "" {

--- a/internal/cockpit/dispatchform_test.go
+++ b/internal/cockpit/dispatchform_test.go
@@ -9,6 +9,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 )
 
 // seedRepoRoot creates a scan root with the given repo dirs (each a fake git
@@ -72,7 +73,8 @@ func TestDispatchFormAcceptsBurstTyping(t *testing.T) {
 	if got := m.dispatchForm.feature.Value(); got != "payment retry flow" {
 		t.Fatalf("feature = %q", got)
 	}
-	m = press(m, "enter")
+	m = press(m, "enter") // → mode
+	m = press(m, "enter") // take the default and go on to the prompt
 	m = typeBurst(m, "retry failed charges with backoff")
 	if got := m.dispatchForm.prompt.Value(); got != "retry failed charges with backoff" {
 		t.Fatalf("prompt = %q", got)
@@ -168,14 +170,40 @@ func TestDispatchFormFlow(t *testing.T) {
 	}
 	m = typeStr(m, "csv export")
 	m = press(m, "enter")
+	if m.dispatchForm.step != dispatchMode {
+		t.Fatalf("after feature name, step = %d, want mode", m.dispatchForm.step)
+	}
+
+	// Step 3: the mode list opens on the default and every mode is on screen —
+	// a three-way choice shown one value at a time hides two thirds of itself.
+	if got := m.dispatchForm.mode(); got != dispatchpkg.DefaultMode {
+		t.Fatalf("mode opened on %q, want the default", got)
+	}
+	out = m.View()
+	for _, k := range dispatchpkg.Modes() {
+		if !strings.Contains(out, string(k)) {
+			t.Errorf("the mode step does not offer %q", k)
+		}
+	}
+	// Down walks to manual, and up comes back — the picked mode is what reaches
+	// the launch.
+	m = press(m, "down")
+	if got := m.dispatchForm.mode(); got != dispatchpkg.ModeManual {
+		t.Fatalf("down → %q, want manual", got)
+	}
+	m = press(m, "up")
+	if got := m.dispatchForm.mode(); got != dispatchpkg.ModeAuto {
+		t.Fatalf("up → %q, want auto", got)
+	}
+	m = press(m, "enter")
 	if m.dispatchForm.step != dispatchPrompt {
-		t.Fatalf("after feature name, step = %d, want prompt", m.dispatchForm.step)
+		t.Fatalf("after mode, step = %d, want prompt", m.dispatchForm.step)
 	}
 	if strings.TrimSpace(strings.Join(strings.Fields(m.View()), " ")) == "" {
 		t.Fatal("prompt step render empty")
 	}
 
-	// Step 3: empty prompt is rejected, then submitting launches and closes.
+	// Step 4: empty prompt is rejected, then submitting launches and closes.
 	m = press(m, "enter")
 	if m.dispatchForm == nil || m.dispatchForm.errMsg == "" {
 		t.Fatal("empty prompt should be rejected and keep the form open")
@@ -194,8 +222,8 @@ func TestDispatchFormFlow(t *testing.T) {
 	}
 }
 
-// TestDispatchFormEscBacksOut walks the esc chain: prompt → feature → repo →
-// closed, mirroring the classic form's back navigation.
+// TestDispatchFormEscBacksOut walks the esc chain: prompt → mode → feature →
+// repo → closed, mirroring the classic form's back navigation.
 func TestDispatchFormEscBacksOut(t *testing.T) {
 	root := seedRepoRoot(t, "api")
 	cfg := &config.Config{Roots: []string{root}}
@@ -208,13 +236,18 @@ func TestDispatchFormEscBacksOut(t *testing.T) {
 	m = press(m, "+")
 	m = press(m, "enter") // pick the only repo
 	m = typeStr(m, "thing")
+	m = press(m, "enter") // → mode
 	m = press(m, "enter") // → prompt
 	if m.dispatchForm.step != dispatchPrompt {
 		t.Fatalf("expected prompt step, got %d", m.dispatchForm.step)
 	}
 	m = press(m, "esc")
+	if m.dispatchForm.step != dispatchMode {
+		t.Fatal("esc from prompt should go back to mode")
+	}
+	m = press(m, "esc")
 	if m.dispatchForm.step != dispatchFeature {
-		t.Fatal("esc from prompt should go back to feature")
+		t.Fatal("esc from mode should go back to feature")
 	}
 	if got := strings.TrimSpace(m.dispatchForm.feature.Value()); got != "thing" {
 		t.Fatalf("feature value lost on back-nav: %q", got)

--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -11,7 +11,7 @@ package cockpit
 //	TITLE      what it is called: the feature name, and the branch
 //	WHAT       the work itself, wrapped over as many rows as it takes
 //	DONE WHEN  the completion condition, optional
-//	AUTO       whether it runs unattended or checks in between steps
+//	MODE       auto, manual or plan — what it may do without asking
 //
 // TITLE and WHAT used to be one field, and the branch was named from it. That
 // asked one line to be two things at once: a name short enough to live in
@@ -20,9 +20,16 @@ package cockpit
 // — the only field with room — and the completion condition was lost. Naming
 // and describing are separate now, and only TITLE reaches the branch.
 //
-// Two of the five are honest about their reach. There is no permission plumbing
-// behind AUTO and no supervisor watching DONE WHEN: the only thing that reaches
-// a session is the prompt, so both are sentences in the prompt and the copy
+// MODE was AUTO, a two-position switch with nothing behind it: the launch
+// command was claude with a prompt and no flags, so "unattended" was a sentence
+// in the prompt and the session still opened in whatever mode the human's own
+// Claude Code defaults to — and stopped on its first permission prompt with
+// nobody watching. It reaches the process now, as --permission-mode (see
+// dispatch/mode.go), which is also what lets it offer plan mode: plan is not
+// something a sentence can ask for.
+//
+// DONE WHEN is still honest about its reach in the other direction: no
+// supervisor watches it, so it is a sentence in the prompt and the copy
 // promises nothing more (see dxPrompt).
 //
 // Everything on screen comes from the same real collector data the products
@@ -51,7 +58,7 @@ const (
 	dxTitleF
 	dxWhatF
 	dxGoalF
-	dxAutoF
+	dxModeF
 	dxFieldCount
 )
 
@@ -77,7 +84,7 @@ func (m model) dxReset() model {
 	m.cqDispatch = false
 	m.dxField, m.dxRepo = dxWhereF, 0
 	m.dxFilter, m.dxTitle, m.dxWhat, m.dxGoal = "", "", "", ""
-	m.dxAuto = true
+	m.dxMode = dispatchpkg.DefaultMode
 	return m
 }
 
@@ -94,8 +101,8 @@ func (m model) dxOpen(filter string) model {
 // dxTouched reports whether anything has been typed into the four text fields.
 // It is what decides whether a navigation key is navigation or text: an
 // untouched form is not a trap, so 1–6, ':', 'd' and 'h' still leave it, but the
-// moment there is a filter or a sentence they are letters again. dxAuto and
-// dxField deliberately do not count — toggling auto or tabbing about is not
+// moment there is a filter or a sentence they are letters again. dxMode and
+// dxField deliberately do not count — cycling the mode or tabbing about is not
 // typing, and must not strand the human on this screen.
 func (m model) dxTouched() bool {
 	return m.dxFilter != "" || m.dxTitle != "" || m.dxWhat != "" || m.dxGoal != ""
@@ -245,22 +252,30 @@ func (m model) dxBranch() string {
 // The two returns stay: a caller that reconstructs the brief from the feature
 // name is precisely the bug, and one function returning both is what stops the
 // next one from trying.
-func dxDispatch(title, what, goal string, auto bool) (feature, prompt string) {
+func dxDispatch(title, what, goal string, mode dispatchpkg.Mode) (feature, prompt string) {
 	title, what = strings.TrimSpace(title), strings.TrimSpace(what)
-	return dxFeatureName(title), dxPrompt(title, what, goal, auto)
+	return dxFeatureName(title), dxPrompt(title, what, goal, mode)
 }
 
 // dxPrompt composes the prompt. what is the sentence as it was typed, in full:
 // the feature name is an abbreviation of it, and abbreviating a brief is not the
-// same thing as abbreviating a name. AUTO and DONE WHEN have no plumbing behind
-// them — the launch command is claude with a prompt, with no permission flags
-// and no watchdog — so they are instructions, and this is the only place they
-// exist. Keep the copy inside what a prompt can promise.
+// same thing as abbreviating a name.
+//
+// DONE WHEN has no plumbing behind it — nothing watches a dispatcher to see
+// whether its condition came true — so it is an instruction, and this is the
+// only place it exists. Keep the copy inside what a prompt can promise.
+//
+// MODE does reach the process, as --permission-mode, and still gets a sentence
+// here: the flag says what claude may do without asking, and the sentence says
+// how far to take the work. "May edit without asking" is not "commit, push and
+// open the PR", and a session given the first and not the second stops with the
+// work uncommitted — which is exactly the unattended dispatch that never
+// shipped. The two lines have to agree, so they are chosen together.
 //
 // TITLE leads, on its own line, because it is the name the branch, the worktree
 // and every screen file this work under: the session should know what it is
 // building before it reads the brief. WHAT follows as the body.
-func dxPrompt(title, what, goal string, auto bool) string {
+func dxPrompt(title, what, goal string, mode dispatchpkg.Mode) string {
 	lines := []string{title}
 	if what != "" {
 		lines = append(lines, "", what)
@@ -268,12 +283,22 @@ func dxPrompt(title, what, goal string, auto bool) string {
 	if goal != "" {
 		lines = append(lines, "", "done when: "+goal, "Keep working until that is true.")
 	}
-	if auto {
-		lines = append(lines, "", "Commit as you go, open the PR, and fix your own CI failures without stopping to ask.")
-	} else {
-		lines = append(lines, "", "Do one pass, then stop and check in before committing, pushing or opening a PR.")
+	return strings.Join(append(lines, "", dxModeInstruction(mode)), "\n")
+}
+
+// dxModeInstruction is the sentence that tells the session how far to take the
+// work, matched to the mode its permissions were set to.
+func dxModeInstruction(mode dispatchpkg.Mode) string {
+	switch mode.Normalize() {
+	case dispatchpkg.ModeManual:
+		return "Do one pass, then stop and check in before committing, pushing or opening a PR."
+	case dispatchpkg.ModePlan:
+		// Plan mode already stops claude from changing anything; the sentence
+		// says what to spend the read-only pass on, so the plan that comes back
+		// is about this work rather than a summary of the repo.
+		return "Work out how you would do this and put the plan up for approval before changing anything."
 	}
-	return strings.Join(lines, "\n")
+	return "Commit as you go, open the PR, and fix your own CI failures without stopping to ask."
 }
 
 // ---- keys ---------------------------------------------------------------------
@@ -285,8 +310,8 @@ func dxPrompt(title, what, goal string, auto bool) string {
 // carrying every rune, and rebuilding from the name would keep only the first
 // (or the brackets a paste is reported inside).
 //
-// The branch order is load-bearing. AUTO is tested before backspace and before
-// text, so on that line space is a toggle rather than a character; and the
+// The branch order is load-bearing. MODE is tested before backspace and before
+// text, so on that line space cycles rather than typing a character; and the
 // text branch is last, so nothing typeable can shadow a navigation key.
 func (m model) dxKey(k string) (model, tea.Cmd) {
 	rows := m.dxRows()
@@ -313,7 +338,7 @@ func (m model) dxKey(k string) (model, tea.Cmd) {
 		return m, nil
 
 	case "enter":
-		if field == dxAutoF {
+		if field == dxModeF {
 			return m.dxSubmit()
 		}
 		m.dxField = field + 1
@@ -324,7 +349,7 @@ func (m model) dxKey(k string) (model, tea.Cmd) {
 			m.dxRepo = mini(m.dxRepo+1, maxi(len(rows)-1, 0))
 			return m, nil
 		}
-		m.dxField = mini2(field+1, dxAutoF)
+		m.dxField = mini2(field+1, dxModeF)
 		return m, nil
 
 	case "up":
@@ -336,12 +361,23 @@ func (m model) dxKey(k string) (model, tea.Cmd) {
 		return m, nil
 	}
 
-	// AUTO is a switch, not a field: space and `a` flip it, and nothing else on
-	// that line types. This has to sit above the text branch, because typedText
-	// turns a space into " ".
-	if field == dxAutoF {
-		if k == " " || k == "space" || k == "a" {
-			m.dxAuto = !m.dxAuto
+	// MODE is a switch, not a field: space and `a` walk the three positions,
+	// left/right steer within the line, and nothing else on it types. This has
+	// to sit above the text branch, because typedText turns a space into " ".
+	//
+	// `a` survives from when this line was AUTO and had two positions; it is
+	// still the letter the field is reached for, and cycling is what it now
+	// does. left/right are here because a three-way switch is a list, and a
+	// list you can only walk one way makes the third choice three keypresses.
+	// The vim pair is deliberately not bound: `h` leaves this lens from an
+	// untouched form, and one key that navigates on an empty form and edits on
+	// a filled one is the kind of thing nobody remembers under pressure.
+	if field == dxModeF {
+		switch k {
+		case " ", "space", "a", "right":
+			m.dxMode = dispatchpkg.Next(m.dxMode.Normalize())
+		case "left":
+			m.dxMode = dispatchpkg.Prev(m.dxMode.Normalize())
 		}
 		return m, nil
 	}
@@ -414,7 +450,8 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 		return m, nil
 	}
 	goal := strings.TrimSpace(m.dxGoal)
-	feature, prompt := dxDispatch(m.dxTitle, m.dxWhat, goal, m.dxAuto)
+	mode := m.dxMode.Normalize()
+	feature, prompt := dxDispatch(m.dxTitle, m.dxWhat, goal, mode)
 	if feature == "" {
 		// Empty *or* unslugabble: a title of nothing but punctuation passes a
 		// plain "is it blank" test and then fails inside Launch, where the human
@@ -427,7 +464,7 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 		m.notice = "say what it should do — the title alone is not a brief"
 		return m, nil
 	}
-	branch, auto := m.dxBranch(), m.dxAuto
+	branch := m.dxBranch()
 
 	m = m.dxReset()
 	// Present tense: nothing has launched yet. launchCmd's actionMsg replaces
@@ -438,9 +475,10 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 	} else {
 		notice += " · one pass, then waits"
 	}
-	if auto {
-		notice += " · auto"
-	}
+	// The mode is always named, not only when it is the interesting one: it now
+	// configures the session rather than describing it, and a launch flag the
+	// notice stayed quiet about would be a setting the human never saw applied.
+	notice += " · " + string(mode)
 	m.notice = notice
 	// The row goes on the table now, not when the launch comes back. The form is
 	// closing over the table it was drawn on top of, and without this the human
@@ -449,7 +487,7 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 	// table is empty. fleetSync re-keys the cursor over the row that just moved
 	// down; on an empty table it lands the cursor on the new row itself.
 	m = m.markPending(m.pendingFor(row.repo, feature, prompt)).fleetSync()
-	return m, dxLaunch(m.cfg, row.repo, feature, prompt)
+	return m, dxLaunch(m.cfg, row.repo, feature, prompt, mode)
 }
 
 // dxLaunch is the launch dxSubmit hands off to, named as a variable so a test
@@ -513,21 +551,51 @@ func (m model) dxGoalHint() string {
 	return "optional · leave empty and it does one pass, then waits for you"
 }
 
-// dxAutoValue is the switch's position and its colour.
-func (m model) dxAutoValue() (string, string) {
-	if m.dxAuto {
-		return "on", cGreen
+// dxModeGap separates the positions on the MODE line.
+const dxModeGap = "  "
+
+// dxModeValue is the switch: all three positions, with a caret on the chosen
+// one.
+//
+// They are drawn together rather than as a single word because a two-position
+// switch could say "on" and be understood as "off is the other one", while a
+// three-way one showing only its current value hides two thirds of the offer
+// behind a key nobody knows to press.
+//
+// The caret is what marks the selection; the colour only reinforces it. Colour
+// alone is not a marker here — the three positions read identically without it,
+// unlike the old on/off whose word changed — so a terminal with no colour, or
+// an eye that cannot separate green from grey, would have no way to tell which
+// one is armed.
+func (m model) dxModeValue() string {
+	cur := m.dxMode.Normalize()
+	parts := make([]string, 0, len(dispatchpkg.Modes()))
+	for _, k := range dispatchpkg.Modes() {
+		if k == cur {
+			parts = append(parts, fg(cGreen, "▸"+string(k)))
+			continue
+		}
+		parts = append(parts, fg(cFaint, " "+string(k)))
 	}
-	return "off", cFaint
+	return strings.Join(parts, dxModeGap)
 }
 
-// dxAutoHint describes what the prompt will actually instruct.
-func (m model) dxAutoHint() string {
-	if m.dxAuto {
-		return "commits, opens the pr, retries its own failures"
+// dxModeWidth is what dxModeValue occupies on screen — the words, their carets
+// and the gaps, without the colour escapes dispWidth would have to see through.
+func dxModeWidth() int {
+	w := 0
+	for i, k := range dispatchpkg.Modes() {
+		if i > 0 {
+			w += dispWidth(dxModeGap)
+		}
+		w += dispWidth("▸" + string(k))
 	}
-	return "stops and asks after every step · space toggles"
+	return w
 }
+
+// dxModeHint describes what the chosen mode actually does to the session, and
+// — this being a switch on a line rather than a list — which key moves it.
+func (m model) dxModeHint() string { return m.dxMode.Hint() + " · space cycles" }
 
 // dxSummary is the whole form in one line: where it lands, what it will be
 // called, and whether it needs you.
@@ -541,11 +609,7 @@ func (m model) dxSummary() string {
 	if !ok {
 		return "pick a repo to dispatch into"
 	}
-	s := row.repo + " · " + m.dxBranch() + " · "
-	if m.dxAuto {
-		return s + "auto"
-	}
-	return s + "asks each step"
+	return row.repo + " · " + m.dxBranch() + " · " + m.dxMode.Summary()
 }
 
 // dxFooterHelp is the chrome row while the form is open. It advertises only
@@ -593,7 +657,6 @@ func (m model) dxView(w, h int) string {
 		cqFixed(m.dxFieldRow(inner, "WHERE", m.dxFilter, m.dxField == dxWhereF, m.dxRepoCount())),
 	}
 
-	autoVal, autoHex := m.dxAutoValue()
 	// The gap under TITLE is order 10: the last spacer to go, because the two
 	// fields either side of it are the two the human types into, and a title
 	// touching its brief reads as one run-on sentence.
@@ -609,7 +672,7 @@ func (m model) dxView(w, h int) string {
 		cqFixed(m.dxFieldRow(inner, "DONE WHEN", m.dxGoal, m.dxField == dxGoalF, "")),
 		cqFixed(dxHintRow(inner, m.dxGoalHint())),
 		cqGap(8),
-		cqFixed(dxAutoRow(inner, m.dxField == dxAutoF, autoVal, autoHex, m.dxAutoHint())),
+		cqFixed(dxModeRow(inner, m.dxField == dxModeF, m.dxModeValue(), m.dxModeHint())),
 		cqGap(6),
 		cqFixed(dxHintRow(inner, m.dxSummary())),
 	}
@@ -674,12 +737,17 @@ func dxHintRow(inner int, s string) string {
 	return flG(blank(dxIndent) + fg(cFaint, truncate(s, maxi(1, inner-dxIndent))))
 }
 
-// dxAutoRow is the AUTO switch. It has no caret: there is nothing to type into
-// it, and a caret would say otherwise.
-func dxAutoRow(inner int, active bool, value, hex, hint string) string {
-	lbl := fg(dxLabelColor(active), padTo("AUTO", dxLabelW, alignLeft))
-	room := maxi(1, inner-dxLabelW-dxGapW-dispWidth(value)-dxGapW)
-	return flG(lbl + blank(dxGapW) + fg(hex, value) + blank(dxGapW) + fg(cFaint, truncate(hint, room)))
+// dxModeRow is the MODE switch: the three positions with the chosen one lit,
+// then what it means. It has no caret: there is nothing to type into it, and a
+// caret would say otherwise.
+//
+// value arrives already coloured, so its width comes from dxModeWidth rather
+// than from measuring the string — the colour escapes are not columns, and
+// budgeting the hint against them would leave the line short.
+func dxModeRow(inner int, active bool, value, hint string) string {
+	lbl := fg(dxLabelColor(active), padTo("MODE", dxLabelW, alignLeft))
+	room := maxi(1, inner-dxLabelW-dxGapW-dxModeWidth()-dxGapW)
+	return flG(lbl + blank(dxGapW) + value + blank(dxGapW) + fg(cFaint, truncate(hint, room)))
 }
 
 // dxLabelColor lifts the label of the field that owns the keyboard, which is

--- a/internal/cockpit/dispatchx_test.go
+++ b/internal/cockpit/dispatchx_test.go
@@ -8,7 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 )
 
 // dxFormModel is the dx form open over a repo list that actually has a repo in
@@ -90,10 +93,10 @@ func TestDXSubmitAsksForTitleThenWhat(t *testing.T) {
 	}
 }
 
-// The prompt leads with the title, then the brief, then the two sentences that
-// are the whole of DONE WHEN and AUTO.
+// The prompt leads with the title, then the brief, then DONE WHEN's sentence
+// and the one that matches the mode.
 func TestDXPromptLeadsWithTheTitle(t *testing.T) {
-	got := dxPrompt("payment retries", "retry declined cards on a backoff", "ci is green", true)
+	got := dxPrompt("payment retries", "retry declined cards on a backoff", "ci is green", dispatchpkg.ModeAuto)
 	want := strings.Join([]string{
 		"payment retries",
 		"",
@@ -110,8 +113,77 @@ func TestDXPromptLeadsWithTheTitle(t *testing.T) {
 
 	// With no brief the title stands alone rather than leaving a hole where the
 	// body would be.
-	if got := dxPrompt("payment retries", "", "", false); !strings.HasPrefix(got, "payment retries\n\nDo one pass") {
+	if got := dxPrompt("payment retries", "", "", dispatchpkg.ModeManual); !strings.HasPrefix(got, "payment retries\n\nDo one pass") {
 		t.Errorf("prompt with no WHAT =\n%s", got)
+	}
+
+	// Plan mode gets its own closing sentence: telling a session that cannot
+	// change anything to commit as it goes would be an instruction it has to
+	// disobey, and the mode is not a two-position switch any more.
+	plan := dxPrompt("payment retries", "retry declined cards", "", dispatchpkg.ModePlan)
+	if strings.Contains(plan, "Commit as you go") || !strings.Contains(plan, "put the plan up for approval") {
+		t.Errorf("plan mode's prompt =\n%s", plan)
+	}
+}
+
+// The MODE line shows all three positions and marks the armed one with a
+// caret rather than with colour alone.
+//
+// The three words read identically without colour — unlike the on/off switch
+// this replaced, whose word changed — so a terminal with no colour, or an eye
+// that cannot separate green from grey, would have no way to tell which one is
+// armed. The test renders through the view, which is where lipgloss strips the
+// escapes when there is no terminal, so it is asserting exactly what such a
+// terminal shows.
+func TestDXModeLineMarksTheArmedModeWithoutColour(t *testing.T) {
+	m := dxFormModel(t)
+	m.dxField = dxModeF
+	for _, want := range dispatchpkg.Modes() {
+		m.dxMode = want
+		out := m.dxView(120, 34)
+		if !strings.Contains(out, "▸"+string(want)) {
+			t.Errorf("MODE %q is not marked as armed:\n%s", want, out)
+		}
+		for _, other := range dispatchpkg.Modes() {
+			if other == want {
+				continue
+			}
+			if strings.Contains(out, "▸"+string(other)) {
+				t.Errorf("MODE %q is armed but %q also carries the caret", want, other)
+			}
+			// Still on offer, though — a three-way switch that showed only its
+			// current value would hide two thirds of itself.
+			if !strings.Contains(out, string(other)) {
+				t.Errorf("MODE %q is not on offer while %q is armed", other, want)
+			}
+		}
+	}
+}
+
+// The mode reaches the launch, not just the prompt: it is what claude is
+// started with (--permission-mode), and a form that composed a sentence about
+// being unattended and then left the flag off is the defect this field had.
+func TestDXSubmitPassesTheMode(t *testing.T) {
+	var got dispatchpkg.Mode
+	prev := dxLaunch
+	dxLaunch = func(_ *config.Config, _, _, _ string, mode dispatchpkg.Mode) tea.Cmd {
+		got = mode
+		return nil
+	}
+	t.Cleanup(func() { dxLaunch = prev })
+
+	m := dxFormModel(t)
+	m.dxTitle, m.dxWhat, m.dxMode = "payment retries", "retry declined cards", dispatchpkg.ModePlan
+	if _, _ = m.dxSubmit(); got != dispatchpkg.ModePlan {
+		t.Errorf("the launch got mode %q, want plan", got)
+	}
+
+	// And the default is auto: a dispatcher is work sent somewhere else to
+	// happen, and the form must not open on a mode that stops on step one.
+	m = dxFormModel(t)
+	m.dxTitle, m.dxWhat = "payment retries", "retry declined cards"
+	if _, _ = m.dxSubmit(); got != dispatchpkg.ModeAuto {
+		t.Errorf("an untouched MODE launched as %q, want auto", got)
 	}
 }
 

--- a/internal/cockpit/fleet.go
+++ b/internal/cockpit/fleet.go
@@ -90,6 +90,12 @@ type fleetRow struct {
 	model     string
 	ctxKnown  bool
 
+	// mode is the permission mode this dispatcher was launched in, straight off
+	// the record. Empty for a record written before the mode was a choice: those
+	// ran in whatever the human's own Claude Code defaults to, and reporting
+	// that as "auto" would be inventing the one fact nobody recorded.
+	mode string
+
 	acts []cqAct
 
 	// moved is the freshest of the transcript's mtime and the record's
@@ -313,6 +319,7 @@ func fleetQueueRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 		ctxTokens: u.Tokens,
 		model:     cqShortModel(u.Model),
 		ctxKnown:  ctxKnown,
+		mode:      rec.Mode,
 		acts:      cqActs(rec, ask),
 		moved:     fleetMoved(rec),
 		started:   rec.CreatedAt,
@@ -376,6 +383,7 @@ func fleetRunRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 		ctxTokens: u.Tokens,
 		model:     cqShortModel(u.Model),
 		ctxKnown:  ctxKnown,
+		mode:      rec.Mode,
 		acts:      cqActs(rec, "running"),
 		moved:     moved,
 		started:   rec.CreatedAt,
@@ -410,6 +418,7 @@ func fleetPastRow(ctx *collectCtx, passes map[string]int, rec *state.Dispatch) f
 		why:       cqSentence(rec.StatusReason),
 		goal:      goal,
 		goalLabel: goalLabel,
+		mode:      rec.Mode,
 		acts:      cqActs(rec, "past"),
 		moved:     fleetMoved(rec),
 		started:   rec.CreatedAt,

--- a/internal/cockpit/fleet_view.go
+++ b/internal/cockpit/fleet_view.go
@@ -21,7 +21,11 @@ package cockpit
 // All content comes from fleet.go and cq.go, which leave out any clause they
 // have no source for. Nothing is composed here that is not already true.
 
-import "strings"
+import (
+	"strings"
+
+	dispatchpkg "claude-dispatcher/internal/dispatch"
+)
 
 // ---- columns ------------------------------------------------------------------
 
@@ -312,21 +316,38 @@ func (m model) fleetHistoryHeadline(inner int, rows []fleetRow) string {
 const fleetWhyLines = 2
 
 // fleetMeta is the panel's status tail: how many turns it has taken, how full
-// its context was on the last assistant turn, and which model ran it. Each
-// clause is dropped whole when its source said nothing.
+// its context was on the last assistant turn, which model ran it, and the
+// permission mode it was dispatched in. Each clause is dropped whole when its
+// source said nothing.
+//
+// The mode used to be in the list of things this line must never claim, because
+// nothing persisted it — it was a form field and not a record field, so any
+// "auto" here would have been the form's intention rather than the session's
+// configuration. It is on the record now, and it is a fact about the dispatcher
+// the human otherwise has no way to see once the form is closed. A record
+// written before the mode was a choice still carries none, and still says
+// nothing rather than the default.
 //
 // Absent, and to stay absent: "of 200k context" (the denominator is not
-// knowable from a model id), "· auto" (nothing persists the mode a session was
-// launched under — dxAuto is a form field, not a record field), and the
-// design's check trend (one sample cannot make a trend).
+// knowable from a model id) and the design's check trend (one sample cannot
+// make a trend).
 func fleetMeta(r fleetRow) string {
-	parts := make([]string, 0, 2)
-	for _, p := range []string{cqPassLine(r.pass), cqCtxLine(r)} {
+	parts := make([]string, 0, 3)
+	for _, p := range []string{cqPassLine(r.pass), cqCtxLine(r), fleetModeLine(r.mode)} {
 		if p != "" {
 			parts = append(parts, p)
 		}
 	}
 	return strings.Join(parts, " · ")
+}
+
+// fleetModeLine names the permission mode a dispatcher was launched in, and
+// says nothing at all for a record that never recorded one.
+func fleetModeLine(mode string) string {
+	if !dispatchpkg.Mode(mode).Known() {
+		return ""
+	}
+	return mode
 }
 
 // fleetDetail is everything under the table about the selected row: what it is

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -6,6 +6,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/version"
 )
 
@@ -167,15 +168,15 @@ type model struct {
 
 	// ---- triage lens: the structured dispatch form -------------------------
 	// The floor's freeform draft became five fields: where it lands, what it is
-	// called, what it does, when it is done, and whether it needs you between
-	// steps. See dispatchx.go — cqDispatch is what says the form is open.
-	dxField  dxFieldID // which line owns the keyboard
-	dxFilter string    // WHERE: repo filter (runes from the key message)
-	dxRepo   int       // cursor into dxRows(); clamped on read, reset by filtering
-	dxTitle  string    // TITLE: the feature name, and the branch
-	dxWhat   string    // WHAT: the work — the prompt's body, wrapped as it is typed
-	dxGoal   string    // DONE WHEN: completion condition, optional
-	dxAuto   bool      // AUTO: unattended (default true)
+	// called, what it does, when it is done, and how much it may do without
+	// asking. See dispatchx.go — cqDispatch is what says the form is open.
+	dxField  dxFieldID        // which line owns the keyboard
+	dxFilter string           // WHERE: repo filter (runes from the key message)
+	dxRepo   int              // cursor into dxRows(); clamped on read, reset by filtering
+	dxTitle  string           // TITLE: the feature name, and the branch
+	dxWhat   string           // WHAT: the work — the prompt's body, wrapped as it is typed
+	dxGoal   string           // DONE WHEN: completion condition, optional
+	dxMode   dispatchpkg.Mode // MODE: auto / manual / plan — the session's permission mode
 }
 
 func newModel() model {
@@ -195,8 +196,10 @@ func newModel() model {
 		// brew/nix/unknown cases without being installed that way.
 		install: version.Detect(),
 		// The default dispatch is unattended. Without this the form opens on
-		// "asks after every step", which is not the product's default posture.
-		dxAuto: true,
+		// the zero value, which is not a mode at all — and the launch it made
+		// would open a session asking about every step, which is not the
+		// product's default posture.
+		dxMode: dispatchpkg.DefaultMode,
 	}
 }
 

--- a/internal/cockpit/pending_test.go
+++ b/internal/cockpit/pending_test.go
@@ -11,6 +11,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/state"
 )
 
@@ -21,7 +22,7 @@ func stubLaunch(t *testing.T) *struct{ repo, feature, prompt string } {
 	t.Helper()
 	got := &struct{ repo, feature, prompt string }{}
 	prev := dxLaunch
-	dxLaunch = func(_ *config.Config, repo, feature, prompt string) tea.Cmd {
+	dxLaunch = func(_ *config.Config, repo, feature, prompt string, _ dispatchpkg.Mode) tea.Cmd {
 		got.repo, got.feature, got.prompt = repo, feature, prompt
 		return nil
 	}

--- a/internal/cockpit/product.go
+++ b/internal/cockpit/product.go
@@ -15,6 +15,7 @@ package cockpit
 import (
 	"strings"
 
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
 
@@ -711,7 +712,12 @@ func (m model) updateProduct(k string) (model, tea.Cmd) {
 				return m, nil
 			}
 			m.notice = "dispatching \"" + t.feature + "\" again…"
-			return m, launchCmd(m.cfg, t.repo, t.feature, text)
+			// Same reading as the backlog's enter: this panel asks for a line of
+			// text, not for a mode, so the re-dispatch takes the default rather
+			// than inheriting the finished dispatcher's — the human typed a new
+			// brief, and a mode chosen for the last run is not consent for this
+			// one.
+			return m, launchCmd(m.cfg, t.repo, t.feature, text, dispatchpkg.DefaultMode)
 		}
 		m.resumeText = next
 		return m, nil

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -68,7 +68,11 @@ func capSlug(s string) string {
 // and the human — from fighting over the repo's single checkout. The
 // CLAUDE_DISPATCHER_ID environment variable is the join key that lets the
 // lifecycle hook attribute events back to this record.
-func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
+//
+// mode is the permission mode the session opens in; it goes on the record as
+// well as on the command line, because Resume has to reopen the session the way
+// it was dispatched and the transcript does not carry it.
+func Launch(r repos.Repo, feature, prompt string, mode Mode) (*state.Dispatch, error) {
 	slug := Slugify(feature)
 	if slug == "" {
 		return nil, fmt.Errorf("feature name %q produces an empty slug", feature)
@@ -92,6 +96,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		baseSHA = strings.TrimSpace(string(out))
 	}
 
+	mode = mode.Normalize()
 	d := &state.Dispatch{
 		ID:           state.NewID(),
 		Feature:      feature,
@@ -103,6 +108,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 		WorktreePath: worktree,
 		BaseSHA:      baseSHA,
 		Prompt:       prompt,
+		Mode:         string(mode),
 		TmuxSession:  uniqueName("disp-" + slug),
 		Status:       state.StatusLaunching,
 		CreatedAt:    time.Now(),
@@ -114,7 +120,7 @@ func Launch(r repos.Repo, feature, prompt string) (*state.Dispatch, error) {
 	// launchCommand is OS-specific (bash on Unix, cmd.exe on Windows); it keeps
 	// the session's window open after claude exits so it stays available for
 	// inspection instead of vanishing.
-	cmd := launchCommand(d.ID, prompt)
+	cmd := launchCommand(d.ID, prompt, mode)
 	if err := newSession(d.TmuxSession, worktree, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -211,7 +211,7 @@ func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
 		sessionAlive, sessionIdle, newSession, uniqueName = prevAlive, prevIdle, prevNew, prevUniq
 	}()
 
-	_, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go")
+	_, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go", ModeAuto)
 	if err == nil {
 		t.Fatal("expected a duplicate of a live feature to be refused")
 	}

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -235,8 +235,15 @@ func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
 	if got := liveDispatch("payment-retry"); got != nil {
 		t.Errorf("a leftover login shell reported as a live dispatcher: %#v", got)
 	}
-	if _, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go"); err != nil {
+	d, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go", ModePlan)
+	if err != nil {
 		t.Errorf("re-dispatching a finished feature was refused: %v", err)
+	}
+	// The only Launch in the suite that runs to completion, so it is where the
+	// mode reaching the record is provable: Resume reads it back to reopen the
+	// dispatcher the way it went out.
+	if d != nil && d.Mode != string(ModePlan) {
+		t.Errorf("the record kept mode %q, want plan", d.Mode)
 	}
 }
 

--- a/internal/dispatch/launchcmd_unix.go
+++ b/internal/dispatch/launchcmd_unix.go
@@ -10,23 +10,36 @@ import (
 // launchCommand builds the shell command that runs claude for a dispatch on
 // Unix. When claude exits we drop to a login shell so the tmux session stays
 // open for inspection instead of vanishing. CLAUDE_DISPATCHER_ID is the join
-// key the lifecycle hook reads to attribute events back to the record.
-func launchCommand(dispatcherID, prompt string) string {
-	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude %s; exec ${SHELL:-/bin/sh}",
-		dispatcherID, shellQuote(prompt))
+// key the lifecycle hook reads to attribute events back to the record, and
+// mode is the permission mode the session opens in (see mode.go).
+func launchCommand(dispatcherID, prompt string, mode Mode) string {
+	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude%s %s; exec ${SHELL:-/bin/sh}",
+		dispatcherID, modeArgs(mode), shellQuote(prompt))
 }
 
 // resumeCommand is launchCommand for a session that already exists: claude
 // picks the recorded conversation back up instead of starting a new one, and an
 // empty prompt is left off entirely rather than passed as an empty argument,
-// which claude would read as a first message with nothing in it.
-func resumeCommand(dispatcherID, sessionID, prompt string) string {
+// which claude would read as a first message with nothing in it. The mode is
+// passed again because --permission-mode is a property of the new session, not
+// of the transcript it reopens.
+func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode) string {
 	arg := ""
 	if prompt != "" {
 		arg = " " + shellQuote(prompt)
 	}
-	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude --resume %s%s; exec ${SHELL:-/bin/sh}",
-		dispatcherID, shellQuote(sessionID), arg)
+	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude%s --resume %s%s; exec ${SHELL:-/bin/sh}",
+		dispatcherID, modeArgs(mode), shellQuote(sessionID), arg)
+}
+
+// modeArgs is the permission-mode flag as a leading-space-prefixed fragment,
+// or "" when this claude has no spelling for the mode.
+func modeArgs(mode Mode) string {
+	args := PermissionArgs(mode)
+	if len(args) == 0 {
+		return ""
+	}
+	return " " + strings.Join(args, " ")
 }
 
 // shellQuote single-quotes a string for POSIX shells, escaping embedded quotes.

--- a/internal/dispatch/launchcmd_windows.go
+++ b/internal/dispatch/launchcmd_windows.go
@@ -9,26 +9,40 @@ import (
 
 // launchCommand builds the cmd.exe command that runs claude for a dispatch on
 // Windows. CLAUDE_DISPATCHER_ID is the join key the lifecycle hook reads to
-// attribute events back to the record. The trailing ` & pause` keeps the
-// detached console window open after claude exits so it stays available for
-// inspection instead of vanishing (the Windows analogue of dropping to a
-// login shell on Unix).
-func launchCommand(dispatcherID, prompt string) string {
-	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude %s & pause`,
-		dispatcherID, winQuote(prompt))
+// attribute events back to the record, and mode is the permission mode the
+// session opens in (see mode.go). The trailing ` & pause` keeps the detached
+// console window open after claude exits so it stays available for inspection
+// instead of vanishing (the Windows analogue of dropping to a login shell on
+// Unix).
+func launchCommand(dispatcherID, prompt string, mode Mode) string {
+	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude%s %s & pause`,
+		dispatcherID, modeArgs(mode), winQuote(prompt))
 }
 
 // resumeCommand is launchCommand for a session that already exists: claude
 // picks the recorded conversation back up instead of starting a new one, and an
 // empty prompt is left off entirely rather than passed as an empty argument,
-// which claude would read as a first message with nothing in it.
-func resumeCommand(dispatcherID, sessionID, prompt string) string {
+// which claude would read as a first message with nothing in it. The mode is
+// passed again because --permission-mode is a property of the new session, not
+// of the transcript it reopens.
+func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode) string {
 	arg := ""
 	if prompt != "" {
 		arg = " " + winQuote(prompt)
 	}
-	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude --resume %s%s & pause`,
-		dispatcherID, winQuote(sessionID), arg)
+	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude%s --resume %s%s & pause`,
+		dispatcherID, modeArgs(mode), winQuote(sessionID), arg)
+}
+
+// modeArgs is the permission-mode flag as a leading-space-prefixed fragment,
+// or "" when this claude has no spelling for the mode. The flag's values are
+// plain words, so they need no cmd.exe quoting.
+func modeArgs(mode Mode) string {
+	args := PermissionArgs(mode)
+	if len(args) == 0 {
+		return ""
+	}
+	return " " + strings.Join(args, " ")
 }
 
 // winQuote wraps a string in double quotes for cmd.exe, doubling any embedded

--- a/internal/dispatch/mode.go
+++ b/internal/dispatch/mode.go
@@ -1,0 +1,225 @@
+package dispatch
+
+// mode.go is the permission mode a dispatcher's claude session opens in.
+//
+// The dispatch form has always asked this question — it was the AUTO switch —
+// and the answer had nowhere to go. The launch command was `claude <prompt>`
+// with no flags, so AUTO was a sentence in the prompt and nothing more: the
+// session opened in whatever mode the human's own Claude Code defaults to, and
+// an "unattended" dispatcher stopped on its first permission prompt with nobody
+// watching it. The switch described a session it did not configure.
+//
+// The mode is now a launch flag (`--permission-mode`), recorded on the dispatch
+// so a resumed session comes back the way it went out. The prompt sentence
+// stays, because the two govern different things: the flag decides what claude
+// may do without asking, the sentence decides how far it takes the work
+// (commit, PR, fix CI). Neither substitutes for the other.
+
+import (
+	"os/exec"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Mode is how much a dispatcher may do without asking.
+type Mode string
+
+const (
+	// ModeAuto is unattended: claude takes the edits and the safe commands
+	// itself. It is the default because a dispatcher is by definition work sent
+	// somewhere else to happen, with nobody sitting on the permission prompt.
+	ModeAuto Mode = "auto"
+	// ModeManual asks before each tool call — the human drives, from the
+	// session's own terminal.
+	ModeManual Mode = "manual"
+	// ModePlan opens in plan mode: it reads and proposes, and changes nothing
+	// until the plan is accepted.
+	ModePlan Mode = "plan"
+)
+
+// DefaultMode is what a dispatch runs in when nothing chose one.
+const DefaultMode = ModeAuto
+
+// Modes is the offer order, and the order the form's switch cycles in: the
+// unattended default first, then the two that hand control back.
+func Modes() []Mode { return []Mode{ModeAuto, ModeManual, ModePlan} }
+
+// Normalize resolves what to launch with. An empty or unrecognised mode
+// becomes DefaultMode — a launch has to pass something, and the default is
+// what the form would have offered.
+//
+// This is a launch-time answer, not a display one: a record written before the
+// mode existed carries "", and the sessions behind those records ran in
+// whatever claude defaulted to. Screens read that "" as unknown rather than
+// calling it auto, because a record that never chose did not choose auto.
+func (m Mode) Normalize() Mode {
+	for _, k := range Modes() {
+		if m == k {
+			return m
+		}
+	}
+	return DefaultMode
+}
+
+// Known reports whether m names a mode this build offers — the test for
+// whether a record actually recorded one.
+func (m Mode) Known() bool {
+	for _, k := range Modes() {
+		if m == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Hint is the one line a form shows beside the mode. It describes the
+// permission behaviour only — no keys, because the two forms that show it bind
+// different ones, and what the dispatcher is told to do with the work is the
+// prompt's half of the answer and is worded there.
+func (m Mode) Hint() string {
+	switch m.Normalize() {
+	case ModeManual:
+		return "asks you before each step"
+	case ModePlan:
+		return "plans first, changes nothing until you accept"
+	}
+	return "takes its own edits and safe commands"
+}
+
+// Summary is the mode as it reads on a one-line recap of the whole form.
+func (m Mode) Summary() string {
+	switch m.Normalize() {
+	case ModeManual:
+		return "asks each step"
+	case ModePlan:
+		return "plans first"
+	}
+	return "auto"
+}
+
+// Next is the mode after m in the cycle, so one key can walk all three.
+func Next(m Mode) Mode {
+	all := Modes()
+	for i, k := range all {
+		if k == m {
+			return all[(i+1)%len(all)]
+		}
+	}
+	return all[0]
+}
+
+// Prev is Next the other way, for shift+tab-style backwards cycling.
+func Prev(m Mode) Mode {
+	all := Modes()
+	for i, k := range all {
+		if k == m {
+			return all[(i+len(all)-1)%len(all)]
+		}
+	}
+	return all[0]
+}
+
+// modeAliases names each mode the way claude spells it, newest spelling first.
+//
+// Claude Code renamed its permission modes: what it now calls `auto` was
+// `acceptEdits`, and what it now calls `manual` was `default`. Passing a name a
+// given build does not know is not a degraded session — the CLI rejects the
+// argument and exits before it ever reads the prompt, so the dispatch dies at
+// launch and leaves a tmux session sitting at a shell. Naming the older
+// equivalent keeps a dispatcher on an older claude running in the mode that was
+// actually asked for.
+var modeAliases = map[Mode][]string{
+	ModeAuto:   {"auto", "acceptEdits"},
+	ModeManual: {"manual", "default"},
+	ModePlan:   {"plan"},
+}
+
+// PermissionArgs is the launch flag for m, as command-line words — empty when
+// this claude has no spelling for it.
+//
+// Empty is the honest answer for a claude too old to have `--permission-mode`
+// at all: the session then opens in that build's own default, which is exactly
+// what every dispatch did before this file existed. Guessing a flag name into a
+// CLI that will reject it would trade a mode we cannot set for a launch that
+// does not happen.
+func PermissionArgs(m Mode) []string {
+	name := permissionName(m.Normalize())
+	if name == "" {
+		return nil
+	}
+	return []string{"--permission-mode", name}
+}
+
+// permissionName is the spelling of m this machine's claude accepts, or "".
+func permissionName(m Mode) string {
+	accepted := claudeModeNames()
+	if len(accepted) == 0 {
+		return ""
+	}
+	for _, name := range modeAliases[m] {
+		if accepted[name] {
+			return name
+		}
+	}
+	return ""
+}
+
+// claudeModeNames is the set of --permission-mode values the installed claude
+// advertises, read once per process. It is a variable so tests can answer for
+// it instead of depending on whichever claude is on the test machine's PATH.
+var claudeModeNames = sync.OnceValue(readClaudeModeNames)
+
+// modeChoiceRe pulls the quoted names out of commander's `(choices: …)` tail.
+var modeChoiceRe = regexp.MustCompile(`"([A-Za-z]+)"`)
+
+// modeHelpWindow bounds how far past `--permission-mode` the choices may sit.
+// Help output wraps, so the list spans lines; a few hundred characters covers
+// the wrapped description without reaching the next option's own choices.
+const modeHelpWindow = 400
+
+// readClaudeModeNames asks claude which permission modes it takes.
+//
+// Reading the help text is the only way to ask: there is no capability
+// endpoint, and the flag's accepted values have changed between releases. A
+// help output we cannot read, or one whose choices do not include `plan` — the
+// one spelling every version that ever had this flag accepts — is reported as
+// "nothing known", and PermissionArgs then passes no flag rather than a guess.
+func readClaudeModeNames() map[string]bool {
+	out, err := exec.Command("claude", "--help").Output()
+	if err != nil {
+		return nil
+	}
+	return parseModeNames(string(out))
+}
+
+// parseModeNames pulls the accepted values out of claude's help text.
+func parseModeNames(help string) map[string]bool {
+	i := strings.Index(help, "--permission-mode")
+	if i < 0 {
+		return nil
+	}
+	rest := help[i:]
+	if len(rest) > modeHelpWindow {
+		rest = rest[:modeHelpWindow]
+	}
+	j := strings.Index(rest, "(choices:")
+	if j < 0 {
+		return nil
+	}
+	rest = rest[j:]
+	if k := strings.Index(rest, ")"); k >= 0 {
+		rest = rest[:k]
+	}
+	names := make(map[string]bool)
+	for _, m := range modeChoiceRe.FindAllStringSubmatch(rest, -1) {
+		names[m[1]] = true
+	}
+	if !names["plan"] {
+		// Not the list we were looking for — the flag's description wrapped past
+		// the window, or the format changed. Claiming these names would be
+		// claiming a launch that works.
+		return nil
+	}
+	return names
+}

--- a/internal/dispatch/mode_test.go
+++ b/internal/dispatch/mode_test.go
@@ -1,0 +1,164 @@
+package dispatch
+
+// mode_test.go covers the permission mode: what it resolves to, what it puts on
+// the command line, and what it does when the claude on this machine spells its
+// modes differently.
+
+import (
+	"strings"
+	"testing"
+)
+
+// modernHelp is the shape claude's help has today: the choices wrap across
+// lines, which is why the parser works on the whole string rather than a line.
+const modernHelp = `Usage: claude [options] [command] [prompt]
+
+Options:
+  --permission-mode <mode>              Permission mode to use for the session
+                                        (choices: "acceptEdits", "auto",
+                                        "bypassPermissions", "manual",
+                                        "dontAsk", "plan")
+  --plugin-dir <path>                   Load a plugin from a directory
+`
+
+// legacyHelp is a build from before the rename: no auto, no manual.
+const legacyHelp = `Options:
+  --permission-mode <mode>              Permission mode to use for the session
+                                        (choices: "acceptEdits", "bypassPermissions", "default", "plan")
+`
+
+// withModes answers for the installed claude so a test never depends on
+// whichever one is on the machine's PATH.
+func withModes(t *testing.T, names map[string]bool) {
+	t.Helper()
+	prev := claudeModeNames
+	claudeModeNames = func() map[string]bool { return names }
+	t.Cleanup(func() { claudeModeNames = prev })
+}
+
+func TestModeNormalizeDefaultsToAuto(t *testing.T) {
+	for _, in := range []Mode{"", "acceptEdits", "nonsense", "AUTO"} {
+		if got := in.Normalize(); got != ModeAuto {
+			t.Errorf("Mode(%q).Normalize() = %q, want auto", in, got)
+		}
+	}
+	for _, in := range Modes() {
+		if got := in.Normalize(); got != in {
+			t.Errorf("Mode(%q).Normalize() = %q, want itself", in, got)
+		}
+	}
+	// A record written before the mode existed did not choose auto — it did not
+	// choose. Screens read Known, not Normalize, so they can say so.
+	if Mode("").Known() {
+		t.Error("an unset mode must not report as a mode that was chosen")
+	}
+}
+
+// The whole point of the field: what the human picked reaches the command line.
+func TestPermissionArgsNamesTheChosenMode(t *testing.T) {
+	withModes(t, parseModeNames(modernHelp))
+	for _, m := range Modes() {
+		args := PermissionArgs(m)
+		if len(args) != 2 || args[0] != "--permission-mode" || args[1] != string(m) {
+			t.Errorf("PermissionArgs(%q) = %v", m, args)
+		}
+	}
+}
+
+// An older claude spells two of the three differently. Passing today's name to
+// it is not a degraded session: the CLI rejects the argument and exits before
+// it reads the prompt, so the dispatch dies at launch.
+func TestPermissionArgsFallsBackToTheOlderSpelling(t *testing.T) {
+	withModes(t, parseModeNames(legacyHelp))
+	want := map[Mode]string{ModeAuto: "acceptEdits", ModeManual: "default", ModePlan: "plan"}
+	for m, spelling := range want {
+		args := PermissionArgs(m)
+		if len(args) != 2 || args[1] != spelling {
+			t.Errorf("PermissionArgs(%q) = %v, want the %q spelling", m, args, spelling)
+		}
+	}
+}
+
+// A claude with no --permission-mode at all, or a help output we cannot read,
+// gets no flag: the session opens in that build's own default, which is what
+// every dispatch did before the mode was plumbed. A guessed flag name would
+// trade a mode we cannot set for a launch that does not happen.
+func TestPermissionArgsSaysNothingWhenItCannotTell(t *testing.T) {
+	for _, help := range []string{
+		"Usage: claude [options]\n  --model <model>  the model\n",             // no such flag
+		"  --permission-mode <mode>   Permission mode to use for the session", // no choices
+		`  --permission-mode <mode>  (choices: "wibble", "wobble")`,           // not a list we recognise
+	} {
+		withModes(t, parseModeNames(help))
+		if args := PermissionArgs(ModeAuto); args != nil {
+			t.Errorf("help %q yielded %v, want no flag", help, args)
+		}
+	}
+}
+
+// The launch and resume commands carry the flag, and carry the same one: a
+// resumed dispatcher that came back in a different mode than it went out in
+// would be a permission change nobody asked for.
+func TestLaunchAndResumeCarryTheMode(t *testing.T) {
+	withModes(t, parseModeNames(modernHelp))
+
+	launch := launchCommand("abc123", "do the thing", ModePlan)
+	if !strings.Contains(launch, "--permission-mode plan") {
+		t.Errorf("launch command has no mode flag:\n%s", launch)
+	}
+	if !strings.Contains(launch, "do the thing") {
+		t.Errorf("launch command lost the prompt:\n%s", launch)
+	}
+
+	resume := resumeCommand("abc123", "sess-1", "", ModePlan)
+	if !strings.Contains(resume, "--permission-mode plan") {
+		t.Errorf("resume command has no mode flag:\n%s", resume)
+	}
+	if !strings.Contains(resume, "--resume") {
+		t.Errorf("resume command lost --resume:\n%s", resume)
+	}
+
+	// And with nothing to pass, the command is exactly what it always was — no
+	// stray spaces where the flag would have gone.
+	withModes(t, nil)
+	if got := launchCommand("abc123", "go", ModeAuto); strings.Contains(got, "claude  ") {
+		t.Errorf("a missing flag left a double space:\n%s", got)
+	}
+}
+
+func TestModeCyclesBothWays(t *testing.T) {
+	all := Modes()
+	m := all[0]
+	for range all {
+		m = Next(m)
+	}
+	if m != all[0] {
+		t.Errorf("cycling through every mode landed on %q, want %q", m, all[0])
+	}
+	if got := Prev(all[0]); got != all[len(all)-1] {
+		t.Errorf("Prev(%q) = %q, want the last mode", all[0], got)
+	}
+	// An unset mode has to go somewhere on the first keypress rather than
+	// staying unset, or the switch reads as broken.
+	if got := Next(""); got != all[0] {
+		t.Errorf("Next(\"\") = %q, want %q", got, all[0])
+	}
+}
+
+// Each mode says something different about itself, and none of it names a key:
+// the two forms that show these bind different ones.
+func TestModeHintsAreDistinctAndKeyless(t *testing.T) {
+	seen := map[string]bool{}
+	for _, m := range Modes() {
+		h := m.Hint()
+		if h == "" || seen[h] {
+			t.Errorf("Mode(%q).Hint() = %q — empty or a repeat", m, h)
+		}
+		seen[h] = true
+		for _, key := range []string{"space", "enter", "tab"} {
+			if strings.Contains(h, key) {
+				t.Errorf("Mode(%q).Hint() names the %q key: %q", m, key, h)
+			}
+		}
+	}
+}

--- a/internal/dispatch/resume.go
+++ b/internal/dispatch/resume.go
@@ -118,8 +118,13 @@ func Resume(d *state.Dispatch, prompt string) (ResumeMode, string, error) {
 	if base == "disp-" {
 		base = "disp-" + d.ID
 	}
+	// The mode it was dispatched in, so reopening a dispatcher does not quietly
+	// change what it may do without asking. A record from before the mode was a
+	// choice normalises to the default rather than inheriting nothing: --resume
+	// still has to be given some mode, and the default is the one the form
+	// would offer.
 	name := uniqueName(base)
-	if err := newSession(name, dir, resumeCommand(d.ID, sid, prompt)); err != nil {
+	if err := newSession(name, dir, resumeCommand(d.ID, sid, prompt, Mode(d.Mode))); err != nil {
 		return "", "", err
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -64,8 +64,16 @@ type Dispatch struct {
 	// under WorktreesDir); the claude session runs there so concurrent
 	// dispatches never fight over the repo's working copy. RepoPath stays the
 	// main repo — refs, PRs, and commit provenance are read from there.
-	WorktreePath   string `json:"worktree_path,omitempty"`
-	Prompt         string `json:"prompt"`
+	WorktreePath string `json:"worktree_path,omitempty"`
+	Prompt       string `json:"prompt"`
+	// Mode is the permission mode the session was dispatched in — one of
+	// dispatch.Mode's values. It is on the record because a resumed session has
+	// to reopen the way it went out and the transcript does not carry it, and
+	// because every screen that says a dispatcher is unattended should be
+	// reading the mode it was actually launched with. Empty on records written
+	// before the mode was a choice: those ran in whatever claude defaulted to,
+	// which is not the same fact as "auto".
+	Mode           string `json:"mode,omitempty"`
 	TmuxSession    string `json:"tmux_session"`
 	SessionID      string `json:"session_id,omitempty"`
 	TranscriptPath string `json:"transcript_path,omitempty"`

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -39,6 +39,32 @@ func TestSaveLoadAllSortsByUrgency(t *testing.T) {
 	}
 }
 
+// The permission mode has to survive the round trip, and an unset one has to
+// stay unset. Resume reads Mode off the record to reopen a dispatcher the way
+// it went out; a dropped field would silently bring a manual or plan
+// dispatcher back in auto, which is a permission change nobody asked for. A
+// record from before the mode was a choice carries none, and inventing one
+// here would be claiming a session ran in a mode nobody picked.
+func TestSaveLoadKeepsTheMode(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	if err := Save(&Dispatch{ID: "m", Feature: "planned", Mode: "plan", Status: StatusWorking}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(&Dispatch{ID: "o", Feature: "older", Status: StatusWorking}); err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]string{}
+	for _, d := range LoadAll() {
+		got[d.ID] = d.Mode
+	}
+	if got["m"] != "plan" {
+		t.Errorf("mode did not survive the round trip: %q", got["m"])
+	}
+	if got["o"] != "" {
+		t.Errorf("a record that never chose a mode came back as %q", got["o"])
+	}
+}
+
 func TestSaveStampsUpdatedAt(t *testing.T) {
 	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
 	d := &Dispatch{ID: "x", Status: StatusWorking}


### PR DESCRIPTION
## What was wrong

The dispatch form's `AUTO` switch had nothing behind it. `dispatch.launchCommand` built `claude <prompt>` with no flags, so whichever way AUTO was set, the session opened in whatever the human's own Claude Code defaults to. The code said so out loud:

```go
// Two of the five are honest about their reach. There is no permission plumbing
// behind AUTO ...
```

The practical failure: an "unattended" dispatcher stopped on its first permission prompt, in a tmux session nobody was watching.

## What it does now

`MODE` — three positions, launched as Claude Code's own `--permission-mode`:

| | |
|---|---|
| `auto` (default) | takes its own edits and safe commands |
| `manual` | asks you before each step |
| `plan` | plans first, changes nothing until you accept |

`plan` is the reason this could not have been a wider prompt sentence: plan mode is not something a session can be asked into.

Auto stays the default. A dispatcher is by definition work sent somewhere else to happen, with nobody sitting on its permission prompt.

```
MODE         ▸auto   manual   plan  takes its own edits and safe commands · space cycles
             shop-api · feature/auto-mode · auto
```

Both dispatch forms ask: the triage lens's `dx` form (`space`/`←`/`→` on the MODE line) and the `+` overlay (a step of its own — repo → feature → mode → prompt). The paths that ask no questions at all — a backlog ticket's `enter`, the bulk `ctrl+d`, a re-dispatch from the product panel — take the default explicitly.

## Details worth reviewing

- **It is on the record and passed again on `Resume`.** A reopened dispatcher comes back the way it went out; the transcript does not carry the mode. The triage detail panel names it too — that line's comment used to list `"· auto"` among the things it must never claim, *precisely because nothing persisted it*. Records written before this still carry none, and still say nothing rather than the default.
- **The prompt sentence stays alongside the flag.** They govern different things: the flag says what claude may do without asking, the sentence says how far to take the work. "May edit without asking" is not "commit, push and open the PR" — a session given the first and not the second stops with the work uncommitted, which is the unattended dispatch that never shipped. Plan mode gets its own sentence rather than being told to commit as it goes.
- **Older claude builds get the older spelling.** `auto` was `acceptEdits` and `manual` was `default`. Passing a name a build does not know is not a degraded session: the CLI rejects the argument and exits *before* it reads the prompt, so the dispatch dies at launch with a tmux session sitting at a shell. The accepted names are read once from `claude --help`; a claude with no such flag, or help we cannot parse, gets no flag at all — which is exactly what every dispatch did before this PR.
- **The armed position is marked with a caret, not colour alone.** The three words read identically without colour, unlike the `on`/`off` they replace, so a monochrome terminal had no way to tell which was selected.

## Verification

`make build`, `go vet ./...`, full `go test ./...` green; cross-compiles for windows and linux. Checked against the installed claude (2.1.220):

```
launch: CLAUDE_DISPATCHER_ID=abc claude --permission-mode auto 'do it'; exec ${SHELL:-/bin/sh}
resume: CLAUDE_DISPATCHER_ID=abc claude --permission-mode plan --resume 'sess'; exec ${SHELL:-/bin/sh}
```

and confirmed the CLI's behaviour the fallback exists for — `claude --permission-mode wibble` errors out rather than degrading.