### PR TITLE
Park an ask you cannot answer right now

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,22 @@
   inventing records is worse than an empty pane. It shipped reading only
   `doc/adr/`, which no repo in the fleet keeps, so the lens was empty for
   every repo while decisions sat in plain sight one file away.
+- **Parking is an annotation, never a status.** A session reaches a point
+  where it asks something the human cannot answer right now; `p` on that queue
+  row shelves it under a required, human-typed reason
+  (`ParkedReason`/`ParkedAt` on the record) and it drops to a *parked* group
+  at the bottom of the fleet — its own divider, its own rank between running
+  and history, out of the "want you" counts. It is not a `Status` because
+  status belongs to the hooks: a parked status would be flipped back by the
+  next lifecycle event, or need a guard everywhere one is applied. The shelf
+  therefore survives everything the machine does — including a reboot killing
+  tmux; a parked row whose session died offers resume instead of attach — and
+  clears on exactly three human acts: `p` again (unpark), a kill (`x` is
+  abandonment, not shelving), and a prompt reaching the session
+  (`UserPromptSubmit` in hookcmd), because someone just answered the question
+  it was parked on. Shipping retires it like any other row: "live" outranks
+  the shelf. Parked rows sit out the `s`-rotation ordering so they can never
+  be dragged above the live table.
 - Features are named at dispatch time (hybrid model): the name is the key;
   branch `feature/<slug>`, commits, and PRs enrich it automatically. Every
   dispatch works on a feature branch, even in repos that ship from main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,9 @@
   (`UserPromptSubmit` in hookcmd), because someone just answered the question
   it was parked on. Shipping retires it like any other row: "live" outranks
   the shelf. Parked rows sit out the `s`-rotation ordering so they can never
