### PR TITLE
Let the dispatch form choose the model, and whether to fan out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,23 @@
   spelling is given the older one (`acceptEdits`/`default`) and one with no
   such flag gets none, because a rejected flag is not a degraded session —
   it is a launch that never happens.
+- **The dispatch form's MODEL is a flag read from claude's own help; FAN OUT
+  is a sentence in the prompt.** Both forms offer them beside MODE. MODEL is
+  `--model`, and its offer is "default" (no flag at all — the human's own
+  Claude Code decides) plus exactly the aliases the installed claude's help
+  names, parsed the way the mode's choices are: an alias we cannot vouch for
+  is never offered and never passed, because a rejected value is a launch that
+  dies or a session erroring unattended. Resume passes `--model` again;
+  "default" is recorded as the word, distinct from the "" of records that
+  never chose. FAN OUT has no flag to pass — Claude Code's multi-agent opt-in
+  is the keyword "ultracode" in the prompt — so on, the launch appends one
+  closing sentence carrying it (skipped if the human already typed the
+  keyword), records the composed prompt, and sets `FanOut` on the record so
+  screens need not grep for it. Not re-applied on resume: the transcript
+  already carries it, and a resume prompt is the human's own message. The
+  ask-nothing paths (backlog enter/ctrl+d, product-panel re-dispatch) launch
+  on the defaults. Full record:
+  `docs/adr/0002-model-is-a-flag-fan-out-is-a-sentence.md`.
 - Commit attribution is by provenance (dispatch records its branch SHAs),
   NEVER by Co-Authored-By trailers — the user strips those from commits.
 - User is on a Claude subscription (not API billing): portfolio roll-up

