### PR TITLE
Sweep dead sessions on every load, so a ghost cannot outlive its tmux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,23 @@
   exited. It never sweeps `launching`: no hook has fired for one, so its
   session may simply not exist *yet* — absence is only evidence where a hook
   proved the session once existed.
+- **A ghost cannot clear itself, so every load looks.** That sweep ran in one
+  place — `recheckCmd`, the reload after a jump-in — so a record whose session
+  had been taken away claimed *working* for as long as the cockpit stayed open
+  and its row went on offering ⏎ attach, which found no session, said so and
+  changed nothing: the only thing that would have retired it was coming back
+  from an attach that could never happen. It is swept on every `loadSnapshot`
+  now, in the boot stage that already asks the supervisor what is running (and
+  reports what it retired), off ONE `supervisor.Sessions` listing rather than a
+  probe per record, because a load happens on every poll and every state-file
+  change. The listing only screens: a record it does not name is asked about
+  directly before anything is written, since a failed listing comes back empty
+  and an empty listing must never retire a fleet. ⏎ on a ghost runs the same
+  sweep on that record and points at history, where ⏎ resumes — the human
+  pressing the key is how a ghost gets found. Reported from WSL, where the
+  distro shuts down with its last console and takes tmux with it; a suspended
+  laptop or a reboot makes the same row anywhere. The full record is
+  `docs/adr/0004-a-ghost-cannot-clear-itself.md`.
 - **Coming back from a jump-in rechecks, it does not redraw.** The human has
   just spent minutes driving the session by hand, so `cockpit.recheckCmd`
   drops the gh cache, sweeps session liveness, reconciles PR/deploy and only