-  be dragged above the live table.
+  be dragged above the live table. The full record is
+  `docs/adr/0001-parking-is-an-annotation-never-a-status.md` — this repo's
+  first ADR, in the folder the DECISIONS lens reads.
 - Features are named at dispatch time (hybrid model): the name is the key;
   branch `feature/<slug>`, commits, and PRs enrich it automatically. Every
   dispatch works on a feature branch, even in repos that ship from main

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Every act the table offers is wired to the live session — the key hints show o
 - **`enter`** attach the tmux session at full fidelity (`Ctrl-\` to come back). Coming back **rechecks** rather than redraws: you have just spent minutes driving that session by hand, so the forge is read again instead of replayed from cache, and any session that died without getting a `SessionEnd` out stops being reported as working
 - **`y`** on a PR waiting to merge: `gh pr merge --squash --auto`, then mark live. Elsewhere it marks the record shipped, and it is hidden entirely when the dispatcher has produced no commits
 - **`x`** kill the session · **`s`** skip to the back of the table · **`ctrl+z`** undo
+- **`p`** park an ask you cannot answer right now — say why, and it drops to a **parked** group at the bottom of the fleet, out of the counts, with your reason on the row. `p` again brings it back, and so does answering it: the shelf clears itself the moment a prompt reaches the session. It survives reboots — a parked dispatcher whose session died resumes from its own row
 - **`d`** open the prompt · **`f`** filter the table · **`enter` on a backlog ticket** dispatches it
 - **`h`** the finished dispatchers, and **`enter`** on one resumes its session — `claude --resume` on the same transcript, in the same worktree, so it comes back knowing what it already did
 
@@ -254,6 +255,7 @@ Anything unmapped is grouped under `unassigned`, which is what a fresh install s
 | `h` | history — every dispatcher whose session is over; `enter` resumes one |
 | `enter` | attach the selected dispatcher's tmux session · open what is selected |
 | `y` · `x` · `s` | ship (squash-merge) · kill · skip to the back |
+| `p` | park an ask with a reason · on a parked row, take it back up |
 | `d` · `ctrl+z` | dispatch · put back the last thing you cleared |
 | `,` · `:` · `?` | settings · command palette · all keys |
 | `U` | upgrade to the published build and come straight back |

--- a/docs/adr/0001-parking-is-an-annotation-never-a-status.md
+++ b/docs/adr/0001-parking-is-an-annotation-never-a-status.md
@@ -1,0 +1,65 @@
+# Parking is an annotation, never a status
+
+## Status
+
+Accepted (2026-08-17)
+
+## Context
+
+A session sometimes stops on a question the human has no answer for yet — legal
+has not come back, the API key is not issued, a design call has not been made.
+Until parking existed that ask sat in triage's "want you" counts indefinitely,
+indistinguishable from asks that could actually be answered. The fix has to
+move such a dispatcher to a *parked* group at the bottom of the fleet, under a
+human-typed reason, until the human takes it back up.
+
+The obvious implementation was a new `Status: parked`. But status truth in this
+product belongs to the lifecycle hooks (`internal/hookcmd`): every event a
+session emits — a Stop, an idle prompt, a permission prompt, a session ending —
+writes the status it proves. A parked *status* would be flipped back by the
+very next event, or need a guard at every one of the half-dozen sites a status
+is applied (hookcmd, reconcile, track, resume, the cockpit's own kill and
+mark-done). And a shelf that a lifecycle event can empty is not a shelf: the
+whole point is that the human's "later" outlives whatever the machine does in
+the meantime — including the machine rebooting and taking tmux, and every
+parked session, down with it.
+
+## Decision
+
+Parking is a pair of fields on the dispatch record — `ParkedReason` (the
+human's required, typed reason) and `ParkedAt` — orthogonal to `Status`. The
+hooks keep reporting machine truth underneath; the fleet groups on the
+annotation. A parked record lands in the parked group whatever its status says,
+with one exception: "live" outranks the shelf, because shipped work has nothing
+left to come back to.
+
+The shelf clears only on the acts that genuinely end it:
+
+- `p` on the parked row — unpark; the row rejoins the live table at whatever
+  rank its real status earns.
+- `x` — a kill is abandonment, not shelving; the record must not haunt a group
+  whose claim is "you will come back to this".
+- A prompt reaching the session (`UserPromptSubmit` in hookcmd) — someone just
+  answered the question it was parked on. No other lifecycle event touches the
+  pair.
+- Shipping — a done record goes to history like any other.
+
+In the fleet, parked is its own row kind at its own rank, between running and
+history, under the table's one divider line, with the reason in the SIGNAL
+cell. Parked rows are excluded from the "want you" / "need a look" counts and
+sit out the `s`-rotation ordering, so an id skipped while it was a queue row
+can never drag its parked self back above the live table. Only queue rows can
+be parked: parking answers "it asked me something I cannot answer right now",
+and a running dispatcher has not asked anything.
+
+## Consequences
+
+The status machine is untouched — no new status, no guards, no new hookcmd
+transitions beyond the one deliberate clear on `UserPromptSubmit`. The shelf
+survives reboots: a parked row whose session died offers resume instead of
+attach, by the same mechanics history rows use. The reason is mandatory at the
+input — a shelf of unexplained rows would just be a second history. The cost of
+the orthogonal pair is that every screen deciding "is this row live" from
+status alone will show a parked dispatcher as its underlying status (the
+products lens counts it as out, collisions still name it), which is accepted:
+those screens report machine truth, and the shelf is a triage-lens concept.

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -78,9 +78,15 @@ func killCmd(features []string) tea.Cmd {
 				continue
 			}
 			_ = supervisor.KillSession(rec.TmuxSession)
-			if rec.Status != state.StatusDone {
-				rec.Status = state.StatusExited
-				rec.StatusReason = "killed from cockpit"
+			if rec.Parked() || rec.Status != state.StatusDone {
+				// A kill is abandonment, not shelving: clear the park so the
+				// record cannot haunt the parked group, whose whole claim is
+				// "you will come back to this".
+				rec.ParkedReason, rec.ParkedAt = "", nil
+				if rec.Status != state.StatusDone {
+					rec.Status = state.StatusExited
+					rec.StatusReason = "killed from cockpit"
+				}
 				_ = state.Save(rec)
 			}
 			if rec.WorktreePath != "" && !dispatchpkg.CleanupWorktree(rec.RepoPath, rec.WorktreePath) {

--- a/internal/cockpit/cq.go
+++ b/internal/cockpit/cq.go
@@ -280,6 +280,27 @@ func cqActs(rec *state.Dispatch, kind string) []cqAct {
 		}
 		return acts
 	}
+	// A parked dispatcher's session may be long gone — a reboot takes tmux
+	// with it and the shelf survives — so ⏎ resumes when the record says
+	// exited and attaches otherwise; cqRun tells the two apart by the act's
+	// own verb. p takes it back up. Unparking is not undo: it puts the ask
+	// back on the live table, where the collector re-ranks it like any other.
+	if kind == "parked" {
+		acts := []cqAct{}
+		if rec.Status == state.StatusExited {
+			acts = append(acts,
+				cqAct{k: "⏎", d: "resume", ok: "resuming \"" + rec.Feature + "\"…", keep: true})
+		} else {
+			acts = append(acts,
+				cqAct{k: "⏎", d: "attach", ok: "attaching to " + rec.RepoName + " session…", keep: true})
+		}
+		acts = append(acts, cqAct{k: "p", d: "unpark",
+			ok: "\"" + rec.Feature + "\" back on the fleet", keep: true})
+		if rec.Status != state.StatusExited {
+			acts = append(acts, cqAct{k: "x", d: "kill", ok: "killed \"" + rec.Feature + "\""})
+		}
+		return acts
+	}
 	acts := []cqAct{
 		{k: "⏎", d: "attach", ok: "attaching to " + rec.RepoName + " session…", keep: true},
 	}
@@ -305,6 +326,11 @@ func cqActs(rec *state.Dispatch, kind string) []cqAct {
 	}
 	acts = append(acts,
 		cqAct{k: "x", d: "kill", ok: "killed \"" + rec.Feature + "\""},
+		// Park and skip carry no ok on purpose: neither is an act that has
+		// happened by the time the key lands. Skip is table rotation; park
+		// opens the reason input, and nothing is parked until the reason is
+		// entered — both are handled by the key machine, not cqRun.
+		cqAct{k: "p", d: "park"},
 		cqAct{k: "s", d: "skip"})
 	return acts
 }

--- a/internal/cockpit/cq_keys.go
+++ b/internal/cockpit/cq_keys.go
@@ -135,11 +135,18 @@ func (m model) cqRun(r fleetRow, a cqAct) (model, tea.Cmd) {
 	case "⏎":
 		// On a history row ⏎ means resume: there is no live session to attach
 		// to, and the record is addressed by id because a feature name can
-		// belong to several finished dispatchers.
-		if r.kind == "past" {
+		// belong to several finished dispatchers. A parked row can be either —
+		// its session survives a park but not a reboot — and cqActs already
+		// decided which from the record, so the act's own verb is the answer.
+		if r.kind == "past" || (r.kind == "parked" && a.d == "resume") {
 			return m, resumeCmd(r.id, "")
 		}
 		return m.attach(r.feature)
+	case "p":
+		// Only the parked row's unpark reaches here: the queue rows' park act
+		// carries no ok, so the act loop never fires it — updateFloorQueue
+		// opens the reason input instead.
+		return m, unparkCmd(r.id)
 	case "o":
 		return m, openPRCmd(r.repo, r.ref)
 	case "y":
@@ -280,6 +287,16 @@ func (m model) updateFloorQueue(k string) (model, tea.Cmd, bool) {
 	}
 
 	if r, ok := m.fleetSel(); ok {
+		// Park wants a reason before anything is written, so the key opens the
+		// input rather than firing a command — a flash is a promise the act
+		// already ran, and nothing has yet. Only a queue row can be parked:
+		// parking answers "it asked me something I cannot answer right now",
+		// and a running dispatcher has not asked anything.
+		if k == "p" && r.kind == "queue" {
+			m.parkOpen, m.parkText = true, ""
+			m.parkAt = &parkTarget{id: r.id, feature: r.feature}
+			return m, nil, true
+		}
 		// Skip sends a row to the back so the next thing comes up under the
 		// cursor; it is queue rotation, not work. A running dispatcher is not
 		// asking for anything, so there is nothing to skip past.

--- a/internal/cockpit/fleet.go
+++ b/internal/cockpit/fleet.go
@@ -212,10 +212,8 @@ func collectFleet(ctx *collectCtx, s *snapshot) {
 // be: it needs a check result sampled twice over time, and gh.Checks is a point
 // sample. See cqShipDetail.
 //
-// Rank 4 is parked                        ‖  the human shelved it, with a
-//                                            reason — it shares the table,
-//                                            below everything that is live,
-//                                            under its own divider line
+// Rank 4 is parked (glyph ‖): the human shelved it, with a reason. It shares
+// the table — below everything that is live, under its own divider line.
 //
 // Rank 5 is history. It is below every live row and never shares a table with
 // one, so it needs no glyph or colour of its own: both fall through to the

--- a/internal/cockpit/fleet.go
+++ b/internal/cockpit/fleet.go
@@ -46,9 +46,10 @@ type fleetRow struct {
 	// has to survive the rebuild.
 	id string
 	// kind is "queue" — it is waiting on you — "run", it is getting on with it,
-	// or "past", its session is over. rank orders the table and picks the glyph;
-	// see fleetRank. Past rows are not part of the in-flight table at all: they
-	// are what `h` and the history filter show, and what resume acts on.
+	// "parked", the human shelved it with a reason, or "past", its session is
+	// over. rank orders the table and picks the glyph; see fleetRank. Past rows
+	// are not part of the in-flight table at all: they are what `h` and the
+	// history filter show, and what resume acts on.
 	kind string
 	rank int
 	// ask classifies what a queue row wants: permission | review | turn-done |
@@ -121,6 +122,9 @@ type fleetRow struct {
 	// waited is the record's UpdatedAt, kept as the queue rows' tie-break sort
 	// key so the ask that has waited longest surfaces first.
 	waited time.Time
+	// parked is when the human shelved it — the parked group's sort key, zero
+	// on every other kind.
+	parked time.Time
 }
 
 // ---- collector ------------------------------------------------------------------
@@ -149,7 +153,17 @@ func collectFleet(ctx *collectCtx, s *snapshot) {
 	var lastOut time.Time // freshest transcript write across everything running
 
 	for _, rec := range ctx.records {
-		switch floorState(rec) {
+		st := floorState(rec)
+		// A parked record is on the human's shelf whatever its machine status
+		// says — waiting, still working, or a session the reboot took (the
+		// shelf must survive a dead tmux, or a machine restart silently empties
+		// it). Only shipping moves it on: "live" means the work is done, and
+		// the shelf entry with it.
+		if rec.Parked() && st != "live" {
+			rows = append(rows, fleetParkedRow(ctx, s, passes, rec))
+			continue
+		}
+		switch st {
 		// "review" belongs in the table's top half, not outside it: a finished
 		// turn with a green unreviewed PR is the single most actionable thing the
 		// cockpit can show. Omitting it made those dispatchers vanish from triage
@@ -198,12 +212,20 @@ func collectFleet(ctx *collectCtx, s *snapshot) {
 // be: it needs a check result sampled twice over time, and gh.Checks is a point
 // sample. See cqShipDetail.
 //
-// Rank 4 is history. It is below every live row and never shares a table with
+// Rank 4 is parked                        ‖  the human shelved it, with a
+//                                            reason — it shares the table,
+//                                            below everything that is live,
+//                                            under its own divider line
+//
+// Rank 5 is history. It is below every live row and never shares a table with
 // one, so it needs no glyph or colour of its own: both fall through to the
 // rank-3 defaults, and the SIGNAL cell says how the session ended.
 func fleetRank(kind, tone string, stalled bool) int {
 	if kind == "past" {
 		return fleetPastRank
+	}
+	if kind == "parked" {
+		return fleetParkedRank
 	}
 	if kind == "queue" {
 		if tone == "red" {
@@ -238,6 +260,14 @@ func fleetSort(rows []fleetRow) {
 			// newest sits at the top.
 			if !a.moved.Equal(b.moved) {
 				return a.moved.After(b.moved)
+			}
+			return a.id < b.id
+		}
+		if a.kind == "parked" {
+			// The shelf reads like history: the thing most recently put down
+			// is the one most likely to be picked back up.
+			if !a.parked.Equal(b.parked) {
+				return a.parked.After(b.parked)
 			}
 			return a.id < b.id
 		}
@@ -405,8 +435,57 @@ func fleetRunRow(ctx *collectCtx, s *snapshot, floorBy map[string]dispatch,
 	}, mt
 }
 
+// fleetParkedRank is where the human's shelf sits: below everything asking or
+// running — parking exists to get an ask you cannot answer out of the live
+// table's way — and above history, because a parked dispatcher is not over.
+const fleetParkedRank = 4
+
 // fleetPastRank is where history sits: below everything alive.
-const fleetPastRank = 4
+const fleetPastRank = 5
+
+// fleetParkedRow builds a row for a dispatcher the human has shelved.
+//
+// It is deliberately as cheap as a past row — no gh request, no transcript
+// tail — because a shelf is somewhere things sit for days. The SIGNAL cell
+// carries the one fact the group exists for: the reason the human typed when
+// they parked it. The record's own status keeps moving underneath (the session
+// may still be working, or may have died with the machine); the acts read it,
+// the grouping does not.
+func fleetParkedRow(ctx *collectCtx, s *snapshot, passes map[string]int, rec *state.Dispatch) fleetRow {
+	goal, goalLabel := cqGoal(rec)
+	est, codedKnown := s.effortBy[rec.Feature]
+	signal := "parked"
+	if rec.ParkedReason != "" {
+		signal += " · " + rec.ParkedReason
+	}
+	var at time.Time
+	if rec.ParkedAt != nil {
+		at = *rec.ParkedAt
+	}
+	return fleetRow{
+		id:         rec.ID,
+		kind:       "parked",
+		rank:       fleetRank("parked", "normal", false),
+		product:    ctx.productFor(rec),
+		feature:    rec.Feature,
+		repo:       rec.RepoName,
+		ref:        cqRef(ctx.forge(rec.RepoPath), rec),
+		pass:       passes[rec.ID],
+		signal:     signal,
+		tone:       "normal",
+		why:        cqSentence(rec.ParkedReason),
+		goal:       goal,
+		goalLabel:  goalLabel,
+		coded:      est.Dur,
+		codedKnown: codedKnown,
+		mode:       rec.Mode,
+		acts:       cqActs(rec, "parked"),
+		parked:     at,
+		moved:      fleetMoved(rec),
+		started:    rec.CreatedAt,
+		waited:     rec.UpdatedAt,
+	}
+}
 
 // fleetPastRow builds a row for a dispatcher whose session is over.
 //
@@ -557,7 +636,11 @@ func (m model) fleetAll() []fleetRow {
 	out := make([]fleetRow, 0, len(fleet))
 	placed := make(map[string]bool, len(fleet))
 	for _, id := range m.cqOrder {
-		if r, ok := byID[id]; ok && !placed[id] && !m.cqSuppressed[id] {
+		// Parked rows sit out the user's ordering: the shelf is always below
+		// the live table, and an id `s` ordered while it was still a queue row
+		// must not drag its parked self back to the top. They fall through to
+		// the collector segment, whose rank sort keeps them last.
+		if r, ok := byID[id]; ok && r.kind != "parked" && !placed[id] && !m.cqSuppressed[id] {
 			out = append(out, r)
 			placed[id] = true
 		}
@@ -622,21 +705,26 @@ func (m model) fleetSel() (fleetRow, bool) {
 	return rows[clampCursor(m.fleetCursor, len(rows))], true
 }
 
-// fleetCount tallies the three headline numbers over the rows on screen: what
-// wants you, what is drifting, and what is simply running. They count the
-// FILTERED set on purpose — the line sits above the table and describes it.
-func fleetCount(rows []fleetRow) (wants, warn, clean int) {
+// fleetCount tallies the headline numbers over the rows on screen: what wants
+// you, what is drifting, what the human shelved, and what is simply running.
+// They count the FILTERED set on purpose — the line sits above the table and
+// describes it. Parked is its own tally because it is neither of the others:
+// it does want you (later), and calling it "running clean" would hide the
+// shelf inside the healthiest number on the line.
+func fleetCount(rows []fleetRow) (wants, warn, parked, clean int) {
 	for _, r := range rows {
 		switch {
 		case r.kind == "queue":
 			wants++
+		case r.kind == "parked":
+			parked++
 		case r.rank == 2:
 			warn++
 		default:
 			clean++
 		}
 	}
-	return wants, warn, clean
+	return wants, warn, parked, clean
 }
 
 // fleetRunning is how many dispatchers are getting on with it, across the whole

--- a/internal/cockpit/fleet_view.go
+++ b/internal/cockpit/fleet_view.go
@@ -196,6 +196,9 @@ func fleetGlyph(rank int) string {
 		return "○"
 	case 2:
 		return "◆"
+	case fleetParkedRank:
+		// The pause bars: shelved by the human, waiting for later.
+		return "‖"
 	}
 	return "·"
 }
@@ -277,7 +280,7 @@ func (m model) fleetHeadline(inner int, rows []fleetRow) string {
 	if f == fleetHistory {
 		return m.fleetHistoryHeadline(inner, rows)
 	}
-	wants, warn, clean := fleetCount(rows)
+	wants, warn, parked, clean := fleetCount(rows)
 
 	title, right := itoa(len(rows))+" in flight", "f filters · h history · sorted by urgency"
 	if f != fleetFilters[0] {
@@ -297,6 +300,11 @@ func (m model) fleetHeadline(inner int, rows []fleetRow) string {
 		fg(blockHex, itoa(wants)+" want you") + "   " +
 		fg(warnHex, itoa(warn)+" need a look") + "   " +
 		fg(cFaint, itoa(clean)+" running clean")
+	// The shelf only earns a clause when something is on it: "0 parked" would
+	// advertise a group the table is not showing.
+	if parked > 0 {
+		left += "   " + fg(cFaint, itoa(parked)+" parked")
+	}
 	// Appended only when the whole cell fits. flSpread's overflow answer is to
 	// truncate the left side, which would leave "≈10h t…" hanging off the end of
 	// a narrow terminal — a clause half-said is worse than one not said, and it
@@ -533,6 +541,13 @@ func (m model) viewFleet(w, h int) string {
 // There is no "↑ N more" / "↓ N more" sacrificial row: window() keeps the
 // cursor on screen and j/k move the cursor rather than a scroll offset, so no
 // row is unreachable and none of the height needs spending to say so.
+//
+// The parked group gets the one header the table has: a divider line naming
+// the shelf, drawn above the first parked row. It is a display line, never a
+// row — the cursor cannot land on it — so the window is computed over lines
+// and the selection mapped across the divider. fleetSort and fleetAll keep the
+// parked rows contiguous at the bottom, which is what lets one divider be the
+// whole boundary.
 func fleetBody(w int, cols fleetCols, rows []fleetRow, sel, h int, empty string) []string {
 	if h <= 0 {
 		return nil
@@ -544,14 +559,46 @@ func fleetBody(w int, cols fleetCols, rows []fleetRow, sel, h int, empty string)
 		// reading as "nothing is running".
 		out = append(out, flG(fg(cFaint, empty)))
 	}
-	start, end := window(sel, len(rows), h)
-	for i := start; i < end; i++ {
+	div := -1
+	for i, r := range rows {
+		if r.kind == "parked" {
+			div = i
+			break
+		}
+	}
+	lines, selLine := len(rows), sel
+	if div >= 0 {
+		lines++
+		if sel >= div {
+			selLine++
+		}
+	}
+	start, end := window(selLine, lines, h)
+	for ln := start; ln < end; ln++ {
+		i := ln
+		if div >= 0 {
+			if ln == div {
+				out = append(out, fleetParkedDivider(w))
+				continue
+			}
+			if ln > div {
+				i = ln - 1
+			}
+		}
 		out = append(out, fleetDataLine(w, cols, rows[i], i == sel))
 	}
 	for len(out) < h {
 		out = append(out, "")
 	}
 	return out[:h]
+}
+
+// fleetParkedDivider is the line above the parked group: the group's name, set
+// into a rule so it reads as a boundary rather than as a row.
+func fleetParkedDivider(w int) string {
+	lead, label := "── ", "parked "
+	rest := maxi(0, cqInner(w)-dispWidth(lead)-dispWidth(label))
+	return flG(fg(cRule, lead) + fg(cFaint, label) + fg(cRule, strings.Repeat("─", rest)))
 }
 
 // ---- footer -----------------------------------------------------------------
@@ -564,6 +611,9 @@ func fleetBody(w int, cols fleetCols, rows []fleetRow, sel, h int, empty string)
 // without attaching to it, so it is not advertised here, in the help sheet or
 // in the key handler.
 func (m model) cqFooterHelp() string {
+	if m.parkOpen {
+		return "type the reason · enter parks it · esc cancels"
+	}
 	if m.cqFormOn() {
 		return m.dxFooterHelp()
 	}

--- a/internal/cockpit/keys.go
+++ b/internal/cockpit/keys.go
@@ -184,6 +184,13 @@ func (m model) handleKey(k string) (tea.Model, tea.Cmd) {
 		mm, cmd := m.updateProduct(k)
 		return mm, cmd
 	}
+	// The park-reason input is text entry and owns the keyboard like the other
+	// overlays — resolved before the triage lens, which would otherwise swallow
+	// every letter as a fleet key.
+	if m.parkOpen {
+		mm, cmd := m.updatePark(k)
+		return mm, cmd
+	}
 	if m.paletteOpen {
 		switch k {
 		case "esc":

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -84,6 +84,12 @@ type model struct {
 	// resume a different dispatcher than the one the human is reading about.
 	resumeAt *resumeTarget
 
+	// The park-reason input over the triage lens. parkAt is the row it is
+	// about, captured when it opened — see parkTarget.
+	parkOpen bool
+	parkText string
+	parkAt   *parkTarget
+
 	backlogCursor int
 	picked        map[string]bool
 	srcFilter     string

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -20,6 +20,7 @@ var helpSections = []struct {
 		{"○", "waiting on you, not blocking anything else"},
 		{"◆", "green in ci and still not merged"},
 		{"·", "running clean · nothing there needs you"},
+		{"‖", "parked · you shelved it, its row keeps your reason"},
 		{"", "sorted by what needs you, not by product — the top row is next"},
 	}},
 	{section: "work the fleet", keys: []struct{ k, d string }{
@@ -30,6 +31,7 @@ var helpSections = []struct {
 		{"y", "approve the merge, or mark it shipped once it has commits"},
 		{"x", "kill it · the branch and any dirty worktree survive"},
 		{"s", "skip · send it to the back, it comes round again"},
+		{"p", "park it · say why, it waits below the fleet · p unparks"},
 		{"d", "dispatch · pick a repo, say what it does"},
 		{"ctrl+z", "put back the last thing you cleared"},
 	}},

--- a/internal/cockpit/park.go
+++ b/internal/cockpit/park.go
@@ -1,0 +1,111 @@
+package cockpit
+
+// park.go is the parking shelf's cockpit side: the reason input that opens
+// over the triage lens, and the two record writes.
+//
+// Parking is a human annotation on the record (state.Dispatch.ParkedReason /
+// ParkedAt), never a Status: the session has asked something the human cannot
+// answer right now, and that is a fact about the human, not the machine.
+// Status stays with the hooks, which keep reporting the truth underneath —
+// the shelf survives every lifecycle event except the one that dissolves it,
+// a prompt reaching the session (hookcmd clears the pair on UserPromptSubmit,
+// because someone just answered the question it was parked on).
+
+import (
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/state"
+)
+
+// parkTarget is what the park input is about. It is captured when the input
+// opens, because the input outlives the cursor that opened it: the table keeps
+// rebuilding underneath, and a target re-read from the cursor could park a
+// different dispatcher than the one the human is reading about.
+type parkTarget struct{ id, feature string }
+
+// updatePark drives the reason input while it owns the keyboard.
+//
+// The reason is the point of the feature — the parked group shows it, and a
+// shelf full of unexplained rows is just a second history — so enter with
+// nothing typed parks nothing and says why, rather than silently closing.
+func (m model) updatePark(k string) (model, tea.Cmd) {
+	next, submit, cancel := applyEdit(m.parkText, k, m.key)
+	if cancel {
+		m.parkOpen, m.parkText, m.parkAt = false, "", nil
+		return m, nil
+	}
+	if submit {
+		t := m.parkAt
+		reason := strings.Join(strings.Fields(m.parkText), " ")
+		if reason == "" {
+			m.notice = "say why — the reason is what the parked group shows"
+			return m, nil
+		}
+		m.parkOpen, m.parkText, m.parkAt = false, "", nil
+		if t == nil {
+			return m, nil
+		}
+		// The cursor stays at its position rather than following the row to
+		// the bottom of the table: parking is putting the thing down.
+		m.fleetSelID = ""
+		return m, parkCmd(t.id, reason)
+	}
+	m.parkText = next
+	return m, nil
+}
+
+// viewPark renders the reason input: what is being parked, what parking does,
+// and the one line to type.
+func (m model) viewPark(w, h int) string {
+	t := m.parkAt
+	if t == nil {
+		return ""
+	}
+	cw := w - 2*pad
+	if cw < 10 {
+		cw = w
+	}
+	var out []string
+	out = append(out, fg(cDim, "park this dispatcher"))
+	out = append(out, line(t.feature, cw, cWhite, ""))
+	explain := "it drops to the parked group at the bottom of the fleet, out of the counts, " +
+		"until you take it back up — p on its row brings it back, and so does answering it"
+	for _, ln := range productWrap(explain, cw) {
+		out = append(out, fg(cFaint, ln))
+	}
+	out = append(out, fg(cRule, strings.Repeat("─", cw)))
+	out = append(out, fg(cAmber, "why ")+fg(cWhite, m.parkText+"▏"))
+	out = append(out, fg(cFaint, "enter parks it · esc cancels"))
+	return clampLines(gutter(strings.Join(out, "\n"), pad), h)
+}
+
+// parkCmd shelves the record under the human's reason.
+func parkCmd(id, reason string) tea.Cmd {
+	return func() tea.Msg {
+		rec := recordByID(id)
+		if rec == nil {
+			return actionMsg{notice: "no dispatch record to park"}
+		}
+		now := time.Now()
+		rec.ParkedReason, rec.ParkedAt = reason, &now
+		_ = state.Save(rec)
+		return actionMsg{notice: "parked \"" + rec.Feature + "\" · " + reason}
+	}
+}
+
+// unparkCmd takes the record back up: the annotation is cleared and the next
+// snapshot re-ranks the row from its real status like any other.
+func unparkCmd(id string) tea.Cmd {
+	return func() tea.Msg {
+		rec := recordByID(id)
+		if rec == nil {
+			return actionMsg{notice: "no dispatch record to unpark"}
+		}
+		rec.ParkedReason, rec.ParkedAt = "", nil
+		_ = state.Save(rec)
+		return actionMsg{notice: "\"" + rec.Feature + "\" back on the fleet"}
+	}
+}

--- a/internal/cockpit/park_test.go
+++ b/internal/cockpit/park_test.go
@@ -1,0 +1,325 @@
+package cockpit
+
+// park_test.go covers the parking shelf: a queue row the human cannot answer
+// right now is parked under a typed reason and drops to its own group at the
+// bottom of the fleet. The tests pin the three claims the feature makes — the
+// shelf is grouped and ranked below everything live, the reason is required
+// and displayed, and the shelf survives everything except the human taking
+// the dispatcher back up.
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"claude-dispatcher/internal/state"
+)
+
+// parkedFixtureRow is a parked dispatcher on the triage table, appended to the
+// standard fleet fixture by the tests that need one.
+func parkedFixtureRow(now time.Time) fleetRow {
+	return fleetRow{
+		id: "id-parked", kind: "parked", rank: fleetParkedRank, product: "alpha",
+		feature: "five", repo: "alpha-api", ref: "feature/five",
+		signal: "parked · waiting on legal", tone: "normal",
+		why: "Waiting on legal.",
+		acts: []cqAct{
+			{k: "⏎", d: "attach", ok: "attaching to alpha-api session…", keep: true},
+			{k: "p", d: "unpark", ok: "\"five\" back on the fleet", keep: true},
+			{k: "x", d: "kill", ok: "killed \"five\""},
+		},
+		parked: now.Add(-time.Hour), moved: now.Add(-time.Hour),
+		waited: now.Add(-time.Hour), started: now.Add(-5 * time.Hour),
+	}
+}
+
+// ---- the collector ----------------------------------------------------------
+
+// A parked record lands in the parked group whatever its machine status says —
+// waiting, or a session a reboot took — and leaves it only by shipping.
+func TestCollectFleetGroupsParkedRecords(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	at := time.Now().Add(-2 * time.Hour)
+	recs := []*state.Dispatch{
+		{ID: "p-needs", Feature: "one", Status: state.StatusNeedsInput,
+			ParkedReason: "waiting on legal", ParkedAt: &at},
+		// The shelf survives the session dying: a reboot kills tmux, not the
+		// human's intent to come back.
+		{ID: "p-dead", Feature: "two", Status: state.StatusExited,
+			ParkedReason: "needs the new api key", ParkedAt: &at},
+		// "live" outranks the shelf: the work shipped, so the entry is over.
+		{ID: "p-done", Feature: "three", Status: state.StatusDone,
+			ParkedReason: "stale", ParkedAt: &at},
+		// And an unparked ask is a queue row like any other.
+		{ID: "q-plain", Feature: "four", Status: state.StatusNeedsInput},
+	}
+
+	s := &snapshot{}
+	collectFleet(&collectCtx{records: recs}, s)
+	byID := map[string]fleetRow{}
+	for _, r := range s.fleet {
+		byID[r.id] = r
+	}
+
+	for _, id := range []string{"p-needs", "p-dead"} {
+		r := byID[id]
+		if r.kind != "parked" || r.rank != fleetParkedRank {
+			t.Errorf("%s = kind %q rank %d, want a parked row at rank %d", id, r.kind, r.rank, fleetParkedRank)
+		}
+	}
+	if got := byID["p-needs"].signal; got != "parked · waiting on legal" {
+		t.Errorf("signal = %q — the reason is the one fact the group exists for", got)
+	}
+	if got := byID["p-needs"].why; got != "Waiting on legal." {
+		t.Errorf("why = %q, want the reason as the panel's lead sentence", got)
+	}
+	if r := byID["p-done"]; r.kind != "past" {
+		t.Errorf("a shipped record = kind %q, want past — done means live, shelf or no shelf", r.kind)
+	}
+	if r := byID["q-plain"]; r.kind != "queue" {
+		t.Errorf("an unparked ask = kind %q, want queue", r.kind)
+	}
+}
+
+// ---- rank and order ---------------------------------------------------------
+
+func TestParkedRankSitsBetweenRunAndHistory(t *testing.T) {
+	if got := fleetRank("parked", "normal", false); got != fleetParkedRank {
+		t.Fatalf("fleetRank(parked) = %d, want %d", got, fleetParkedRank)
+	}
+	if fleetParkedRank <= fleetRank("run", "normal", false) || fleetParkedRank >= fleetPastRank {
+		t.Error("parked must sort below every live row and above history")
+	}
+	if fleetGlyph(fleetParkedRank) != "‖" {
+		t.Error("the parked glyph does not match the help sheet's legend")
+	}
+	if fleetRankColor(fleetParkedRank) != cFaint {
+		t.Error("a shelved row must be quiet, not coloured like a demand")
+	}
+}
+
+func TestFleetSortPutsParkedAfterRunNewestFirst(t *testing.T) {
+	now := time.Now()
+	rows := []fleetRow{
+		{id: "old-park", kind: "parked", rank: fleetParkedRank, parked: now.Add(-3 * time.Hour)},
+		{id: "run", kind: "run", rank: 3, moved: now},
+		{id: "new-park", kind: "parked", rank: fleetParkedRank, parked: now.Add(-time.Minute)},
+		{id: "ask", kind: "queue", ask: "needs", rank: 1, waited: now},
+		{id: "gone", kind: "past", rank: fleetPastRank, moved: now},
+	}
+	fleetSort(rows)
+	var order []string
+	for _, r := range rows {
+		order = append(order, r.id)
+	}
+	want := "ask,run,new-park,old-park,gone"
+	if got := strings.Join(order, ","); got != want {
+		t.Errorf("order = %s, want %s", got, want)
+	}
+}
+
+// A parked id the user ordered while it was still a queue row must not drag
+// its parked self back to the top of the table.
+func TestFleetAllKeepsParkedBelowTheUserOrdering(t *testing.T) {
+	m := cqModel(t)
+	prev := fleet
+	t.Cleanup(func() { fleet = prev })
+	// The collector's slice is always fleetSort'd, so the parked row arrives
+	// after every live one — what this test pins is that cqOrder cannot lift
+	// it back out.
+	fleet = append(fleet, parkedFixtureRow(time.Now()))
+	m.cqOrder = []string{"id-parked", "id-one", "id-two"}
+
+	all := m.fleetAll()
+	if got := all[len(all)-1].id; got != "id-parked" {
+		t.Errorf("last live row = %q, want the parked one whatever the ordering says", got)
+	}
+	for i, r := range all[:len(all)-1] {
+		if r.kind == "parked" {
+			t.Errorf("parked row surfaced at position %d", i)
+		}
+	}
+}
+
+func TestFleetCountSeparatesParkedFromClean(t *testing.T) {
+	rows := []fleetRow{
+		{kind: "queue"},
+		{kind: "run", rank: 3},
+		{kind: "parked", rank: fleetParkedRank},
+	}
+	wants, warn, parked, clean := fleetCount(rows)
+	if wants != 1 || warn != 0 || parked != 1 || clean != 1 {
+		t.Errorf("fleetCount = %d,%d,%d,%d — a shelved row is not running clean", wants, warn, parked, clean)
+	}
+}
+
+// ---- the divider ------------------------------------------------------------
+
+// The parked group is the one part of the table with a header: a divider line
+// above the first parked row. It is a display line, not a row, so the body
+// still fits its height exactly and the selection maps across it.
+func TestFleetBodyDrawsTheParkedDivider(t *testing.T) {
+	now := time.Now()
+	rows := []fleetRow{
+		{id: "a", kind: "queue", rank: 1, feature: "ask"},
+		{id: "b", kind: "parked", rank: fleetParkedRank, feature: "shelved", parked: now},
+	}
+	cols := fleetColumns(130, 12)
+	h := 6
+	lines := fleetBody(130, cols, rows, 1, h, "")
+	if len(lines) != h {
+		t.Fatalf("body = %d lines, want exactly %d — the divider must not overflow the box", len(lines), h)
+	}
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "parked") || !strings.Contains(joined, "──") {
+		t.Error("the parked group has no divider above it")
+	}
+	if !strings.Contains(joined, "shelved") || !strings.Contains(joined, "ask") {
+		t.Error("a row went missing to make room for the divider")
+	}
+	if strings.Index(joined, "ask") > strings.Index(joined, "parked") {
+		t.Error("the divider must sit between the live rows and the shelf")
+	}
+
+	// Without a parked row there is no divider to draw.
+	plain := strings.Join(fleetBody(130, cols, rows[:1], 0, h, ""), "\n")
+	if strings.Contains(plain, "──") {
+		t.Error("a table with nothing parked drew a divider anyway")
+	}
+}
+
+// ---- the keys ---------------------------------------------------------------
+
+// p on a queue row opens the reason input; enter with a reason parks. The
+// input owns the keyboard — letters are text, not fleet keys.
+func TestParkKeyAsksWhyThenParks(t *testing.T) {
+	m := cqModel(t)
+	m = press(m, "p")
+	if !m.parkOpen || m.parkAt == nil || m.parkAt.id != "id-one" {
+		t.Fatalf("p did not open the reason input for the selected row (open=%v at=%v)", m.parkOpen, m.parkAt)
+	}
+	m = typeBurst(m, "waiting on legal")
+	if m.parkText != "waiting on legal" {
+		t.Fatalf("typed reason = %q", m.parkText)
+	}
+	if !strings.Contains(m.View(), "waiting on legal") {
+		t.Error("the input does not render what is being typed")
+	}
+
+	next, cmd := m.handleKey("enter")
+	m = next.(model)
+	if m.parkOpen || m.parkAt != nil || m.parkText != "" {
+		t.Error("submitting did not close the input")
+	}
+	if cmd == nil {
+		t.Error("submitting a reason must reach the park command")
+	}
+}
+
+// The reason is the point: enter with nothing typed parks nothing.
+func TestParkRefusesAnEmptyReason(t *testing.T) {
+	m := cqModel(t)
+	m = press(m, "p")
+	next, cmd := m.handleKey("enter")
+	m = next.(model)
+	if !m.parkOpen {
+		t.Error("an empty submit closed the input instead of asking for the reason")
+	}
+	if cmd != nil {
+		t.Error("an empty submit must not write anything")
+	}
+	if m.notice == "" {
+		t.Error("refusing silently reads as a dead key — say why")
+	}
+
+	m = press(m, "esc")
+	if m.parkOpen || m.parkAt != nil {
+		t.Error("esc did not cancel the input")
+	}
+}
+
+// p means park only where there is an ask to park: a running dispatcher has
+// not asked anything, and on a parked row the same key takes it back up.
+func TestParkKeyOnlyActsWhereItMeansSomething(t *testing.T) {
+	m := cqModel(t)
+	m = press(m, "j")
+	m = press(m, "j") // onto the running row
+	if r, _ := m.fleetSel(); r.kind != "run" {
+		t.Fatalf("cursor on %q, want the running row", r.kind)
+	}
+	m = press(m, "p")
+	if m.parkOpen {
+		t.Error("p opened the park input on a running row")
+	}
+
+	// A parked row's p is the unpark act, which fires like any other act.
+	prev := fleet
+	t.Cleanup(func() { fleet = prev })
+	fleet = append(fleet, parkedFixtureRow(time.Now()))
+	m = m.fleetSync()
+	m = press(m, "G")
+	if r, _ := m.fleetSel(); r.kind != "parked" {
+		t.Fatalf("cursor on %q, want the parked row", r.kind)
+	}
+	m = press(m, "p")
+	if m.parkOpen {
+		t.Error("p on a parked row must unpark, not open the input again")
+	}
+	if !strings.Contains(m.cqFlash, "back on the fleet") {
+		t.Errorf("flash = %q, want the unpark confirmation", m.cqFlash)
+	}
+}
+
+// ---- the acts ---------------------------------------------------------------
+
+// Every act a parked row advertises reaches a real command, and which ⏎ it
+// offers follows the record: a live session attaches, a dead one resumes.
+func TestParkedActsFollowTheRecord(t *testing.T) {
+	alive := testRec("five", 2)
+	alive.Status = state.StatusNeedsInput
+	var keys []string
+	for _, a := range cqActs(alive, "parked") {
+		keys = append(keys, a.k+" "+a.d)
+	}
+	if got := strings.Join(keys, " · "); got != "⏎ attach · p unpark · x kill" {
+		t.Errorf("parked acts = %q", got)
+	}
+
+	dead := testRec("five", 2)
+	dead.Status = state.StatusExited
+	keys = nil
+	for _, a := range cqActs(dead, "parked") {
+		keys = append(keys, a.k+" "+a.d)
+	}
+	if got := strings.Join(keys, " · "); got != "⏎ resume · p unpark" {
+		t.Errorf("parked acts on a dead session = %q — there is no session to attach or kill", got)
+	}
+
+	// And the commands behind them are real (see cq_acts_test's contract).
+	row := fleetRow{id: "id-parked", kind: "parked", feature: "five"}
+	if _, cmd := newModel().cqRun(row, cqAct{k: "p", d: "unpark"}); cmd == nil {
+		t.Error("unpark reaches no command")
+	}
+	if _, cmd := newModel().cqRun(row, cqAct{k: "⏎", d: "resume"}); cmd == nil {
+		t.Error("resume on a parked row with a dead session reaches no command")
+	}
+}
+
+// The queue rows advertise the park key so the footer can say it, but the act
+// deliberately carries no ok: cqRun must never fire it — the reason input is
+// the only way onto the shelf.
+func TestQueueRowsAdvertiseParkWithoutACommand(t *testing.T) {
+	var park *cqAct
+	for _, a := range cqActs(testRec("one", 3), "turn-done") {
+		if a.k == "p" {
+			aa := a
+			park = &aa
+		}
+	}
+	if park == nil {
+		t.Fatal("queue rows do not advertise the park key")
+	}
+	if park.ok != "" {
+		t.Error("the park act must not flash — nothing is parked until the reason is entered")
+	}
+}

--- a/internal/cockpit/pending_test.go
+++ b/internal/cockpit/pending_test.go
@@ -71,7 +71,7 @@ func TestDispatchAppearsBeforeItHasLaunched(t *testing.T) {
 	}
 	// It is not asking for anything, so it must not be counted among the rows
 	// that are — the headline above the table is read as a count of demands.
-	if wants, _, _ := fleetCount(rows); wants != 0 {
+	if wants, _, _, _ := fleetCount(rows); wants != 0 {
 		t.Errorf("a starting dispatcher wants you %d times", wants)
 	}
 	// And it offers no keys, because there is nothing behind them yet.

--- a/internal/cockpit/view.go
+++ b/internal/cockpit/view.go
@@ -198,6 +198,8 @@ func (m model) overlayView(w, h int) (string, bool) {
 		return m.viewReview(w, h), true
 	case m.resumeOpen:
 		return m.viewResume(w, h), true
+	case m.parkOpen:
+		return m.viewPark(w, h), true
 	case m.paletteOpen:
 		return m.viewPalette(w, h), true
 	}

--- a/internal/hookcmd/hookcmd.go
+++ b/internal/hookcmd/hookcmd.go
@@ -181,6 +181,12 @@ func apply(d *state.Dispatch, event string, in hookInput) bool {
 		d.Status = state.StatusWorking
 		d.StatusReason = "processing your prompt"
 		d.WaitingOnTasks = false
+		// A prompt reaching the session answers the question it was parked on:
+		// the park said "I cannot answer that right now", and someone just did.
+		// No other event clears the shelf — a Stop, an idle prompt or a session
+		// dying with the machine are all things a parked dispatcher is allowed
+		// to do while it waits.
+		d.ParkedReason, d.ParkedAt = "", nil
 	case "PostToolUse":
 		// A tool completing means any permission prompt was approved.
 		if d.Status != state.StatusBlocked {

--- a/internal/hookcmd/hookcmd_test.go
+++ b/internal/hookcmd/hookcmd_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"claude-dispatcher/internal/state"
 )
@@ -194,5 +195,29 @@ func TestSamePath(t *testing.T) {
 	}
 	if samePath("/a", "/b") {
 		t.Error("different paths should not match")
+	}
+}
+
+// Parking is the human saying "I cannot answer that right now". The one event
+// that dissolves it is a prompt reaching the session — someone just answered —
+// and nothing else the session does may empty the shelf: a parked dispatcher
+// is allowed to sit at its prompt, go idle, and even die with the machine.
+func TestApplyOnlyAPromptClearsThePark(t *testing.T) {
+	at := time.Now().Add(-time.Hour)
+	parked := func(st state.Status) *state.Dispatch {
+		return &state.Dispatch{Status: st, ParkedReason: "waiting on legal", ParkedAt: &at}
+	}
+
+	d := parked(state.StatusNeedsInput)
+	if !apply(d, "UserPromptSubmit", hookInput{}) || d.Parked() {
+		t.Errorf("a submitted prompt must clear the park, got parked=%v", d.Parked())
+	}
+
+	for _, ev := range []string{"Stop", "Notification:idle_prompt", "SessionEnd", "SessionStart"} {
+		d := parked(state.StatusWorking)
+		apply(d, ev, hookInput{})
+		if !d.Parked() {
+			t.Errorf("%s cleared the park — only the human, a kill or a prompt may", ev)
+		}
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -93,10 +93,23 @@ type Dispatch struct {
 	// background tasks: the session is paused, not waiting on the human, and
 	// will wake itself. Guards against a later idle_prompt notification (whose
 	// payload has no task info) downgrading the status to needs-input.
-	WaitingOnTasks bool      `json:"waiting_on_tasks,omitempty"`
-	CreatedAt      time.Time `json:"created_at"`
-	UpdatedAt      time.Time `json:"updated_at"`
+	WaitingOnTasks bool `json:"waiting_on_tasks,omitempty"`
+	// ParkedReason and ParkedAt are the human's shelf, not the machine's truth:
+	// the session asked something they cannot answer right now, and they said
+	// why. Parking is an annotation rather than a Status because Status belongs
+	// to the lifecycle hooks — a "parked" status would be overwritten by the
+	// next event the session emitted, and guarded everywhere one is applied.
+	// The cockpit sets and clears the pair together; hookcmd clears it on
+	// UserPromptSubmit, because a prompt reaching the session means the
+	// question it was parked on got its answer.
+	ParkedReason string     `json:"parked_reason,omitempty"`
+	ParkedAt     *time.Time `json:"parked_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
 }