--- a/docs/adr/0002-model-is-a-flag-fan-out-is-a-sentence.md
+++ b/docs/adr/0002-model-is-a-flag-fan-out-is-a-sentence.md
@@ -1,0 +1,69 @@
+# The model is a flag read from claude's help; fan-out is a sentence in the prompt
+
+## Status
+
+Accepted (2026-08-17)
+
+## Context
+
+The dispatch form chose two of a session's three launch-time properties — the
+permission mode, and (implicitly) the prompt — but not the model the session
+runs, and not whether it may spread the work across multiple agents. Every
+dispatch ran whatever the human's own Claude Code defaults to, and the dx
+form's summary line deliberately named no model, because printing one we did
+not pass would have been a fabricated fact.
+
+Making them choosable raises the same problem the mode had (see
+`internal/dispatch/mode.go`): Claude Code's `--model` values are not a fixed
+enum. The flag takes an alias for the latest model ('fable', 'opus', 'sonnet'
+today) or a full model name, the alias set grows with releases, and a value
+the installed claude does not accept is either a launch that dies before it
+reads the prompt or a session erroring on its first message with nobody
+watching. Fan-out is different in kind: Claude Code has no flag for it at all.
+Its opt-in for multi-agent orchestration is the keyword "ultracode" appearing
+in the prompt itself.
+
+## Decision
+
+Both forms (the triage lens's dx form and the `+` overlay) offer two new
+choices, and each travels by the only honest channel it has:
+
+- **MODEL is a launch flag whose offer is read from the installed claude's
+  help.** `dispatch.Models()` is "default" — pass no flag at all — plus the
+  aliases `claude --help` names for `--model`, parsed once per process the way
+  the mode's choices are. An alias the help does not vouch for is never
+  offered and never passed: `ModelArgs` emits nothing for it, so a record
+  resumed on a machine whose claude no longer advertises the alias opens on
+  that build's own default rather than being handed a value it may reject.
+  "default" is recorded as the explicit word, distinct from the "" of records
+  written before the model was a choice — those sessions did not choose.
+
+- **FAN OUT is prompt composition, not a flag and not a status.** On, the
+  launch appends one closing sentence carrying the ultracode keyword
+  (`dispatch.FanOutInstruction`) — unless the human already typed the keyword,
+  in which case they opted in themselves and saying it twice is noise. The
+  record carries `FanOut` so screens can say which kind of session they are
+  looking at without grepping the prompt, and it carries the composed prompt,
+  because the record's Prompt is the prompt the session actually received.
+
+Resume passes `--model` again alongside `--permission-mode` — both are
+properties of the new session, not of the transcript it reopens. Fan-out is
+deliberately *not* re-applied on resume: the keyword lives in the recorded
+prompt and the transcript already carries it, and a resume prompt is the
+human's own message, which this feature never edits.
+
+The paths that ask no questions — the backlog's enter and ctrl+d, the product
+panel's re-dispatch — launch on the defaults, for the same reason they take
+the default mode: a choice made for a previous run is not consent for this
+one, and a form that did not ask must not answer.
+
+## Consequences
+
+The offer is machine-dependent by design: on a box whose claude help cannot be
+read, MODEL collapses to a one-position switch ("default") and stays honest
+about having nothing else to offer. Tests answer for the parsed aliases the
+way mode tests answer for the mode names, so CI needs no claude on PATH. The
+alias hints claim nothing about capability ("runs the latest Opus"), because
+capability claims go stale with every release. And fan-out costing tokens is
+the human's call at dispatch time, made per-dispatch on a switch whose off
+position — solo — is the default.

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -214,8 +214,9 @@ func resumeCmd(id, prompt string) tea.Cmd {
 }
 
 // launchCmd dispatches a new feature into repoName with prompt, in the
-// permission mode the form chose.
-func launchCmd(cfg *config.Config, repoName, feature, prompt string, mode dispatchpkg.Mode) tea.Cmd {
+// permission mode the form chose, on the model it chose, fanning out across
+// agents if the form asked for that.
+func launchCmd(cfg *config.Config, repoName, feature, prompt string, mode dispatchpkg.Mode, mdl dispatchpkg.Model, fanOut bool) tea.Cmd {
 	return func() tea.Msg {
 		if cfg == nil {
 			return launchedMsg{feature: feature, notice: "no config — cannot dispatch", failed: true}
@@ -231,7 +232,7 @@ func launchCmd(cfg *config.Config, repoName, feature, prompt string, mode dispat
 		if found == nil {
 			return launchedMsg{feature: feature, notice: "repo not found: " + repoName, failed: true}
 		}
-		d, err := dispatchpkg.Launch(*found, feature, prompt, mode)
+		d, err := dispatchpkg.Launch(*found, feature, prompt, mode, mdl, fanOut)
 		if err != nil {
 			return launchedMsg{feature: feature, notice: "launch failed: " + err.Error(), failed: true}
 		}

--- a/internal/cockpit/actions_test.go
+++ b/internal/cockpit/actions_test.go
@@ -224,7 +224,7 @@ func TestReplyCmdNoSession(t *testing.T) {
 }
 
 func TestLaunchCmdNoConfig(t *testing.T) {
-	msg := launchCmd(nil, "repo", "feature", "prompt", dispatchpkg.ModeAuto)()
+	msg := launchCmd(nil, "repo", "feature", "prompt", dispatchpkg.ModeAuto, dispatchpkg.DefaultModel, false)()
 	lm, ok := msg.(launchedMsg)
 	if !ok || !lm.failed || lm.feature != "feature" || !strings.Contains(lm.notice, "no config") {
 		t.Errorf("launchCmd(nil cfg) = %#v", msg)
@@ -234,7 +234,7 @@ func TestLaunchCmdNoConfig(t *testing.T) {
 func TestLaunchCmdRepoNotFound(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &config.Config{Roots: []string{dir}}
-	msg := launchCmd(cfg, "nonexistent-repo", "feature", "prompt", dispatchpkg.ModeAuto)()
+	msg := launchCmd(cfg, "nonexistent-repo", "feature", "prompt", dispatchpkg.ModeAuto, dispatchpkg.DefaultModel, false)()
 	lm, ok := msg.(launchedMsg)
 	if !ok || !lm.failed || lm.feature != "feature" || !strings.Contains(lm.notice, "repo not found") {
 		t.Errorf("launchCmd(repo not found) = %#v", msg)
@@ -254,7 +254,7 @@ func TestLaunchCmdEnsureBranchFails(t *testing.T) {
 	}
 	cfg := &config.Config{Roots: []string{root}}
 
-	msg := launchCmd(cfg, "fake-repo", "new feature", "do something", dispatchpkg.ModeAuto)()
+	msg := launchCmd(cfg, "fake-repo", "new feature", "do something", dispatchpkg.ModeAuto, dispatchpkg.DefaultModel, false)()
 	lm, ok := msg.(launchedMsg)
 	if !ok || !lm.failed || lm.feature != "new feature" || !strings.Contains(lm.notice, "launch failed") {
 		t.Errorf("launchCmd(broken repo) = %#v", msg)

--- a/internal/cockpit/backlog.go
+++ b/internal/cockpit/backlog.go
@@ -387,11 +387,12 @@ func (m model) updateBacklog(k string) (model, tea.Cmd) {
 			// to go and look — see pending.go.
 			m = m.markPending(m.pendingFor(t.repo, backlogFeature(t), t.prompt))
 			// The backlog asks no questions — enter on a ticket is the whole
-			// interaction — so it dispatches in the default mode. That is the
-			// posture the ticket implies: work handed off to happen elsewhere,
-			// with nobody sitting on its permission prompt. Anything else is
-			// dispatched from a form that asks.
-			return m, launchCmd(m.cfg, t.repo, backlogFeature(t), t.prompt, dispatchpkg.DefaultMode)
+			// interaction — so it dispatches in the default mode, on the default
+			// model, without fan-out. That is the posture the ticket implies:
+			// work handed off to happen elsewhere, with nobody sitting on its
+			// permission prompt. Anything else is dispatched from a form that
+			// asks.
+			return m, launchCmd(m.cfg, t.repo, backlogFeature(t), t.prompt, dispatchpkg.DefaultMode, dispatchpkg.DefaultModel, false)
 		}
 	case "ctrl+d":
 		// This used to announce a dispatch and launch nothing — the worst kind
@@ -412,7 +413,7 @@ func (m model) updateBacklog(k string) (model, tea.Cmd) {
 				continue
 			}
 			m = m.markPending(m.pendingFor(bt.repo, backlogFeature(bt), bt.prompt))
-			cmds = append(cmds, launchCmd(m.cfg, bt.repo, backlogFeature(bt), bt.prompt, dispatchpkg.DefaultMode))
+			cmds = append(cmds, launchCmd(m.cfg, bt.repo, backlogFeature(bt), bt.prompt, dispatchpkg.DefaultMode, dispatchpkg.DefaultModel, false))
 		}
 		m.picked = map[string]bool{}
 		var why []string

--- a/internal/cockpit/cq_test.go
+++ b/internal/cockpit/cq_test.go
@@ -403,7 +403,7 @@ func TestCQFormDispatchesTheSentenceNotTheName(t *testing.T) {
 
 	var gotFeature, gotPrompt string
 	prev := dxLaunch
-	dxLaunch = func(_ *config.Config, _, feature, prompt string, _ dispatchpkg.Mode) tea.Cmd {
+	dxLaunch = func(_ *config.Config, _, feature, prompt string, _ dispatchpkg.Mode, _ dispatchpkg.Model, _ bool) tea.Cmd {
 		gotFeature, gotPrompt = feature, prompt
 		return nil
 	}

--- a/internal/cockpit/dispatchform.go
+++ b/internal/cockpit/dispatchform.go
@@ -1,18 +1,20 @@
 package cockpit
 
 // dispatchform.go is the in-cockpit "new dispatch" overlay: the classic
-// cockpit's repo → feature → mode → prompt flow, ported into v2 so ad-hoc work
-// can be dispatched without a backlog ticket. Open it with `+` or the palette's
-// "dispatch" / "new dispatch" command. Like settings, it lives behind a pointer
-// on the model so its textinputs keep focus state across value-receiver Update
-// copies. Submitting hands off to launchCmd, which does the real dispatch.
+// cockpit's repo → feature → mode → model → fan out → prompt flow, ported into
+// v2 so ad-hoc work can be dispatched without a backlog ticket. Open it with
+// `+` or the palette's "dispatch" / "new dispatch" command. Like settings, it
+// lives behind a pointer on the model so its textinputs keep focus state
+// across value-receiver Update copies. Submitting hands off to launchCmd,
+// which does the real dispatch.
 //
-// MODE is a step of its own rather than a default this overlay picks quietly.
-// It is the session's permission mode — what a dispatcher may do without
-// asking — and it reaches the process as --permission-mode, so a form that
-// chose it on the human's behalf would be deciding that silently every time.
-// It opens on the default with the list in view, so taking the default is one
-// keypress and changing it is two.
+// MODE, MODEL and FAN OUT are steps of their own rather than defaults this
+// overlay picks quietly. The first two reach the process as launch flags
+// (--permission-mode and --model), and fan-out reaches it as the ultracode
+// sentence in the prompt (see dispatch/fanout.go) — so a form that chose any
+// of them on the human's behalf would be deciding that silently every time.
+// Each opens on its default with the list in view, so taking the default is
+// one keypress and changing it is two.
 
 import (
 	"strings"
@@ -31,6 +33,8 @@ const (
 	dispatchRepo dispatchStep = iota
 	dispatchFeature
 	dispatchMode
+	dispatchModel
+	dispatchFanout
 	dispatchPrompt
 	dispatchStepCount
 )
@@ -44,10 +48,12 @@ type dispatchForm struct {
 	cursor int
 	repo   repos.Repo
 
-	filter  textinput.Model // step 1: filter repos by name/product
-	feature textinput.Model // step 2: feature name
-	modeSel int             // step 3: cursor into dispatchpkg.Modes()
-	prompt  textinput.Model // step 4: the prompt
+	filter    textinput.Model // step 1: filter repos by name/product
+	feature   textinput.Model // step 2: feature name
+	modeSel   int             // step 3: cursor into dispatchpkg.Modes()
+	modelSel  int             // step 4: cursor into dispatchpkg.Models()
+	fanoutSel int             // step 5: cursor into dispatchFanoutOptions
+	prompt    textinput.Model // step 6: the prompt
 
 	errMsg string
 }
@@ -57,6 +63,23 @@ type dispatchForm struct {
 func (df *dispatchForm) mode() dispatchpkg.Mode {
 	all := dispatchpkg.Modes()
 	return all[clampCursor(df.modeSel, len(all))]
+}
+
+// mdl is the model step 4 has landed on — same cursor-is-the-state shape.
+func (df *dispatchForm) mdl() dispatchpkg.Model {
+	all := dispatchpkg.Models()
+	return all[clampCursor(df.modelSel, len(all))]
+}
+
+// fanOut is whether step 5 chose fanning out.
+func (df *dispatchForm) fanOut() bool { return df.fanoutSel == 1 }
+
+// dispatchFanoutOptions are FAN OUT's two answers, in offer order: staying
+// solo is the default. The labels match the dx form's switch, and the hints
+// say what each position actually does.
+var dispatchFanoutOptions = []struct{ label, hint string }{
+	{"solo", "one session does all the work itself"},
+	{"fan out", "may spread across multiple agents where the task splits"},
 }
 
 // newDispatchForm builds the overlay, discovering repos from cfg. It focuses
@@ -79,16 +102,22 @@ func newDispatchForm(cfg *config.Config) *dispatchForm {
 	prompt.Placeholder = "describe the work to dispatch…"
 	prompt.CharLimit = 500
 
-	// modeSel opens on the default's own index rather than on 0, so the offer
-	// order in dispatchpkg.Modes() can change without silently changing what a
-	// dispatch that took the default runs as.
+	// modeSel and modelSel open on their default's own index rather than on 0,
+	// so the offer order in dispatchpkg can change without silently changing
+	// what a dispatch that took the default runs as.
 	sel := 0
 	for i, k := range dispatchpkg.Modes() {
 		if k == dispatchpkg.DefaultMode {
 			sel = i
 		}
 	}
-	return &dispatchForm{step: dispatchRepo, repos: rs, modeSel: sel, filter: filter, feature: feature, prompt: prompt}
+	mdlSel := 0
+	for i, k := range dispatchpkg.Models() {
+		if k == dispatchpkg.DefaultModel {
+			mdlSel = i
+		}
+	}
+	return &dispatchForm{step: dispatchRepo, repos: rs, modeSel: sel, modelSel: mdlSel, filter: filter, feature: feature, prompt: prompt}
 }
 
 // filtered returns the repos matching the current filter (by name or product).
@@ -173,7 +202,8 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 
 	case dispatchMode:
 		// Nothing on this step types, so every key is navigation and anything
-		// unrecognised is swallowed rather than treated as text.
+		// unrecognised is swallowed rather than treated as text. The same goes
+		// for the model and fan-out steps below.
 		switch k {
 		case "esc":
 			df.step = dispatchFeature
@@ -189,6 +219,48 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 			}
 			return m, nil
 		case "enter":
+			df.step = dispatchModel
+			return m, nil
+		}
+		return m, nil
+
+	case dispatchModel:
+		switch k {
+		case "esc":
+			df.step = dispatchMode
+			return m, nil
+		case "up", "ctrl+k", "left":
+			if df.modelSel > 0 {
+				df.modelSel--
+			}
+			return m, nil
+		case "down", "ctrl+j", "right":
+			if df.modelSel < len(dispatchpkg.Models())-1 {
+				df.modelSel++
+			}
+			return m, nil
+		case "enter":
+			df.step = dispatchFanout
+			return m, nil
+		}
+		return m, nil
+
+	case dispatchFanout:
+		switch k {
+		case "esc":
+			df.step = dispatchModel
+			return m, nil
+		case "up", "ctrl+k", "left":
+			if df.fanoutSel > 0 {
+				df.fanoutSel--
+			}
+			return m, nil
+		case "down", "ctrl+j", "right":
+			if df.fanoutSel < len(dispatchFanoutOptions)-1 {
+				df.fanoutSel++
+			}
+			return m, nil
+		case "enter":
 			df.step = dispatchPrompt
 			return m, df.prompt.Focus()
 		}
@@ -197,7 +269,7 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 	case dispatchPrompt:
 		switch k {
 		case "esc":
-			df.step = dispatchMode
+			df.step = dispatchFanout
 			df.prompt.Blur()
 			return m, nil
 		case "enter", "ctrl+d":
@@ -209,13 +281,22 @@ func (m model) updateDispatchForm(k string) (model, tea.Cmd) {
 			feature := strings.TrimSpace(df.feature.Value())
 			prompt := strings.TrimSpace(df.prompt.Value())
 			mode := df.mode()
+			mdl := df.mdl()
+			fanOut := df.fanOut()
 			m.dispatchForm = nil
-			m.notice = "dispatching \"" + feature + "\" · " + string(mode) + "…"
+			notice := "dispatching \"" + feature + "\" · " + string(mode)
+			if mdl != dispatchpkg.DefaultModel {
+				notice += " · " + string(mdl)
+			}
+			if fanOut {
+				notice += " · fans out"
+			}
+			m.notice = notice + "…"
 			// This overlay closes onto whichever lens was behind it, so the
 			// dispatch has to be on the triage table by the time the human gets
 			// there — see pending.go.
 			m = m.markPending(m.pendingFor(repo, feature, prompt)).fleetSync()
-			return m, launchCmd(m.cfg, repo, feature, prompt, mode)
+			return m, launchCmd(m.cfg, repo, feature, prompt, mode, mdl, fanOut)
 		default:
 			var cmd tea.Cmd
 			df.prompt, cmd = df.prompt.Update(m.inputMsg(k))
@@ -272,7 +353,7 @@ func (m model) viewDispatchForm(w, h int) string {
 	var lines []string
 	lines = append(lines, fg(cWhite, "new dispatch"))
 	lines = append(lines, fg(cDim, "step "+itoa(int(df.step)+1)+" of "+itoa(int(dispatchStepCount))+
-		" · repo → feature → mode → prompt · esc backs out"))
+		" · repo → feature → mode → model → fan out → prompt · esc backs out"))
 	lines = append(lines, "")
 
 	// Breadcrumb of what's already been chosen.
@@ -288,6 +369,12 @@ func (m model) viewDispatchForm(w, h int) string {
 	}
 	if df.step > dispatchMode {
 		lines = append(lines, row(iw, "", c("mode", 10, cFaint), flexc(string(df.mode()), cMid)))
+	}
+	if df.step > dispatchModel {
+		lines = append(lines, row(iw, "", c("model", 10, cFaint), flexc(string(df.mdl()), cMid)))
+	}
+	if df.step > dispatchFanout {
+		lines = append(lines, row(iw, "", c("fan out", 10, cFaint), flexc(dispatchFanoutOptions[clampCursor(df.fanoutSel, len(dispatchFanoutOptions))].label, cMid)))
 	}
 	if df.step > dispatchRepo {
 		lines = append(lines, "")
@@ -348,14 +435,51 @@ func (m model) viewDispatchForm(w, h int) string {
 			))
 		}
 		lines = append(lines, "")
-		lines = append(lines, blank(2)+fg(cFaint, "enter → prompt · esc → feature"))
+		lines = append(lines, blank(2)+fg(cFaint, "enter → model · esc → feature"))
+
+	case dispatchModel:
+		lines = append(lines, fg(cMid, "model")+fg(cFaint, "  what the session runs — default passes no flag"))
+		lines = append(lines, "")
+		all := dispatchpkg.Models()
+		sel := clampCursor(df.modelSel, len(all))
+		for i, k := range all {
+			bg, marker, nameColor := cTransparent, " ", cFg
+			if i == sel {
+				bg, marker, nameColor = cSel, "▸", cWhite
+			}
+			lines = append(lines, row(iw, bg,
+				c(marker, 2, cMid),
+				c(string(k), 10, nameColor),
+				flexc(k.Hint(), cDim),
+			))
+		}
+		lines = append(lines, "")
+		lines = append(lines, blank(2)+fg(cFaint, "enter → fan out · esc → mode"))
+
+	case dispatchFanout:
+		lines = append(lines, fg(cMid, "fan out")+fg(cFaint, "  may it spread across agents when the task splits"))
+		lines = append(lines, "")
+		sel := clampCursor(df.fanoutSel, len(dispatchFanoutOptions))
+		for i, opt := range dispatchFanoutOptions {
+			bg, marker, nameColor := cTransparent, " ", cFg
+			if i == sel {
+				bg, marker, nameColor = cSel, "▸", cWhite
+			}
+			lines = append(lines, row(iw, bg,
+				c(marker, 2, cMid),
+				c(opt.label, 10, nameColor),
+				flexc(opt.hint, cDim),
+			))
+		}
+		lines = append(lines, "")
+		lines = append(lines, blank(2)+fg(cFaint, "enter → prompt · esc → model"))
 
 	case dispatchPrompt:
 		lines = append(lines, fg(cFaint, "prompt")+"  "+fg(cMid, df.repo.Name)+fg(cFaint, " · ")+fg(cMid, strings.TrimSpace(df.feature.Value())))
 		lines = append(lines, "")
 		lines = append(lines, df.prompt.View())
 		lines = append(lines, "")
-		lines = append(lines, blank(2)+fg(cFaint, "enter or ctrl+d dispatches · esc → mode"))
+		lines = append(lines, blank(2)+fg(cFaint, "enter or ctrl+d dispatches · esc → fan out"))
 	}
 
 	if df.errMsg != "" {

--- a/internal/cockpit/dispatchform_test.go
+++ b/internal/cockpit/dispatchform_test.go
@@ -74,6 +74,8 @@ func TestDispatchFormAcceptsBurstTyping(t *testing.T) {
 		t.Fatalf("feature = %q", got)
 	}
 	m = press(m, "enter") // → mode
+	m = press(m, "enter") // take the default → model
+	m = press(m, "enter") // take the default → fan out
 	m = press(m, "enter") // take the default and go on to the prompt
 	m = typeBurst(m, "retry failed charges with backoff")
 	if got := m.dispatchForm.prompt.Value(); got != "retry failed charges with backoff" {
@@ -196,14 +198,45 @@ func TestDispatchFormFlow(t *testing.T) {
 		t.Fatalf("up → %q, want auto", got)
 	}
 	m = press(m, "enter")
+	if m.dispatchForm.step != dispatchModel {
+		t.Fatalf("after mode, step = %d, want model", m.dispatchForm.step)
+	}
+
+	// Step 4: the model list opens on the default — no flag at all — and every
+	// offered model is on screen.
+	if got := m.dispatchForm.mdl(); got != dispatchpkg.DefaultModel {
+		t.Fatalf("model opened on %q, want the default", got)
+	}
+	out = m.View()
+	for _, k := range dispatchpkg.Models() {
+		if !strings.Contains(out, string(k)) {
+			t.Errorf("the model step does not offer %q", k)
+		}
+	}
+	m = press(m, "enter")
+	if m.dispatchForm.step != dispatchFanout {
+		t.Fatalf("after model, step = %d, want fan out", m.dispatchForm.step)
+	}
+
+	// Step 5: fan out opens on solo, and down arms it — the choice is what
+	// reaches the launch.
+	if m.dispatchForm.fanOut() {
+		t.Fatal("fan out opened armed, want solo")
+	}
+	m = press(m, "down")
+	if !m.dispatchForm.fanOut() {
+		t.Fatal("down did not arm fan out")
+	}
+	m = press(m, "up")
+	m = press(m, "enter")
 	if m.dispatchForm.step != dispatchPrompt {
-		t.Fatalf("after mode, step = %d, want prompt", m.dispatchForm.step)
+		t.Fatalf("after fan out, step = %d, want prompt", m.dispatchForm.step)
 	}
 	if strings.TrimSpace(strings.Join(strings.Fields(m.View()), " ")) == "" {
 		t.Fatal("prompt step render empty")
 	}
 
-	// Step 4: empty prompt is rejected, then submitting launches and closes.
+	// Step 6: empty prompt is rejected, then submitting launches and closes.
 	m = press(m, "enter")
 	if m.dispatchForm == nil || m.dispatchForm.errMsg == "" {
 		t.Fatal("empty prompt should be rejected and keep the form open")
@@ -222,8 +255,9 @@ func TestDispatchFormFlow(t *testing.T) {
 	}
 }
 
-// TestDispatchFormEscBacksOut walks the esc chain: prompt → mode → feature →
-// repo → closed, mirroring the classic form's back navigation.
+// TestDispatchFormEscBacksOut walks the esc chain: prompt → fan out → model →
+// mode → feature → repo → closed, mirroring the classic form's back
+// navigation.
 func TestDispatchFormEscBacksOut(t *testing.T) {
 	root := seedRepoRoot(t, "api")
 	cfg := &config.Config{Roots: []string{root}}
@@ -237,13 +271,23 @@ func TestDispatchFormEscBacksOut(t *testing.T) {
 	m = press(m, "enter") // pick the only repo
 	m = typeStr(m, "thing")
 	m = press(m, "enter") // → mode
+	m = press(m, "enter") // → model
+	m = press(m, "enter") // → fan out
 	m = press(m, "enter") // → prompt
 	if m.dispatchForm.step != dispatchPrompt {
 		t.Fatalf("expected prompt step, got %d", m.dispatchForm.step)
 	}
 	m = press(m, "esc")
+	if m.dispatchForm.step != dispatchFanout {
+		t.Fatal("esc from prompt should go back to fan out")
+	}
+	m = press(m, "esc")
+	if m.dispatchForm.step != dispatchModel {
+		t.Fatal("esc from fan out should go back to model")
+	}
+	m = press(m, "esc")
 	if m.dispatchForm.step != dispatchMode {
-		t.Fatal("esc from prompt should go back to mode")
+		t.Fatal("esc from model should go back to mode")
 	}
 	m = press(m, "esc")
 	if m.dispatchForm.step != dispatchFeature {

--- a/internal/cockpit/dispatchx.go
+++ b/internal/cockpit/dispatchx.go
@@ -5,13 +5,15 @@ package cockpit
 // It replaces the freeform draft (`cqDraft`) that used to sit under "what
 // should we build?". A draft answered only half the question: it said what to
 // build and then handed off to a three-step overlay to say where. The form asks
-// the five things a dispatch actually needs, on one screen:
+// the things a dispatch actually needs, on one screen:
 //
 //	WHERE      which repo it lands in — filtered, not scrolled through
 //	TITLE      what it is called: the feature name, and the branch
 //	WHAT       the work itself, wrapped over as many rows as it takes
 //	DONE WHEN  the completion condition, optional
 //	MODE       auto, manual or plan — what it may do without asking
+//	MODEL      default, or an alias the installed claude advertises
+//	FAN OUT    whether it may spread across agents when the task splits
 //
 // TITLE and WHAT used to be one field, and the branch was named from it. That
 // asked one line to be two things at once: a name short enough to live in
@@ -27,6 +29,14 @@ package cockpit
 // nobody watching. It reaches the process now, as --permission-mode (see
 // dispatch/mode.go), which is also what lets it offer plan mode: plan is not
 // something a sentence can ask for.
+//
+// MODEL reaches the process the same way MODE does — as a launch flag
+// (--model, see dispatch/model.go) — and its offer comes from the claude
+// actually installed, because a model name we invented is a session erroring
+// with nobody watching. FAN OUT is the other kind of switch: Claude Code's
+// opt-in for multi-agent work is the keyword "ultracode" in the prompt, not a
+// flag, so on it becomes one closing sentence (dispatch/fanout.go) and off it
+// changes nothing.
 //
 // DONE WHEN is still honest about its reach in the other direction: no
 // supervisor watches it, so it is a sentence in the prompt and the copy
@@ -59,6 +69,8 @@ const (
 	dxWhatF
 	dxGoalF
 	dxModeF
+	dxModelF
+	dxFanoutF
 	dxFieldCount
 )
 
@@ -85,6 +97,7 @@ func (m model) dxReset() model {
 	m.dxField, m.dxRepo = dxWhereF, 0
 	m.dxFilter, m.dxTitle, m.dxWhat, m.dxGoal = "", "", "", ""
 	m.dxMode = dispatchpkg.DefaultMode
+	m.dxModel, m.dxFanOut = dispatchpkg.DefaultModel, false
 	return m
 }
 
@@ -101,9 +114,9 @@ func (m model) dxOpen(filter string) model {
 // dxTouched reports whether anything has been typed into the four text fields.
 // It is what decides whether a navigation key is navigation or text: an
 // untouched form is not a trap, so 1–6, ':', 'd' and 'h' still leave it, but the
-// moment there is a filter or a sentence they are letters again. dxMode and
-// dxField deliberately do not count — cycling the mode or tabbing about is not
-// typing, and must not strand the human on this screen.
+// moment there is a filter or a sentence they are letters again. dxMode,
+// dxModel, dxFanOut and dxField deliberately do not count — cycling a switch or
+// tabbing about is not typing, and must not strand the human on this screen.
 func (m model) dxTouched() bool {
 	return m.dxFilter != "" || m.dxTitle != "" || m.dxWhat != "" || m.dxGoal != ""
 }
@@ -338,7 +351,7 @@ func (m model) dxKey(k string) (model, tea.Cmd) {
 		return m, nil
 
 	case "enter":
-		if field == dxModeF {
+		if field == dxFanoutF {
 			return m.dxSubmit()
 		}
 		m.dxField = field + 1
@@ -349,7 +362,7 @@ func (m model) dxKey(k string) (model, tea.Cmd) {
 			m.dxRepo = mini(m.dxRepo+1, maxi(len(rows)-1, 0))
 			return m, nil
 		}
-		m.dxField = mini2(field+1, dxModeF)
+		m.dxField = mini2(field+1, dxFanoutF)
 		return m, nil
 
 	case "up":
@@ -361,23 +374,41 @@ func (m model) dxKey(k string) (model, tea.Cmd) {
 		return m, nil
 	}
 
-	// MODE is a switch, not a field: space and `a` walk the three positions,
-	// left/right steer within the line, and nothing else on it types. This has
-	// to sit above the text branch, because typedText turns a space into " ".
+	// MODE, MODEL and FAN OUT are switches, not fields: space walks the
+	// positions, left/right steer within the line, and nothing else on them
+	// types. These have to sit above the text branch, because typedText turns
+	// a space into " ".
 	//
-	// `a` survives from when this line was AUTO and had two positions; it is
-	// still the letter the field is reached for, and cycling is what it now
-	// does. left/right are here because a three-way switch is a list, and a
-	// list you can only walk one way makes the third choice three keypresses.
-	// The vim pair is deliberately not bound: `h` leaves this lens from an
-	// untouched form, and one key that navigates on an empty form and edits on
-	// a filled one is the kind of thing nobody remembers under pressure.
+	// `a` survives on MODE from when that line was AUTO and had two positions;
+	// it is still the letter the field is reached for, and cycling is what it
+	// now does. left/right are here because a switch is a list, and a list you
+	// can only walk one way makes the far choice that many keypresses. The vim
+	// pair is deliberately not bound: `h` leaves this lens from an untouched
+	// form, and one key that navigates on an empty form and edits on a filled
+	// one is the kind of thing nobody remembers under pressure.
 	if field == dxModeF {
 		switch k {
 		case " ", "space", "a", "right":
 			m.dxMode = dispatchpkg.Next(m.dxMode.Normalize())
 		case "left":
 			m.dxMode = dispatchpkg.Prev(m.dxMode.Normalize())
+		}
+		return m, nil
+	}
+	if field == dxModelF {
+		switch k {
+		case " ", "space", "right":
+			m.dxModel = dispatchpkg.NextModel(m.dxModel.Normalize())
+		case "left":
+			m.dxModel = dispatchpkg.PrevModel(m.dxModel.Normalize())
+		}
+		return m, nil
+	}
+	if field == dxFanoutF {
+		switch k {
+		case " ", "space", "left", "right":
+			// Two positions: every direction is the other one.
+			m.dxFanOut = !m.dxFanOut
 		}
 		return m, nil
 	}
@@ -451,6 +482,8 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 	}
 	goal := strings.TrimSpace(m.dxGoal)
 	mode := m.dxMode.Normalize()
+	mdl := m.dxModel.Normalize()
+	fanOut := m.dxFanOut
 	feature, prompt := dxDispatch(m.dxTitle, m.dxWhat, goal, mode)
 	if feature == "" {
 		// Empty *or* unslugabble: a title of nothing but punctuation passes a
@@ -478,7 +511,15 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 	// The mode is always named, not only when it is the interesting one: it now
 	// configures the session rather than describing it, and a launch flag the
 	// notice stayed quiet about would be a setting the human never saw applied.
+	// The model is named only when one was chosen — "default" is the absence of
+	// a flag, and naming a model we did not pass would be a fabricated fact.
 	notice += " · " + string(mode)
+	if mdl != dispatchpkg.DefaultModel {
+		notice += " · " + string(mdl)
+	}
+	if fanOut {
+		notice += " · fans out"
+	}
 	m.notice = notice
 	// The row goes on the table now, not when the launch comes back. The form is
 	// closing over the table it was drawn on top of, and without this the human
@@ -487,7 +528,7 @@ func (m model) dxSubmit() (model, tea.Cmd) {
 	// table is empty. fleetSync re-keys the cursor over the row that just moved
 	// down; on an empty table it lands the cursor on the new row itself.
 	m = m.markPending(m.pendingFor(row.repo, feature, prompt)).fleetSync()
-	return m, dxLaunch(m.cfg, row.repo, feature, prompt, mode)
+	return m, dxLaunch(m.cfg, row.repo, feature, prompt, mode, mdl, fanOut)
 }
 
 // dxLaunch is the launch dxSubmit hands off to, named as a variable so a test
@@ -551,65 +592,137 @@ func (m model) dxGoalHint() string {
 	return "optional · leave empty and it does one pass, then waits for you"
 }
 
-// dxModeGap separates the positions on the MODE line.
+// dxModeGap separates the positions on a switch line.
 const dxModeGap = "  "
 
-// dxModeValue is the switch: all three positions, with a caret on the chosen
+// dxSwitchValue is a switch: every position drawn, with a caret on the chosen
 // one.
 //
 // They are drawn together rather than as a single word because a two-position
 // switch could say "on" and be understood as "off is the other one", while a
-// three-way one showing only its current value hides two thirds of the offer
-// behind a key nobody knows to press.
+// wider one showing only its current value hides most of the offer behind a
+// key nobody knows to press.
 //
 // The caret is what marks the selection; the colour only reinforces it. Colour
-// alone is not a marker here — the three positions read identically without it,
-// unlike the old on/off whose word changed — so a terminal with no colour, or
-// an eye that cannot separate green from grey, would have no way to tell which
-// one is armed.
-func (m model) dxModeValue() string {
-	cur := m.dxMode.Normalize()
-	parts := make([]string, 0, len(dispatchpkg.Modes()))
-	for _, k := range dispatchpkg.Modes() {
-		if k == cur {
-			parts = append(parts, fg(cGreen, "▸"+string(k)))
+// alone is not a marker here — the positions read identically without it — so
+// a terminal with no colour, or an eye that cannot separate green from grey,
+// would have no way to tell which one is armed.
+func dxSwitchValue(words []string, sel int) string {
+	parts := make([]string, 0, len(words))
+	for i, w := range words {
+		if i == sel {
+			parts = append(parts, fg(cGreen, "▸"+w))
 			continue
 		}
-		parts = append(parts, fg(cFaint, " "+string(k)))
+		parts = append(parts, fg(cFaint, " "+w))
 	}
 	return strings.Join(parts, dxModeGap)
 }
 
-// dxModeWidth is what dxModeValue occupies on screen — the words, their carets
-// and the gaps, without the colour escapes dispWidth would have to see through.
-func dxModeWidth() int {
+// dxSwitchWidth is what dxSwitchValue occupies on screen — the words, their
+// carets and the gaps, without the colour escapes dispWidth would have to see
+// through.
+func dxSwitchWidth(words []string) int {
 	w := 0
-	for i, k := range dispatchpkg.Modes() {
+	for i, word := range words {
 		if i > 0 {
 			w += dispWidth(dxModeGap)
 		}
-		w += dispWidth("▸" + string(k))
+		w += dispWidth("▸" + word)
 	}
 	return w
+}
+
+// dxModeWords are MODE's positions, in the offer order the switch cycles in.
+func dxModeWords() []string {
+	out := make([]string, 0, len(dispatchpkg.Modes()))
+	for _, k := range dispatchpkg.Modes() {
+		out = append(out, string(k))
+	}
+	return out
+}
+
+// dxModeSel is the position the caret sits on.
+func (m model) dxModeSel() int {
+	cur := m.dxMode.Normalize()
+	for i, k := range dispatchpkg.Modes() {
+		if k == cur {
+			return i
+		}
+	}
+	return 0
 }
 
 // dxModeHint describes what the chosen mode actually does to the session, and
 // — this being a switch on a line rather than a list — which key moves it.
 func (m model) dxModeHint() string { return m.dxMode.Hint() + " · space cycles" }
 
+// dxModelWords are MODEL's positions: the default, then whatever aliases the
+// installed claude advertises (see dispatch/model.go). On a machine whose help
+// we cannot read this is one word, and the switch is honest about having
+// nothing else to offer.
+func dxModelWords() []string {
+	out := make([]string, 0, len(dispatchpkg.Models()))
+	for _, k := range dispatchpkg.Models() {
+		out = append(out, string(k))
+	}
+	return out
+}
+
+func (m model) dxModelSel() int {
+	cur := m.dxModel.Normalize()
+	for i, k := range dispatchpkg.Models() {
+		if k == cur {
+			return i
+		}
+	}
+	return 0
+}
+
+func (m model) dxModelHint() string { return m.dxModel.Hint() + " · space cycles" }
+
+// dxFanoutWords are FAN OUT's two positions. "solo" rather than "off" because
+// the switch is about who does the work, and the off state is a working state,
+// not an absence.
+func dxFanoutWords() []string { return []string{"solo", "fan out"} }
+
+func (m model) dxFanoutSel() int {
+	if m.dxFanOut {
+		return 1
+	}
+	return 0
+}
+
+// dxFanoutHint says what the chosen position actually does: on adds the
+// ultracode sentence to the prompt (see dispatch/fanout.go), off adds nothing.
+func (m model) dxFanoutHint() string {
+	if m.dxFanOut {
+		return "may spread across multiple agents where the task splits · space flips"
+	}
+	return "one session does all the work itself · space flips"
+}
+
 // dxSummary is the whole form in one line: where it lands, what it will be
-// called, and whether it needs you.
+// called, whether it needs you, and — only when they were chosen — what it
+// runs on and whether it may fan out.
 //
-// The design also prints a model name here. This does not: the launch command
-// passes no --model, so the session runs whatever the user's Claude Code
-// default is, and naming one we did not choose would be a fabricated fact on
-// the most-read line of the screen.
+// The model appears only when one was picked: "default" passes no --model, so
+// the session runs whatever the user's Claude Code default is, and naming a
+// model we did not choose would be a fabricated fact on the most-read line of
+// the screen.
 func (m model) dxSummary() string {
 	row, ok := m.dxPicked()
 	if !ok {
 		return "pick a repo to dispatch into"
 	}
-	return row.repo + " · " + m.dxBranch() + " · " + m.dxMode.Summary()
+	s := row.repo + " · " + m.dxBranch() + " · " + m.dxMode.Summary()
+	if mdl := m.dxModel.Normalize(); mdl != dispatchpkg.DefaultModel {
+		s += " · " + string(mdl)
+	}
+	if m.dxFanOut {
+		s += " · fans out"
+	}
+	return s
 }
 
 // dxFooterHelp is the chrome row while the form is open. It advertises only
@@ -672,7 +785,9 @@ func (m model) dxView(w, h int) string {
 		cqFixed(m.dxFieldRow(inner, "DONE WHEN", m.dxGoal, m.dxField == dxGoalF, "")),
 		cqFixed(dxHintRow(inner, m.dxGoalHint())),
 		cqGap(8),
-		cqFixed(dxModeRow(inner, m.dxField == dxModeF, m.dxModeValue(), m.dxModeHint())),
+		cqFixed(dxSwitchRow(inner, m.dxField == dxModeF, "MODE", dxModeWords(), m.dxModeSel(), m.dxModeHint())),
+		cqFixed(dxSwitchRow(inner, m.dxField == dxModelF, "MODEL", dxModelWords(), m.dxModelSel(), m.dxModelHint())),
+		cqFixed(dxSwitchRow(inner, m.dxField == dxFanoutF, "FAN OUT", dxFanoutWords(), m.dxFanoutSel(), m.dxFanoutHint())),
 		cqGap(6),
 		cqFixed(dxHintRow(inner, m.dxSummary())),
 	}
@@ -737,17 +852,17 @@ func dxHintRow(inner int, s string) string {
 	return flG(blank(dxIndent) + fg(cFaint, truncate(s, maxi(1, inner-dxIndent))))
 }
 
-// dxModeRow is the MODE switch: the three positions with the chosen one lit,
-// then what it means. It has no caret: there is nothing to type into it, and a
-// caret would say otherwise.
+// dxSwitchRow is one switch line — MODE, MODEL or FAN OUT: the positions with
+// the chosen one lit, then what it means. It has no caret: there is nothing to
+// type into it, and a caret would say otherwise.
 //
-// value arrives already coloured, so its width comes from dxModeWidth rather
-// than from measuring the string — the colour escapes are not columns, and
-// budgeting the hint against them would leave the line short.
-func dxModeRow(inner int, active bool, value, hint string) string {
-	lbl := fg(dxLabelColor(active), padTo("MODE", dxLabelW, alignLeft))
-	room := maxi(1, inner-dxLabelW-dxGapW-dxModeWidth()-dxGapW)
-	return flG(lbl + blank(dxGapW) + value + blank(dxGapW) + fg(cFaint, truncate(hint, room)))
+// The value is drawn here from its words, because it arrives coloured and its
+// width has to come from the words themselves — the colour escapes are not
+// columns, and budgeting the hint against them would leave the line short.
+func dxSwitchRow(inner int, active bool, label string, words []string, sel int, hint string) string {
+	lbl := fg(dxLabelColor(active), padTo(label, dxLabelW, alignLeft))
+	room := maxi(1, inner-dxLabelW-dxGapW-dxSwitchWidth(words)-dxGapW)
+	return flG(lbl + blank(dxGapW) + dxSwitchValue(words, sel) + blank(dxGapW) + fg(cFaint, truncate(hint, room)))
 }
 
 // dxLabelColor lifts the label of the field that owns the keyboard, which is

--- a/internal/cockpit/dispatchx_test.go
+++ b/internal/cockpit/dispatchx_test.go
@@ -166,7 +166,7 @@ func TestDXModeLineMarksTheArmedModeWithoutColour(t *testing.T) {
 func TestDXSubmitPassesTheMode(t *testing.T) {
 	var got dispatchpkg.Mode
 	prev := dxLaunch
-	dxLaunch = func(_ *config.Config, _, _, _ string, mode dispatchpkg.Mode) tea.Cmd {
+	dxLaunch = func(_ *config.Config, _, _, _ string, mode dispatchpkg.Mode, _ dispatchpkg.Model, _ bool) tea.Cmd {
 		got = mode
 		return nil
 	}
@@ -184,6 +184,38 @@ func TestDXSubmitPassesTheMode(t *testing.T) {
 	m.dxTitle, m.dxWhat = "payment retries", "retry declined cards"
 	if _, _ = m.dxSubmit(); got != dispatchpkg.ModeAuto {
 		t.Errorf("an untouched MODE launched as %q, want auto", got)
+	}
+}
+
+// MODEL and FAN OUT reach the launch the same way MODE does. The model is
+// asserted against whatever this machine's claude offers (dispatchpkg.Models),
+// because the offer is read from the installed help and a hard-coded alias
+// would only pass on machines that advertise it.
+func TestDXSubmitPassesModelAndFanOut(t *testing.T) {
+	var gotModel dispatchpkg.Model
+	var gotFan bool
+	prev := dxLaunch
+	dxLaunch = func(_ *config.Config, _, _, _ string, _ dispatchpkg.Mode, mdl dispatchpkg.Model, fanOut bool) tea.Cmd {
+		gotModel, gotFan = mdl, fanOut
+		return nil
+	}
+	t.Cleanup(func() { dxLaunch = prev })
+
+	all := dispatchpkg.Models()
+	pick := all[len(all)-1]
+
+	m := dxFormModel(t)
+	m.dxTitle, m.dxWhat = "payment retries", "retry declined cards"
+	m.dxModel, m.dxFanOut = pick, true
+	if _, _ = m.dxSubmit(); gotModel != pick || !gotFan {
+		t.Errorf("the launch got model %q fanOut %v, want %q and true", gotModel, gotFan, pick)
+	}
+
+	// And untouched switches launch as the defaults: no flag, no fan-out.
+	m = dxFormModel(t)
+	m.dxTitle, m.dxWhat = "payment retries", "retry declined cards"
+	if _, _ = m.dxSubmit(); gotModel != dispatchpkg.DefaultModel || gotFan {
+		t.Errorf("untouched switches launched as model %q fanOut %v, want the defaults", gotModel, gotFan)
 	}
 }
 

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -176,13 +176,15 @@ type model struct {
 	// The floor's freeform draft became five fields: where it lands, what it is
 	// called, what it does, when it is done, and how much it may do without
 	// asking. See dispatchx.go — cqDispatch is what says the form is open.
-	dxField  dxFieldID        // which line owns the keyboard
-	dxFilter string           // WHERE: repo filter (runes from the key message)
-	dxRepo   int              // cursor into dxRows(); clamped on read, reset by filtering
-	dxTitle  string           // TITLE: the feature name, and the branch
-	dxWhat   string           // WHAT: the work — the prompt's body, wrapped as it is typed
-	dxGoal   string           // DONE WHEN: completion condition, optional
-	dxMode   dispatchpkg.Mode // MODE: auto / manual / plan — the session's permission mode
+	dxField  dxFieldID         // which line owns the keyboard
+	dxFilter string            // WHERE: repo filter (runes from the key message)
+	dxRepo   int               // cursor into dxRows(); clamped on read, reset by filtering
+	dxTitle  string            // TITLE: the feature name, and the branch
+	dxWhat   string            // WHAT: the work — the prompt's body, wrapped as it is typed
+	dxGoal   string            // DONE WHEN: completion condition, optional
+	dxMode   dispatchpkg.Mode  // MODE: auto / manual / plan — the session's permission mode
+	dxModel  dispatchpkg.Model // MODEL: default, or a claude alias — what the session runs
+	dxFanOut bool              // FAN OUT: may the session spread across agents when the task splits
 }
 
 func newModel() model {
@@ -206,6 +208,10 @@ func newModel() model {
 		// would open a session asking about every step, which is not the
 		// product's default posture.
 		dxMode: dispatchpkg.DefaultMode,
+		// Same reasoning for the model: the zero value is not a choice, and the
+		// default — no --model at all — is the only answer that cannot be wrong
+		// on a machine we have not asked yet.
+		dxModel: dispatchpkg.DefaultModel,
 	}
 }
 

--- a/internal/cockpit/pending_test.go
+++ b/internal/cockpit/pending_test.go
@@ -22,7 +22,7 @@ func stubLaunch(t *testing.T) *struct{ repo, feature, prompt string } {
 	t.Helper()
 	got := &struct{ repo, feature, prompt string }{}
 	prev := dxLaunch
-	dxLaunch = func(_ *config.Config, repo, feature, prompt string, _ dispatchpkg.Mode) tea.Cmd {
+	dxLaunch = func(_ *config.Config, repo, feature, prompt string, _ dispatchpkg.Mode, _ dispatchpkg.Model, _ bool) tea.Cmd {
 		got.repo, got.feature, got.prompt = repo, feature, prompt
 		return nil
 	}

--- a/internal/cockpit/product.go
+++ b/internal/cockpit/product.go
@@ -713,11 +713,11 @@ func (m model) updateProduct(k string) (model, tea.Cmd) {
 			}
 			m.notice = "dispatching \"" + t.feature + "\" again…"
 			// Same reading as the backlog's enter: this panel asks for a line of
-			// text, not for a mode, so the re-dispatch takes the default rather
-			// than inheriting the finished dispatcher's — the human typed a new
-			// brief, and a mode chosen for the last run is not consent for this
-			// one.
-			return m, launchCmd(m.cfg, t.repo, t.feature, text, dispatchpkg.DefaultMode)
+			// text, not for a mode, a model or a fan-out, so the re-dispatch
+			// takes the defaults rather than inheriting the finished
+			// dispatcher's — the human typed a new brief, and choices made for
+			// the last run are not consent for this one.
+			return m, launchCmd(m.cfg, t.repo, t.feature, text, dispatchpkg.DefaultMode, dispatchpkg.DefaultModel, false)
 		}
 		m.resumeText = next
 		return m, nil

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -69,10 +69,14 @@ func capSlug(s string) string {
 // CLAUDE_DISPATCHER_ID environment variable is the join key that lets the
 // lifecycle hook attribute events back to this record.
 //
-// mode is the permission mode the session opens in; it goes on the record as
-// well as on the command line, because Resume has to reopen the session the way
-// it was dispatched and the transcript does not carry it.
-func Launch(r repos.Repo, feature, prompt string, mode Mode) (*state.Dispatch, error) {
+// mode is the permission mode the session opens in and model is the model it
+// runs; both go on the record as well as on the command line, because Resume
+// has to reopen the session the way it was dispatched and the transcript does
+// not carry either. fanOut is the third form choice, and it travels in the
+// prompt rather than as a flag (see fanout.go): when set, the prompt gains the
+// ultracode sentence before anything records or runs it, so the record's
+// Prompt is the prompt the session actually received.
+func Launch(r repos.Repo, feature, prompt string, mode Mode, model Model, fanOut bool) (*state.Dispatch, error) {
 	slug := Slugify(feature)
 	if slug == "" {
 		return nil, fmt.Errorf("feature name %q produces an empty slug", feature)
@@ -97,6 +101,8 @@ func Launch(r repos.Repo, feature, prompt string, mode Mode) (*state.Dispatch, e
 	}
 
 	mode = mode.Normalize()
+	model = model.Normalize()
+	prompt = withFanOut(prompt, fanOut)
 	d := &state.Dispatch{
 		ID:           state.NewID(),
 		Feature:      feature,
@@ -109,6 +115,8 @@ func Launch(r repos.Repo, feature, prompt string, mode Mode) (*state.Dispatch, e
 		BaseSHA:      baseSHA,
 		Prompt:       prompt,
 		Mode:         string(mode),
+		Model:        string(model),
+		FanOut:       fanOut,
 		TmuxSession:  uniqueName("disp-" + slug),
 		Status:       state.StatusLaunching,
 		CreatedAt:    time.Now(),
@@ -120,7 +128,7 @@ func Launch(r repos.Repo, feature, prompt string, mode Mode) (*state.Dispatch, e
 	// launchCommand is OS-specific (bash on Unix, cmd.exe on Windows); it keeps
 	// the session's window open after claude exits so it stays available for
 	// inspection instead of vanishing.
-	cmd := launchCommand(d.ID, prompt, mode)
+	cmd := launchCommand(d.ID, prompt, mode, model)
 	if err := newSession(d.TmuxSession, worktree, cmd); err != nil {
 		d.Status = state.StatusExited
 		d.StatusReason = "tmux launch failed"

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -211,7 +211,7 @@ func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
 		sessionAlive, sessionIdle, newSession, uniqueName = prevAlive, prevIdle, prevNew, prevUniq
 	}()
 
-	_, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go", ModeAuto)
+	_, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go", ModeAuto, DefaultModel, false)
 	if err == nil {
 		t.Fatal("expected a duplicate of a live feature to be refused")
 	}
@@ -235,15 +235,27 @@ func TestLaunchRefusesDuplicateOfLiveFeature(t *testing.T) {
 	if got := liveDispatch("payment-retry"); got != nil {
 		t.Errorf("a leftover login shell reported as a live dispatcher: %#v", got)
 	}
-	d, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go", ModePlan)
+	withAliases(t, []string{"fable", "opus", "sonnet"})
+	d, err := Launch(repos.Repo{Name: "acme", Path: repo}, "payment retry", "go", ModePlan, Model("opus"), true)
 	if err != nil {
 		t.Errorf("re-dispatching a finished feature was refused: %v", err)
 	}
 	// The only Launch in the suite that runs to completion, so it is where the
-	// mode reaching the record is provable: Resume reads it back to reopen the
-	// dispatcher the way it went out.
+	// choices reaching the record are provable: Resume reads them back to
+	// reopen the dispatcher the way it went out.
 	if d != nil && d.Mode != string(ModePlan) {
 		t.Errorf("the record kept mode %q, want plan", d.Mode)
+	}
+	if d != nil && d.Model != "opus" {
+		t.Errorf("the record kept model %q, want opus", d.Model)
+	}
+	// Fan-out is a sentence in the prompt, not a flag, so the record has to
+	// carry both the flag for screens and the sentence the session was given.
+	if d != nil && !d.FanOut {
+		t.Error("the record lost the fan-out choice")
+	}
+	if d != nil && !strings.Contains(d.Prompt, "ultracode") {
+		t.Errorf("a fan-out dispatch's prompt carries no ultracode opt-in:\n%s", d.Prompt)
 	}
 }
 

--- a/internal/dispatch/fanout.go
+++ b/internal/dispatch/fanout.go
@@ -1,0 +1,32 @@
+package dispatch
+
+import "strings"
+
+// fanout.go is the dispatch form's FAN OUT switch: whether the session may
+// spread the work across multiple agents when the task warrants it.
+//
+// Unlike the mode and the model, fanning out is not a launch flag — Claude
+// Code's opt-in for multi-agent orchestration is the keyword "ultracode"
+// appearing in the prompt itself. So the switch is prompt composition: on, the
+// launch appends one sentence carrying the keyword; off, the prompt goes out
+// as written and the session works alone. The choice is recorded on the
+// dispatch (state.Dispatch.FanOut) so screens can say which kind of session
+// they are looking at, but it is a property of the brief, not of the session:
+// a resumed dispatcher's follow-up prompt is the human's own message, and this
+// never edits what a human typed.
+
+// FanOutInstruction is the sentence a fan-out dispatch closes its prompt with.
+// The word "ultracode" is the load-bearing part — it is Claude Code's opt-in
+// keyword for multi-agent workflows — and the rest keeps the offer
+// conditional: fan out where the task splits, not everywhere.
+const FanOutInstruction = "ultracode: fan out across multiple agents where the task splits into independent parts; work solo where it does not."
+
+// withFanOut appends the opt-in sentence when fanOut is on and the prompt does
+// not already carry the keyword — a human who typed "ultracode" themselves has
+// already opted in, and saying it twice reads as noise.
+func withFanOut(prompt string, fanOut bool) string {
+	if !fanOut || strings.Contains(strings.ToLower(prompt), "ultracode") {
+		return prompt
+	}
+	return prompt + "\n\n" + FanOutInstruction
+}

--- a/internal/dispatch/launchcmd_unix.go
+++ b/internal/dispatch/launchcmd_unix.go
@@ -10,32 +10,43 @@ import (
 // launchCommand builds the shell command that runs claude for a dispatch on
 // Unix. When claude exits we drop to a login shell so the tmux session stays
 // open for inspection instead of vanishing. CLAUDE_DISPATCHER_ID is the join
-// key the lifecycle hook reads to attribute events back to the record, and
-// mode is the permission mode the session opens in (see mode.go).
-func launchCommand(dispatcherID, prompt string, mode Mode) string {
-	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude%s %s; exec ${SHELL:-/bin/sh}",
-		dispatcherID, modeArgs(mode), shellQuote(prompt))
+// key the lifecycle hook reads to attribute events back to the record, mode is
+// the permission mode the session opens in (see mode.go), and model is the
+// model it runs (see model.go).
+func launchCommand(dispatcherID, prompt string, mode Mode, model Model) string {
+	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude%s%s %s; exec ${SHELL:-/bin/sh}",
+		dispatcherID, modeArgs(mode), modelArgs(model), shellQuote(prompt))
 }
 
 // resumeCommand is launchCommand for a session that already exists: claude
 // picks the recorded conversation back up instead of starting a new one, and an
 // empty prompt is left off entirely rather than passed as an empty argument,
-// which claude would read as a first message with nothing in it. The mode is
-// passed again because --permission-mode is a property of the new session, not
-// of the transcript it reopens.
-func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode) string {
+// which claude would read as a first message with nothing in it. The mode and
+// the model are passed again because both are properties of the new session,
+// not of the transcript it reopens.
+func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode, model Model) string {
 	arg := ""
 	if prompt != "" {
 		arg = " " + shellQuote(prompt)
 	}
-	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude%s --resume %s%s; exec ${SHELL:-/bin/sh}",
-		dispatcherID, modeArgs(mode), shellQuote(sessionID), arg)
+	return fmt.Sprintf("CLAUDE_DISPATCHER_ID=%s claude%s%s --resume %s%s; exec ${SHELL:-/bin/sh}",
+		dispatcherID, modeArgs(mode), modelArgs(model), shellQuote(sessionID), arg)
 }
 
 // modeArgs is the permission-mode flag as a leading-space-prefixed fragment,
 // or "" when this claude has no spelling for the mode.
 func modeArgs(mode Mode) string {
 	args := PermissionArgs(mode)
+	if len(args) == 0 {
+		return ""
+	}
+	return " " + strings.Join(args, " ")
+}
+
+// modelArgs is the model flag the same way, or "" for the default and for an
+// alias this claude does not advertise.
+func modelArgs(model Model) string {
+	args := ModelArgs(model)
 	if len(args) == 0 {
 		return ""
 	}

--- a/internal/dispatch/launchcmd_windows.go
+++ b/internal/dispatch/launchcmd_windows.go
@@ -14,24 +14,24 @@ import (
 // console window open after claude exits so it stays available for inspection
 // instead of vanishing (the Windows analogue of dropping to a login shell on
 // Unix).
-func launchCommand(dispatcherID, prompt string, mode Mode) string {
-	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude%s %s & pause`,
-		dispatcherID, modeArgs(mode), winQuote(prompt))
+func launchCommand(dispatcherID, prompt string, mode Mode, model Model) string {
+	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude%s%s %s & pause`,
+		dispatcherID, modeArgs(mode), modelArgs(model), winQuote(prompt))
 }
 
 // resumeCommand is launchCommand for a session that already exists: claude
 // picks the recorded conversation back up instead of starting a new one, and an
 // empty prompt is left off entirely rather than passed as an empty argument,
-// which claude would read as a first message with nothing in it. The mode is
-// passed again because --permission-mode is a property of the new session, not
-// of the transcript it reopens.
-func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode) string {
+// which claude would read as a first message with nothing in it. The mode and
+// the model are passed again because both are properties of the new session,
+// not of the transcript it reopens.
+func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode, model Model) string {
 	arg := ""
 	if prompt != "" {
 		arg = " " + winQuote(prompt)
 	}
-	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude%s --resume %s%s & pause`,
-		dispatcherID, modeArgs(mode), winQuote(sessionID), arg)
+	return fmt.Sprintf(`set "CLAUDE_DISPATCHER_ID=%s" && claude%s%s --resume %s%s & pause`,
+		dispatcherID, modeArgs(mode), modelArgs(model), winQuote(sessionID), arg)
 }
 
 // modeArgs is the permission-mode flag as a leading-space-prefixed fragment,
@@ -39,6 +39,16 @@ func resumeCommand(dispatcherID, sessionID, prompt string, mode Mode) string {
 // plain words, so they need no cmd.exe quoting.
 func modeArgs(mode Mode) string {
 	args := PermissionArgs(mode)
+	if len(args) == 0 {
+		return ""
+	}
+	return " " + strings.Join(args, " ")
+}
+
+// modelArgs is the model flag the same way, or "" for the default and for an
+// alias this claude does not advertise.
+func modelArgs(model Model) string {
+	args := ModelArgs(model)
 	if len(args) == 0 {
 		return ""
 	}

--- a/internal/dispatch/mode.go
+++ b/internal/dispatch/mode.go
@@ -178,6 +178,13 @@ var modeChoiceRe = regexp.MustCompile(`"([A-Za-z]+)"`)
 // the wrapped description without reaching the next option's own choices.
 const modeHelpWindow = 400
 
+// claudeHelp reads the installed claude's --help output, once per process:
+// it answers for the permission modes here and the model aliases in model.go,
+// and one subprocess is enough for both.
+var claudeHelp = sync.OnceValues(func() ([]byte, error) {
+	return exec.Command("claude", "--help").Output()
+})
+
 // readClaudeModeNames asks claude which permission modes it takes.
 //
 // Reading the help text is the only way to ask: there is no capability
@@ -186,7 +193,7 @@ const modeHelpWindow = 400
 // one spelling every version that ever had this flag accepts — is reported as
 // "nothing known", and PermissionArgs then passes no flag rather than a guess.
 func readClaudeModeNames() map[string]bool {
-	out, err := exec.Command("claude", "--help").Output()
+	out, err := claudeHelp()
 	if err != nil {
 		return nil
 	}

--- a/internal/dispatch/mode_test.go
+++ b/internal/dispatch/mode_test.go
@@ -102,7 +102,7 @@ func TestPermissionArgsSaysNothingWhenItCannotTell(t *testing.T) {
 func TestLaunchAndResumeCarryTheMode(t *testing.T) {
 	withModes(t, parseModeNames(modernHelp))
 
-	launch := launchCommand("abc123", "do the thing", ModePlan)
+	launch := launchCommand("abc123", "do the thing", ModePlan, DefaultModel)
 	if !strings.Contains(launch, "--permission-mode plan") {
 		t.Errorf("launch command has no mode flag:\n%s", launch)
 	}
@@ -110,7 +110,7 @@ func TestLaunchAndResumeCarryTheMode(t *testing.T) {
 		t.Errorf("launch command lost the prompt:\n%s", launch)
 	}
 
-	resume := resumeCommand("abc123", "sess-1", "", ModePlan)
+	resume := resumeCommand("abc123", "sess-1", "", ModePlan, DefaultModel)
 	if !strings.Contains(resume, "--permission-mode plan") {
 		t.Errorf("resume command has no mode flag:\n%s", resume)
 	}
@@ -121,7 +121,7 @@ func TestLaunchAndResumeCarryTheMode(t *testing.T) {
 	// And with nothing to pass, the command is exactly what it always was — no
 	// stray spaces where the flag would have gone.
 	withModes(t, nil)
-	if got := launchCommand("abc123", "go", ModeAuto); strings.Contains(got, "claude  ") {
+	if got := launchCommand("abc123", "go", ModeAuto, DefaultModel); strings.Contains(got, "claude  ") {
 		t.Errorf("a missing flag left a double space:\n%s", got)
 	}
 }

--- a/internal/dispatch/model.go
+++ b/internal/dispatch/model.go
@@ -1,0 +1,185 @@
+package dispatch
+
+// model.go is the model a dispatcher's claude session runs.
+//
+// Like the permission mode (mode.go), this is a launch flag: `--model` with an
+// alias like `opus` or `sonnet`. And like the mode, the offer has to come from
+// the claude actually installed — its help text names the aliases it takes, and
+// a flag value we invented would either kill the launch or open a session that
+// errors on its first message with nobody watching. So the form offers exactly
+// two kinds of answer: "default", which passes no flag and lets the session
+// open on whatever the human's own Claude Code is configured for, and the
+// aliases this machine's claude advertises.
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// Model is which model the session is asked to run — a claude CLI alias, or
+// ModelDefault for "pass no flag".
+type Model string
+
+// ModelDefault passes no --model at all: the session opens on whatever the
+// human's own Claude Code defaults to, which is exactly what every dispatch
+// did before the model was a choice.
+const ModelDefault Model = "default"
+
+// DefaultModel is what a dispatch runs when nothing chose one.
+const DefaultModel = ModelDefault
+
+// Models is the offer order: the no-flag default first — taking it is one
+// keypress, and it is the only answer that cannot be wrong — then the aliases
+// the installed claude advertises, in the order its help names them.
+func Models() []Model {
+	out := []Model{ModelDefault}
+	for _, a := range claudeModelAliases() {
+		out = append(out, Model(a))
+	}
+	return out
+}
+
+// Known reports whether m names a model this machine's claude offers — the
+// test for whether a record actually recorded a choice this build can read.
+func (m Model) Known() bool {
+	for _, k := range Models() {
+		if m == k {
+			return true
+		}
+	}
+	return false
+}
+
+// Normalize resolves what to launch with. Empty, unrecognised, or an alias
+// this machine's claude does not advertise all become ModelDefault: there is
+// no older spelling to fall back to the way modes have, and no flag at all is
+// the one value that launches everywhere.
+//
+// Like the mode, this is a launch-time answer, not a display one: a record
+// written before the model existed carries "", and screens read that as
+// unknown rather than calling it the default, because a record that never
+// chose did not choose.
+func (m Model) Normalize() Model {
+	if m.Known() {
+		return m
+	}
+	return ModelDefault
+}
+
+// Hint is the one line a form shows beside the model. Capability claims would
+// go stale with every release, so the hints say only what the choice does.
+func (m Model) Hint() string {
+	if m.Normalize() == ModelDefault {
+		return "whatever your own claude is set to"
+	}
+	return "runs the latest " + capitalize(string(m.Normalize()))
+}
+
+// capitalize upper-cases the first rune, for reading an alias as a name.
+func capitalize(s string) string {
+	r := []rune(s)
+	if len(r) == 0 {
+		return s
+	}
+	return strings.ToUpper(string(r[0])) + string(r[1:])
+}
+
+// NextModel and PrevModel walk the offer, so one key can cycle a switch.
+func NextModel(m Model) Model {
+	all := Models()
+	for i, k := range all {
+		if k == m {
+			return all[(i+1)%len(all)]
+		}
+	}
+	return all[0]
+}
+
+func PrevModel(m Model) Model {
+	all := Models()
+	for i, k := range all {
+		if k == m {
+			return all[(i+len(all)-1)%len(all)]
+		}
+	}
+	return all[0]
+}
+
+// ModelArgs is the launch flag for m, as command-line words — empty for the
+// default, and empty for an alias this claude does not advertise. A dispatch
+// resumed on a machine whose claude no longer names the recorded alias opens
+// on that build's own default rather than being handed a value it may reject:
+// a rejected flag is not a degraded session — it is a launch that never
+// happens.
+func ModelArgs(m Model) []string {
+	m = m.Normalize()
+	if m == ModelDefault {
+		return nil
+	}
+	return []string{"--model", string(m)}
+}
+
+// claudeModelAliases is the list of --model aliases the installed claude
+// advertises, read once per process. A variable so tests can answer for it
+// instead of depending on whichever claude is on the test machine's PATH.
+var claudeModelAliases = sync.OnceValue(readClaudeModelAliases)
+
+// modelAliasRe pulls the quoted aliases out of the flag's description —
+// claude's help quotes them 'like this', unlike the mode choices' "this".
+var modelAliasRe = regexp.MustCompile(`'([a-z][a-z0-9-]*)'`)
+
+// modelHelpWindow bounds how far past `--model ` the aliases may sit; the
+// description wraps, so they span lines.
+const modelHelpWindow = 400
+
+// readClaudeModelAliases asks claude which model aliases it takes.
+//
+// Reading the help text is the only way to ask, and the help does not
+// enumerate choices the way --permission-mode does — it names example aliases
+// in prose ("an alias for the latest model (e.g. 'fable', 'opus', or
+// 'sonnet')"). Those examples are the aliases worth offering: a name the help
+// does not vouch for is a guess, and a guessed model is a session erroring on
+// its first message with nobody watching it.
+func readClaudeModelAliases() []string {
+	out, err := claudeHelp()
+	if err != nil {
+		return nil
+	}
+	return parseModelAliases(string(out))
+}
+
+// parseModelAliases pulls the advertised aliases out of claude's help text.
+func parseModelAliases(help string) []string {
+	// "--model " with the trailing space: --fallback-model and the <model>
+	// placeholders must not anchor the window.
+	i := strings.Index(help, "--model ")
+	if i < 0 {
+		return nil
+	}
+	rest := help[i:]
+	if len(rest) > modelHelpWindow {
+		rest = rest[:modelHelpWindow]
+	}
+	var names []string
+	sane := false
+	for _, m := range modelAliasRe.FindAllStringSubmatch(rest, -1) {
+		a := m[1]
+		if strings.Contains(a, "-") {
+			// A full model name ('claude-fable-5') — an example of the other
+			// argument form, not an alias to offer.
+			continue
+		}
+		names = append(names, a)
+		if a == "opus" || a == "sonnet" {
+			sane = true
+		}
+	}
+	if !sane {
+		// Not the list we were looking for — the format changed, or the window
+		// caught someone else's quotes. Claiming these names would be claiming
+		// a launch that works.
+		return nil
+	}
+	return names
+}

--- a/internal/dispatch/model_test.go
+++ b/internal/dispatch/model_test.go
@@ -1,0 +1,194 @@
+package dispatch
+
+// model_test.go covers the model choice: what the form may offer, what reaches
+// the command line, and what happens on a machine whose claude advertises
+// nothing — plus the fan-out sentence, which is the prompt's half of the same
+// form.
+
+import (
+	"strings"
+	"testing"
+)
+
+// modelHelp is the shape claude's help has today: --fallback-model sits above
+// --model (so a naive substring anchor grabs the wrong flag), the aliases are
+// quoted in prose, and a full model name is quoted right beside them.
+const modelHelp = `Options:
+  --fallback-model <model>              Enable automatic fallback to specified
+                                        model(s) when the default model is
+                                        overloaded (only works with --print)
+  --model <model>                       Model for the current session. Provide
+                                        an alias for the latest model (e.g.
+                                        'fable', 'opus', or 'sonnet') or a
+                                        model's full name (e.g.
+                                        'claude-fable-5').
+`
+
+// withAliases answers for the installed claude so a test never depends on
+// whichever one is on the machine's PATH.
+func withAliases(t *testing.T, aliases []string) {
+	t.Helper()
+	prev := claudeModelAliases
+	claudeModelAliases = func() []string { return aliases }
+	t.Cleanup(func() { claudeModelAliases = prev })
+}
+
+func TestParseModelAliasesReadsTheAdvertisedAliases(t *testing.T) {
+	got := parseModelAliases(modelHelp)
+	want := []string{"fable", "opus", "sonnet"}
+	if len(got) != len(want) {
+		t.Fatalf("parseModelAliases = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseModelAliases = %v, want %v", got, want)
+		}
+	}
+}
+
+// A help output we cannot read yields no aliases, and the offer collapses to
+// the default — never to a guess.
+func TestParseModelAliasesSaysNothingWhenItCannotTell(t *testing.T) {
+	for _, help := range []string{
+		"Usage: claude [options]\n  --permission-mode <mode>  the mode\n", // no such flag
+		"  --model <model>   Model for the current session",               // no quoted aliases
+		"  --model <model>   an alias (e.g. 'wibble' or 'wobble')",        // not a list we recognise
+	} {
+		if got := parseModelAliases(help); got != nil {
+			t.Errorf("help %q yielded %v, want nothing", help, got)
+		}
+	}
+}
+
+// The offer is the default first — the one answer that cannot be wrong — then
+// whatever this machine's claude advertises, and nothing else.
+func TestModelsOffersDefaultThenAdvertised(t *testing.T) {
+	withAliases(t, parseModelAliases(modelHelp))
+	all := Models()
+	if all[0] != ModelDefault {
+		t.Fatalf("Models() opens on %q, want the default", all[0])
+	}
+	if len(all) != 4 || all[1] != "fable" || all[2] != "opus" || all[3] != "sonnet" {
+		t.Fatalf("Models() = %v", all)
+	}
+
+	withAliases(t, nil)
+	if all := Models(); len(all) != 1 || all[0] != ModelDefault {
+		t.Fatalf("with nothing advertised, Models() = %v, want just the default", all)
+	}
+}
+
+func TestModelArgsNamesTheChosenModel(t *testing.T) {
+	withAliases(t, []string{"fable", "opus", "sonnet"})
+	if args := ModelArgs(Model("opus")); len(args) != 2 || args[0] != "--model" || args[1] != "opus" {
+		t.Errorf("ModelArgs(opus) = %v", args)
+	}
+	// The default is the absence of the flag, and so is anything this claude
+	// does not advertise: a value it may reject is a launch that never happens.
+	if args := ModelArgs(ModelDefault); args != nil {
+		t.Errorf("ModelArgs(default) = %v, want no flag", args)
+	}
+	if args := ModelArgs(Model("haiku")); args != nil {
+		t.Errorf("ModelArgs(unadvertised) = %v, want no flag", args)
+	}
+	withAliases(t, nil)
+	if args := ModelArgs(Model("opus")); args != nil {
+		t.Errorf("with nothing advertised, ModelArgs(opus) = %v, want no flag", args)
+	}
+}
+
+func TestModelNormalizeAndKnown(t *testing.T) {
+	withAliases(t, []string{"opus", "sonnet"})
+	if got := Model("opus").Normalize(); got != "opus" {
+		t.Errorf("Normalize(opus) = %q", got)
+	}
+	for _, in := range []Model{"", "nonsense", "OPUS"} {
+		if got := in.Normalize(); got != ModelDefault {
+			t.Errorf("Model(%q).Normalize() = %q, want the default", in, got)
+		}
+	}
+	// A record written before the model existed did not choose the default —
+	// it did not choose. Screens read Known, not Normalize, so they can say so.
+	if Model("").Known() {
+		t.Error("an unset model must not report as a model that was chosen")
+	}
+}
+
+func TestModelCyclesBothWays(t *testing.T) {
+	withAliases(t, []string{"opus", "sonnet"})
+	all := Models()
+	m := all[0]
+	for range all {
+		m = NextModel(m)
+	}
+	if m != all[0] {
+		t.Errorf("cycling through every model landed on %q, want %q", m, all[0])
+	}
+	if got := PrevModel(all[0]); got != all[len(all)-1] {
+		t.Errorf("PrevModel(%q) = %q, want the last model", all[0], got)
+	}
+	if got := NextModel(""); got != all[0] {
+		t.Errorf("NextModel(\"\") = %q, want %q", got, all[0])
+	}
+}
+
+// Each offered model says something about itself, and none of it names a key.
+func TestModelHintsAreDistinctAndKeyless(t *testing.T) {
+	withAliases(t, []string{"fable", "opus", "sonnet"})
+	seen := map[string]bool{}
+	for _, m := range Models() {
+		h := m.Hint()
+		if h == "" || seen[h] {
+			t.Errorf("Model(%q).Hint() = %q — empty or a repeat", m, h)
+		}
+		seen[h] = true
+		for _, key := range []string{"space", "enter", "tab"} {
+			if strings.Contains(h, key) {
+				t.Errorf("Model(%q).Hint() names the %q key: %q", m, key, h)
+			}
+		}
+	}
+}
+
+// The launch and resume commands carry the flag, and carry the same one: a
+// resumed dispatcher that came back on a different model than it went out on
+// would be a change nobody asked for.
+func TestLaunchAndResumeCarryTheModel(t *testing.T) {
+	withModes(t, parseModeNames(modernHelp))
+	withAliases(t, []string{"opus", "sonnet"})
+
+	launch := launchCommand("abc123", "do the thing", ModeAuto, Model("opus"))
+	if !strings.Contains(launch, "--model opus") {
+		t.Errorf("launch command has no model flag:\n%s", launch)
+	}
+	resume := resumeCommand("abc123", "sess-1", "", ModeAuto, Model("opus"))
+	if !strings.Contains(resume, "--model opus") {
+		t.Errorf("resume command has no model flag:\n%s", resume)
+	}
+
+	// And the default leaves the command exactly what it always was — no
+	// stray spaces where the flag would have gone.
+	withModes(t, nil)
+	if got := launchCommand("abc123", "go", ModeAuto, ModelDefault); strings.Contains(got, "claude  ") {
+		t.Errorf("a missing flag left a double space:\n%s", got)
+	}
+}
+
+// Fan-out is not a flag: it is the ultracode keyword, appended once.
+func TestWithFanOutAppendsTheOptInOnce(t *testing.T) {
+	if got := withFanOut("fix the bug", false); got != "fix the bug" {
+		t.Errorf("fan-out off changed the prompt: %q", got)
+	}
+	on := withFanOut("fix the bug", true)
+	if !strings.Contains(on, "ultracode") {
+		t.Errorf("fan-out on carries no ultracode keyword:\n%s", on)
+	}
+	if !strings.HasPrefix(on, "fix the bug") {
+		t.Errorf("fan-out rewrote the human's prompt:\n%s", on)
+	}
+	// A human who already typed the keyword has already opted in.
+	already := "do this, and ULTRACODE the hard parts"
+	if got := withFanOut(already, true); got != already {
+		t.Errorf("the opt-in was said twice:\n%s", got)
+	}
+}

--- a/internal/dispatch/resume.go
+++ b/internal/dispatch/resume.go
@@ -118,13 +118,13 @@ func Resume(d *state.Dispatch, prompt string) (ResumeMode, string, error) {
 	if base == "disp-" {
 		base = "disp-" + d.ID
 	}
-	// The mode it was dispatched in, so reopening a dispatcher does not quietly
-	// change what it may do without asking. A record from before the mode was a
-	// choice normalises to the default rather than inheriting nothing: --resume
-	// still has to be given some mode, and the default is the one the form
-	// would offer.
+	// The mode and model it was dispatched in, so reopening a dispatcher does
+	// not quietly change what it may do without asking or what it runs on. A
+	// record from before either was a choice normalises to the default rather
+	// than inheriting nothing: --resume still has to be given some mode, and
+	// the default is the one the form would offer.
 	name := uniqueName(base)
-	if err := newSession(name, dir, resumeCommand(d.ID, sid, prompt, Mode(d.Mode))); err != nil {
+	if err := newSession(name, dir, resumeCommand(d.ID, sid, prompt, Mode(d.Mode), Model(d.Model))); err != nil {
 		return "", "", err
 	}
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -73,7 +73,20 @@ type Dispatch struct {
 	// reading the mode it was actually launched with. Empty on records written
 	// before the mode was a choice: those ran in whatever claude defaulted to,
 	// which is not the same fact as "auto".
-	Mode           string `json:"mode,omitempty"`
+	Mode string `json:"mode,omitempty"`
+	// Model is the model the session was asked to run — one of
+	// dispatch.Models(): "default" for "no --model passed", or a claude alias
+	// like "opus". On the record for the same reason Mode is: Resume reopens
+	// the session the way it went out. Empty on records written before the
+	// model was a choice — those sessions ran whatever claude defaulted to,
+	// which is the same behaviour as "default" but not the same fact.
+	Model string `json:"model,omitempty"`
+	// FanOut records that the prompt closed with the ultracode fan-out
+	// sentence (see dispatch/fanout.go): the session was invited to spread the
+	// work across multiple agents where the task warranted it. The sentence
+	// itself lives in Prompt; this flag is what lets screens say so without
+	// grepping the prompt for a keyword.
+	FanOut         bool   `json:"fan_out,omitempty"`
 	TmuxSession    string `json:"tmux_session"`
 	SessionID      string `json:"session_id,omitempty"`
 	TranscriptPath string `json:"transcript_path,omitempty"`


### PR DESCRIPTION
## What

Both dispatch forms — the triage lens's dx form and the `+` overlay — gain two choices beside MODE:

- **MODEL** — which model the session runs, as `--model`. The offer is read from the installed claude's own help, the way the permission mode's choices are: "default" passes no flag at all (the human's own Claude Code decides), and the aliases offered are exactly the ones `claude --help` names for `--model` ('fable', 'opus', 'sonnet' today). An alias the help does not vouch for is never offered and never passed — a rejected value is a launch that dies, or a session erroring on its first message with nobody watching. The choice is recorded and Resume passes it again, alongside `--permission-mode`.
- **FAN OUT** — whether the session may spread across multiple agents when the task splits. There is no flag for this: Claude Code's multi-agent opt-in is the keyword "ultracode" in the prompt, so the switch is prompt composition — on, the launch appends one closing sentence carrying the keyword (skipped when the human already typed it), records the composed prompt, and sets `FanOut` on the record so screens need not grep for it. Not re-applied on resume: the transcript already carries it, and a resume prompt is the human's own message.

The ask-nothing paths (backlog enter/ctrl+d, product-panel re-dispatch) launch on the defaults, for the same reason they take the default mode.

## Decision record

`docs/adr/0002-model-is-a-flag-fan-out-is-a-sentence.md`, plus the CLAUDE.md bullet pointing at it.

## Tests

- `internal/dispatch/model_test.go`: help parsing (anchored past `--fallback-model`), offer order, `ModelArgs` refusing unvouched aliases, cycling, hints, launch/resume command lines, fan-out sentence composition.
- The completed-`Launch` test now proves model + fan-out reach the record and the prompt carries the ultracode opt-in.
- Both forms' flow tests walk the new steps; the dx form's submit test asserts model + fan-out reach the launch seam.