--- a/docs/adr/0004-a-ghost-cannot-clear-itself.md
+++ b/docs/adr/0004-a-ghost-cannot-clear-itself.md
@@ -1,0 +1,76 @@
+# A ghost cannot clear itself: liveness is swept on every load
+
+## Status
+
+Accepted (2026-08-17)
+
+## Context
+
+Status comes from Claude Code hooks, and they are truth right up to the
+moment a session dies without getting a `SessionEnd` out: a SIGKILL, a
+`tmux kill-session` from another terminal, a machine that took the tmux
+server down with it. `dispatch.ReconcileSessions` exists for exactly that —
+it retires a working/needs-input/blocked record whose session is gone.
+
+It was wired into one caller: `cockpit.recheckCmd`, the reload that runs
+when the human comes back from a jump-in. Nothing else swept. Not the
+opening load, not the 60s poll, not the fsnotify reload.
+
+So a record whose session had been taken away went on claiming *working* for
+as long as the cockpit was open, and its triage row went on offering ⏎
+attach. Attach checks the session, finds nothing, sets a notice and changes
+nothing — and the one thing that would have retired the record was coming
+back from an attach that could never happen. The state that made the row
+un-attachable was the state only a successful attach could clear.
+
+It was reported from WSL, and WSL is why it was reported there: the distro
+shuts down when its last console closes, taking every tmux session with it,
+so a fresh cockpit opened on a fleet of dispatchers that no longer existed.
+On macOS a tmux server survives for weeks, so the same ghosts are rare
+enough to look like a WSL bug. They are not — a suspended laptop, a reboot
+or a stray `tmux kill-server` produces the identical row anywhere. The
+human's reading was "once you have dispatched something you can no longer
+attach"; the giveaway was that a newly dispatched one attached fine, and the
+old row disappeared moments after the new one's jump-in returned — that
+return was the sweep finally running.
+
+## Decision
+
+Session liveness is reconciled on **every** snapshot load, in the
+`LIVE SESSIONS` boot stage that already asks the supervisor what is running.
+The stage retires what it finds and reports it ("0 sessions live of 1 · 1
+ghost retired"), and the sweep writes through the records the load then
+builds its snapshot from, so the collectors see the corrected status.
+
+The sweep reads the whole fleet from ONE listing (`supervisor.Sessions`)
+rather than a probe per record, because a load happens on every poll and
+every state-file change. The listing screens; it never convicts. A record
+the listing does not mention is asked about directly before anything is
+written, since a failed listing comes back empty and an empty listing must
+never be read as "the whole fleet died" — the same reason an unreachable
+supervisor sweeps nothing. That costs one subprocess per record about to be
+retired, and a retired record is skipped by every pass after it.
+
+What counts as evidence has not changed. Only the three statuses a hook
+proved a session behind are swept, and `launching` is still never swept: no
+hook has fired for one, so its session may simply not exist *yet*.
+
+⏎ on a ghost that slipped through between loads no longer merely refuses. It
+runs the same sweep on that one record and says where the dispatcher went —
+"retired · h for history, where ⏎ resumes it" — because the human pressing
+the key is how a ghost gets discovered, and a refusal leaves the same dead
+key on the same lying row. The decision stays with the sweep: on a record
+still `launching` it retires nothing and the notice says it is starting.
+
+## Consequences
+
+- `recheckCmd` still sweeps before `track.Refresh`, for that path's ordering
+  — it is no longer the only way in.
+- The cockpit costs one `tmux list-sessions` per load. It replaces the one
+  the opening screen already ran to count live sessions: `ReconcileSessions`
+  returns that count as a byproduct, so nothing asks twice.
+- A dispatcher whose machine ate its session lands in history (`h`) within
+  one load, where ⏎ resumes it — a real recovery, where the ghost row's ⏎
+  was a key that could never work.
+- Killing tmux out from under a running cockpit is now visible within a
+  poll rather than never.

--- a/internal/cockpit/actions.go
+++ b/internal/cockpit/actions.go
@@ -29,6 +29,18 @@ type actionMsg struct{ notice string }
 type attachReturnedMsg struct{ err error }
 
 // attach hands the terminal to the feature's tmux session.
+//
+// A row offering "attach" whose session is not there is a ghost: the record
+// still claims a status only a hook could have written, and the session that
+// wrote it has since been taken away. Pressing ⏎ on one is how the human finds
+// out, so this does not merely refuse — it retires the record on the spot,
+// through the same sweep the load runs, and says where the dispatcher went. A
+// notice alone would leave the row on the table saying "working", offering the
+// same key, forever.
+//
+// The sweep is what decides, not this function, because the rule about what
+// absence proves lives there: a launching record has had no hook at all, so its
+// session may simply not exist yet and nothing is claimed about it.
 func (m model) attach(feature string) (model, tea.Cmd) {
 	rec := recordFor(feature)
 	if rec == nil {
@@ -36,7 +48,21 @@ func (m model) attach(feature string) (model, tea.Cmd) {
 		return m, nil
 	}
 	if !supervisor.HasSession(rec.TmuxSession) {
-		m.notice = "no live tmux session for \"" + feature + "\""
+		if retired, _ := reconcileSessions([]*state.Dispatch{rec}); retired > 0 {
+			m.notice = "\"" + feature + "\" lost its " + supervisor.Backend() +
+				" session — retired · h for history, where ⏎ resumes it"
+			if m.cfg != nil {
+				return m, loadSnapshotCmd(m.cfg)
+			}
+			return m, nil
+		}
+		if rec.Status == state.StatusLaunching {
+			// Nothing has fired a hook for it, so its session may not exist yet
+			// rather than not exist at all — the one absence that proves nothing.
+			m.notice = "\"" + feature + "\" is still starting — no " + supervisor.Backend() + " session yet"
+			return m, nil
+		}
+		m.notice = "no live " + supervisor.Backend() + " session for \"" + feature + "\""
 		return m, nil
 	}
 	return m.attachSession(rec.TmuxSession)

--- a/internal/cockpit/actions_test.go
+++ b/internal/cockpit/actions_test.go
@@ -69,6 +69,68 @@ func TestAttachNoTmuxSession(t *testing.T) {
 	}
 }
 
+// withFakeSweep swaps the stray-session sweep for one that answers from the
+// test, so these cases do not need a real tmux server (CI has none) and can
+// still say what the sweep found.
+func withFakeSweep(t *testing.T, retired, live int) *int {
+	t.Helper()
+	prev := reconcileSessions
+	t.Cleanup(func() { reconcileSessions = prev })
+	calls := 0
+	reconcileSessions = func([]*state.Dispatch) (int, int) {
+		calls++
+		return retired, live
+	}
+	return &calls
+}
+
+// A row offering "attach" whose session is gone is a ghost: the record claims a
+// status only a hook could have written, and the session that wrote it has been
+// taken away. Pressing ⏎ is how the human meets one, so it must retire the
+// record and name the way on — not refuse and leave the same dead key on the
+// same row.
+func TestAttachRetiresAGhostAndSaysWhereItWent(t *testing.T) {
+	withFakeRecord(t, "phantom", &state.Dispatch{
+		Feature: "phantom", TmuxSession: "cockpit-test-does-not-exist-8231",
+		Status: state.StatusWorking,
+	})
+	calls := withFakeSweep(t, 1, 0)
+
+	m := newModel()
+	m.cfg = &config.Config{}
+	mm, cmd := m.attach("phantom")
+	if *calls != 1 {
+		t.Fatalf("the sweep ran %d times, want 1 — attach must not decide this itself", *calls)
+	}
+	if cmd == nil {
+		t.Error("a retired record must be reloaded, or the table keeps showing it as working")
+	}
+	if !strings.Contains(mm.notice, "retired") || !strings.Contains(mm.notice, "history") {
+		t.Errorf("notice = %q, want the retirement and where the dispatcher went", mm.notice)
+	}
+}
+
+// The one absence that proves nothing: a launching record has had no hook, so
+// its session may not exist YET. The sweep declines to retire it, and attach
+// must say that rather than reporting a dispatcher as lost mid-launch.
+func TestAttachDoesNotRetireADispatcherStillStarting(t *testing.T) {
+	withFakeRecord(t, "starting", &state.Dispatch{
+		Feature: "starting", TmuxSession: "cockpit-test-does-not-exist-8232",
+		Status: state.StatusLaunching,
+	})
+	withFakeSweep(t, 0, 0)
+
+	m := newModel()
+	m.cfg = &config.Config{}
+	mm, cmd := m.attach("starting")
+	if cmd != nil {
+		t.Error("nothing changed, so nothing to reload")
+	}
+	if !strings.Contains(mm.notice, "still starting") {
+		t.Errorf("notice = %q, want the launch window named", mm.notice)
+	}
+}
+
 func TestKillCmdNothingToKill(t *testing.T) {
 	saved := captureVars()
 	defer restoreVars(saved)

--- a/internal/cockpit/live.go
+++ b/internal/cockpit/live.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"claude-dispatcher/internal/config"
+	dispatchpkg "claude-dispatcher/internal/dispatch"
 	"claude-dispatcher/internal/effort"
 	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/repos"
@@ -190,6 +191,11 @@ func readForge(repoPath string) string {
 	return "gh"
 }
 
+// reconcileSessions is the stray-session sweep, as a seam: the rule about what
+// a missing session proves belongs to internal/dispatch, and a test swaps this
+// to assert that the load runs it at all without standing up a tmux server.
+var reconcileSessions = dispatchpkg.ReconcileSessions
+
 // loadSnapshot assembles a full snapshot from the real backends. Each collector
 // fills its own fields; collectors live in collect_*.go.
 func loadSnapshot(cfg *config.Config) snapshot { return loadSnapshotReporting(cfg, nil) }
@@ -213,8 +219,19 @@ func loadSnapshotReporting(cfg *config.Config, r bootReport) snapshot {
 	r.done(bootRecords, countOf(len(records), "dispatch", "dispatches"), false)
 
 	r.begin(bootSessions, "asking "+supervisor.Backend()+" what is still running…")
-	live := liveSessions(records)
-	r.done(bootSessions, countOf(live, "session", "sessions")+" live of "+itoa(len(records)), false)
+	// Asking is also answering: the sweep runs here, on every load, so a record
+	// whose session died without getting a SessionEnd out stops claiming to be
+	// working the moment the cockpit next looks. See ReconcileSessions for what
+	// counts as evidence, and the "a ghost can only be cleared by attaching to
+	// it" decision in CLAUDE.md for why this cannot be left to the jump-in.
+	// The sweep writes to the records in this slice, so every collector below
+	// reads the corrected status rather than the one on disk when it was read.
+	retired, live := reconcileSessions(records)
+	sessionsFound := countOf(live, "session", "sessions") + " live of " + itoa(len(records))
+	if retired > 0 {
+		sessionsFound += " · " + countOf(retired, "ghost", "ghosts") + " retired"
+	}
+	r.done(bootSessions, sessionsFound, false)
 
 	roots := cfg.ExpandedRoots()
 	r.begin(bootRepos, "scanning "+countOf(len(roots), "root", "roots")+"…")
@@ -285,27 +302,13 @@ func loadSnapshotReporting(cfg *config.Config, r bootReport) snapshot {
 	return s
 }
 
-// liveSessions counts the recorded dispatches whose supervisor session is still
-// running, from one listing rather than a probe per record.
-//
-// It is read for the opening screen alone. The cockpit's own notion of what is
-// live comes from the records the lifecycle hook writes, and replacing that
-// with a session probe would be a different change with different consequences
-// — a session can outlive the work in it, and the work can outlive a session
-// the human killed by hand.
-func liveSessions(records []*state.Dispatch) int {
-	alive := map[string]bool{}
-	for _, name := range supervisor.Sessions() {
-		alive[name] = true
-	}
-	n := 0
-	for _, rec := range records {
-		if rec.TmuxSession != "" && alive[rec.TmuxSession] {
-			n++
-		}
-	}
-	return n
-}
+// The count of live sessions used to be read here, by a listing of its own, for
+// the opening screen alone. ReconcileSessions returns it now: it takes the same
+// listing for the sweep, and two callers asking the supervisor the same
+// question in the same load is one subprocess for nothing. Nothing else about
+// what the cockpit treats as live has moved — the sweep still only touches the
+// three statuses a hook proved a session behind, because a session can outlive
+// the work in it, and the work can outlive a session the human killed by hand.
 
 // namedProducts counts real products, excluding the bucket every unmapped repo
 // is folded into — the same distinction the header's portfolio line makes.

--- a/internal/cockpit/live_test.go
+++ b/internal/cockpit/live_test.go
@@ -141,3 +141,48 @@ func TestLiveSnapshotEmpty(t *testing.T) {
 		}
 	}
 }
+
+// The sweep that retires a dispatcher whose session is gone has to run on the
+// ORDINARY load, not only on the reload that follows a jump-in.
+//
+// It shipped in one place: recheckCmd, which runs when the human comes back
+// from a session. So a record whose session died without getting a SessionEnd
+// out — a machine that slept the tmux server away, a WSL distro shut down with
+// the last console, a reboot — kept claiming "working" for as long as the
+// cockpit was open, and the row went on offering ⏎ attach. Attach found no
+// session, said so, and changed nothing; the only thing that would have
+// retired the record was coming back from an attach that could never happen.
+// A ghost could only be cleared by attaching to it, which is the one thing it
+// could not do.
+func TestEveryLoadSweepsStraySessions(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	defer restoreVars(captureVars())
+
+	if err := state.Save(&state.Dispatch{
+		ID: "ghost", Feature: "ghost", Status: state.StatusWorking,
+		TmuxSession: "disp-ghost",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	prev := reconcileSessions
+	defer func() { reconcileSessions = prev }()
+	swept := 0
+	var saw []string
+	reconcileSessions = func(ds []*state.Dispatch) (int, int) {
+		swept++
+		for _, d := range ds {
+			saw = append(saw, d.ID)
+		}
+		return 0, 0
+	}
+
+	loadSnapshot(&config.Config{})
+
+	if swept != 1 {
+		t.Fatalf("the load swept %d times, want 1", swept)
+	}
+	if len(saw) != 1 || saw[0] != "ghost" {
+		t.Errorf("the sweep was handed %v, want the records this load read", saw)
+	}
+}

--- a/internal/cockpit/refresh.go
+++ b/internal/cockpit/refresh.go
@@ -86,7 +86,11 @@ func loadSnapshotCmd(cfg *config.Config) tea.Cmd {
 //     rather than replayed from before the jump (shipCmd invalidates for the
 //     same reason after a merge — a hand at the wheel is no less of a change);
 //  2. re-check session liveness, so a session that died without getting a
-//     SessionEnd out stops being reported as working;
+//     SessionEnd out stops being reported as working. loadSnapshot sweeps too,
+//     on every load; this one is here for the order below it, not because the
+//     sweep is this path's alone — it was, and a fleet of dispatchers whose
+//     sessions had died could not raise it, because the only way in was the
+//     jump-in they could no longer make;
 //  3. reconcile PRs and deploys against that, and in that order — track.midWork
 //     reads status, so a record the sweep just retired can still be flipped to
 //     done by its merge, where the reverse order would hold it open;

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -177,16 +177,20 @@ func liveDispatch(slug string) *state.Dispatch {
 	return nil
 }
 
-// sessionAlive and supervisorReady are seams: tests swap them rather than
-// stand up real sessions.
+// sessionAlive, sessionNames and supervisorReady are seams: tests swap them
+// rather than stand up real sessions.
 var (
 	sessionAlive    = supervisor.HasSession
+	sessionNames    = supervisor.Sessions
 	supervisorReady = supervisor.Available
 )
 
 // ReconcileSessions re-derives status from the one fact the lifecycle hook
 // cannot report — whether the session behind a record still exists — and marks
-// every stray record exited. It returns how many it changed.
+// every stray record exited. It returns how many it retired, and how many
+// records still have a session of their own; the second figure is a byproduct
+// of the same listing, and the caller that draws it would otherwise ask the
+// supervisor the same question twice.
 //
 // Status normally comes from Claude Code hooks, and they are truth right up to
 // the moment a session dies without getting to say so: a SIGKILL, a
@@ -208,13 +212,30 @@ var (
 // there proves nothing, so nothing is claimed. Likewise a supervisor we cannot
 // even reach is not evidence that every session is gone, which is why an
 // unavailable backend sweeps nothing rather than retiring the whole fleet.
-func ReconcileSessions(ds []*state.Dispatch) int {
+//
+// It reads the whole fleet's liveness from ONE listing, because the cockpit now
+// runs it on every load rather than once per jump-in: a probe per record would
+// be a subprocess per record on every poll and every state-file change. The
+// listing screens; it never convicts on its own. A record it says is missing is
+// asked about directly before anything is written, since a listing that failed
+// for any reason comes back empty and an empty listing must never be read as
+// "the whole fleet died" — the same reason an unreachable supervisor sweeps
+// nothing. The extra probe costs one subprocess per record about to be retired,
+// and a retired record is skipped on every pass after this one.
+func ReconcileSessions(ds []*state.Dispatch) (retired, live int) {
 	if !supervisorReady() {
-		return 0
+		return 0, 0
 	}
-	n := 0
+	listed := make(map[string]bool)
+	for _, name := range sessionNames() {
+		listed[name] = true
+	}
 	for _, d := range ds {
 		if d.TmuxSession == "" {
+			continue
+		}
+		if listed[d.TmuxSession] {
+			live++
 			continue
 		}
 		switch d.Status {
@@ -223,15 +244,16 @@ func ReconcileSessions(ds []*state.Dispatch) int {
 			continue
 		}
 		if sessionAlive(d.TmuxSession) {
+			live++
 			continue
 		}
 		d.Status = state.StatusExited
 		d.StatusReason = "its " + supervisor.Backend() + " session is gone"
 		if state.Save(d) == nil {
-			n++
+			retired++
 		}
 	}
-	return n
+	return retired, live
 }
 
 // fetchTimeout bounds the pre-dispatch fetch. Refreshing the base is a

--- a/internal/dispatch/reconcile_test.go
+++ b/internal/dispatch/reconcile_test.go
@@ -7,12 +7,28 @@ import (
 )
 
 // withFakeSessions swaps the supervisor seams so the sweep runs against a
-// hand-written liveness map instead of a real tmux server.
+// hand-written liveness map instead of a real tmux server. The listing and the
+// per-name probe answer from the same map, which is what a working supervisor
+// does; withSessionSeams is how a test pulls the two apart.
 func withFakeSessions(t *testing.T, alive map[string]bool, ready bool) {
 	t.Helper()
-	prevAlive, prevReady := sessionAlive, supervisorReady
-	t.Cleanup(func() { sessionAlive, supervisorReady = prevAlive, prevReady })
-	sessionAlive = func(name string) bool { return alive[name] }
+	names := make([]string, 0, len(alive))
+	for name, ok := range alive {
+		if ok {
+			names = append(names, name)
+		}
+	}
+	withSessionSeams(t, func() []string { return names }, func(name string) bool { return alive[name] }, ready)
+}
+
+// withSessionSeams is withFakeSessions with the listing and the probe given
+// separately, for the cases where they do not agree.
+func withSessionSeams(t *testing.T, list func() []string, probe func(string) bool, ready bool) {
+	t.Helper()
+	prevAlive, prevNames, prevReady := sessionAlive, sessionNames, supervisorReady
+	t.Cleanup(func() { sessionAlive, sessionNames, supervisorReady = prevAlive, prevNames, prevReady })
+	sessionNames = list
+	sessionAlive = probe
 	supervisorReady = func() bool { return ready }
 }
 
@@ -59,8 +75,14 @@ func TestReconcileSessionsRetiresOnlyProvableStrays(t *testing.T) {
 
 	withFakeSessions(t, map[string]bool{"disp-live": true}, true)
 
-	if n := ReconcileSessions(state.LoadAll()); n != 3 {
-		t.Errorf("ReconcileSessions retired %d records, want 3 (gone, needs, blocked)", n)
+	retired, stillRunning := ReconcileSessions(state.LoadAll())
+	if retired != 3 {
+		t.Errorf("ReconcileSessions retired %d records, want 3 (gone, needs, blocked)", retired)
+	}
+	// The second figure is the one the opening screen prints, and it counts
+	// records with a session rather than statuses: only "live" still has one.
+	if stillRunning != 1 {
+		t.Errorf("ReconcileSessions counted %d live sessions, want 1", stillRunning)
 	}
 
 	for _, id := range []string{"gone", "needs", "blocked"} {
@@ -122,7 +144,7 @@ func TestReconcileSessionsSweepsNothingWithoutASupervisor(t *testing.T) {
 	})
 	withFakeSessions(t, nil, false)
 
-	if n := ReconcileSessions(state.LoadAll()); n != 0 {
+	if n, _ := ReconcileSessions(state.LoadAll()); n != 0 {
 		t.Errorf("ReconcileSessions retired %d records with no supervisor, want 0", n)
 	}
 	if got := statusOnDisk(t, "orphan"); got != state.StatusWorking {
@@ -141,10 +163,66 @@ func TestReconcileSessionsIsIdempotent(t *testing.T) {
 	})
 	withFakeSessions(t, nil, true)
 
-	if n := ReconcileSessions(state.LoadAll()); n != 1 {
+	if n, _ := ReconcileSessions(state.LoadAll()); n != 1 {
 		t.Fatalf("first pass retired %d, want 1", n)
 	}
-	if n := ReconcileSessions(state.LoadAll()); n != 0 {
+	if n, _ := ReconcileSessions(state.LoadAll()); n != 0 {
 		t.Errorf("second pass retired %d, want 0", n)
+	}
+}
+
+// The listing screens; it never convicts on its own. A listing that came back
+// empty because tmux failed — rather than because nothing is running — would
+// otherwise retire every working dispatcher on the machine in one pass, which
+// is the same mass-retirement an unreachable supervisor is guarded against
+// above. The direct probe is what has to agree before anything is written.
+func TestReconcileSessionsConfirmsAnEmptyListingBeforeRetiring(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	saveAll(t, &state.Dispatch{
+		ID: "busy", Feature: "busy", Status: state.StatusWorking,
+		TmuxSession: "disp-busy",
+	})
+	probes := 0
+	withSessionSeams(t,
+		func() []string { return nil }, // the listing failed and said nothing
+		func(name string) bool { probes++; return name == "disp-busy" },
+		true)
+
+	retired, live := ReconcileSessions(state.LoadAll())
+	if retired != 0 {
+		t.Errorf("retired %d records the listing missed, want 0 — the probe says it is there", retired)
+	}
+	if live != 1 {
+		t.Errorf("counted %d live, want 1 — the probe found the session the listing did not list", live)
+	}
+	if probes != 1 {
+		t.Errorf("probed %d times, want 1 — only a record about to be retired is worth a subprocess", probes)
+	}
+	if got := statusOnDisk(t, "busy"); got != state.StatusWorking {
+		t.Errorf("busy: status = %q, want working", got)
+	}
+}
+
+// A record the listing already accounts for is never probed. The sweep runs on
+// every cockpit load now, so a probe per record would be a subprocess per
+// record on every poll and every state-file change.
+func TestReconcileSessionsProbesOnlyWhatTheListingMissed(t *testing.T) {
+	t.Setenv("CLAUDE_DISPATCHER_STATE", t.TempDir())
+	saveAll(t,
+		&state.Dispatch{ID: "a", Feature: "a", Status: state.StatusWorking, TmuxSession: "disp-a"},
+		&state.Dispatch{ID: "b", Feature: "b", Status: state.StatusNeedsInput, TmuxSession: "disp-b"},
+		&state.Dispatch{ID: "old", Feature: "old", Status: state.StatusDone, TmuxSession: "disp-old"},
+	)
+	probes := 0
+	withSessionSeams(t,
+		func() []string { return []string{"disp-a", "disp-b"} },
+		func(string) bool { probes++; return false },
+		true)
+
+	if _, live := ReconcileSessions(state.LoadAll()); live != 2 {
+		t.Errorf("counted %d live, want 2", live)
+	}
+	if probes != 0 {
+		t.Errorf("probed %d times, want 0 — the listing already answered for every record", probes)
 	}
 }


### PR DESCRIPTION
## What was happening

"Once you have dispatched something you can no longer attach." Reported from WSL; fine on a MacBook.

A dispatcher whose tmux session dies **without getting a `SessionEnd` out** — a reboot, a suspended laptop, an outside `tmux kill-server`, or a WSL distro shutting down with its last console and taking the tmux server with it — leaves a record that still claims `working`. `dispatch.ReconcileSessions` exists to retire exactly those records, and it was wired into **one** caller: `cockpit.recheckCmd`, the reload that runs when the human comes back from a jump-in.

Nothing else swept. Not the opening load, not the 60s poll, not the fsnotify reload. So the ghost row sat on the triage table offering ⏎ attach; attach checked the session, found nothing, set a notice and changed nothing — and the only thing that would have retired the record was coming back from an attach that could never happen. **The state that made the row un-attachable was the state only a successful attach could clear.**

WSL is where it shows up because a distro shutdown takes every session at once; a macOS tmux server survives for weeks, so the same ghosts are rare enough there to look like a WSL bug. The tells in the report: a *newly* dispatched one attached and returned fine, `tmux ls` found no server at all, and the old row "disappeared" moments after the new one's jump-in returned — that return was the sweep finally running.

## The fix

- `ReconcileSessions` runs on **every** `loadSnapshot`, in the `LIVE SESSIONS` boot stage that already asks the supervisor what is running — and the stage now reports what it retired: `0 sessions live of 1 · 1 ghost retired`. It writes through the records the load then builds its snapshot from, so the collectors see the corrected status in the same pass.
- It reads the fleet from **one** `supervisor.Sessions` listing rather than a probe per record, because a load happens on every poll and every state-file change. The listing only *screens*: a record it does not name is probed directly before anything is written, since a failed listing comes back empty and an empty listing must never be read as "the whole fleet died" — the same reason an unreachable supervisor sweeps nothing. The live-session count for the opening screen comes back from that same listing, so nothing asks tmux twice.
- ⏎ on a ghost that slipped through between loads runs the same sweep on that one record and says where the dispatcher went — *retired · h for history, where ⏎ resumes it* — instead of leaving a dead key on a lying row.
- What counts as evidence is unchanged: only the three statuses a hook proved a session behind are swept, and a `launching` record is still never retired (no hook has fired for it, so its session may simply not exist *yet* — ⏎ says "still starting").

## Verified

- Unit tests for the listing-vs-probe rule (an empty listing does not convict; already-listed records are never probed), the load-time sweep, and both ⏎ branches.
- End to end against the real binary: a record claiming `working` with a session that does not exist, in a sandboxed state dir — first ordinary load, no jump-in anywhere, boot line read `0 sessions live of 1 · 1 ghost retired` and the record on disk became `exited` / "its tmux session is gone".
- `go test ./... -race`, `go vet`, `golangci-lint` clean.

Full record: `docs/adr/0004-a-ghost-cannot-clear-itself.md`.