+
+// Parked reports whether the human has shelved this dispatch — see ParkedReason.
+func (d *Dispatch) Parked() bool { return d.ParkedAt != nil || d.ParkedReason != "" }
 
 func Dir() string {
 	if d := os.Getenv("CLAUDE_DISPATCHER_STATE"); d != "" {

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -90,3 +90,29 @@ func TestLoadAllSkipsCorruptRecords(t *testing.T) {
 		t.Fatalf("expected only the valid record, got %d", len(got))
 	}
 }
+
+// The shelf has to survive the round trip: the cockpit that reads the record
+// back may be a different process days later, and Resume, the fleet and the
+// hooks all read Parked() off what was persisted.
+func TestSaveLoadKeepsThePark(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	at := time.Now().Add(-time.Hour).Truncate(time.Second)
+	if err := Save(&Dispatch{ID: "p", Status: StatusNeedsInput,
+		ParkedReason: "waiting on legal", ParkedAt: &at}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(&Dispatch{ID: "q", Status: StatusNeedsInput}); err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]*Dispatch{}
+	for _, d := range LoadAll() {
+		got[d.ID] = d
+	}
+	p := got["p"]
+	if !p.Parked() || p.ParkedReason != "waiting on legal" || p.ParkedAt == nil || !p.ParkedAt.Equal(at) {
+		t.Errorf("the park did not survive the round trip: %+v", p)
+	}
+	if got["q"].Parked() {
+		t.Error("a record nobody parked came back parked")
+	}
+}


### PR DESCRIPTION
A session sometimes stops on a question the human has no answer for yet — legal hasn't come back, the API key isn't issued, the design call hasn't been made. Until now that ask sat in the triage queue's "want you" counts forever, indistinguishable from things that could actually be answered.

**`p` on a queue row parks it.** The key opens a reason input (the reason is required — the shelf is the reason), and on enter the dispatcher drops to a **parked** group at the bottom of the fleet: its own divider line, its own rank between the running rows and history, its own `‖` glyph, out of the "want you" / "need a look" counts, with the reason carried on the row's SIGNAL cell and in the detail panel.

## How it works

- **Parking is an annotation on the record (`ParkedReason` / `ParkedAt`), never a `Status`.** Status belongs to the lifecycle hooks; a parked status would be flipped back by the next event the session emitted, or need a guard at every site one is applied. The hooks keep reporting machine truth underneath, and the fleet groups on the annotation.
- **The shelf is durable.** It survives a Stop, an idle prompt, and a reboot taking tmux down — a parked row whose session died offers `⏎ resume` instead of `⏎ attach` (same mechanics as history rows), so a machine restart cannot silently empty the shelf.
- **It clears on exactly the acts that end it:** `p` again (unpark, back onto the live table at whatever rank its real status earns), `x` (a kill is abandonment, not shelving), a prompt reaching the session (`UserPromptSubmit` in hookcmd — someone just answered the question it was parked on), and shipping ("live" outranks the shelf; a done record goes to history like any other).
- **Parked rows sit out the `s`-rotation ordering**, so an id skipped while it was a queue row can never drag its parked self back above the live table, and the group stays contiguous under its one divider.
- The headline gains an "N parked" clause only when something is on the shelf; the help sheet, footer hints and README document the key; the decision is recorded in CLAUDE.md's decision log, where the DECISIONS lens reads it.

## Tests

Collector grouping (parked beats every status except done/live), rank/glyph/sort placement, the divider rendering inside the body's height budget, the reason being required, `p`'s three meanings (park / unpark / no-op on a running row), the acts following the record's session liveness, hookcmd clearing the park only on a submitted prompt, and the JSON round trip.
