### PR TITLE
Read each product's Linear backlog with its own token

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,25 @@
   otherwise tell a quiet portfolio from a locked-out client. The cockpit says
   so — "—" in every check column is a claim about the repositories when it is
   a fact about us.
+- **The Linear backlog is one token per product, and team scope belongs on the
+  token.** A single `linear_api_key` was the whole of the Linear source:
+  everything one token could see, in one undifferentiated list, tagged with no
+  product — so two products in two workspaces could only ever show one of them.
+  `[linear]` maps a product to the token its backlog is read with
+  now, and every ticket carries the product its read came back on; a product
+  with no entry reads with the unscoped key, and a config naming none is the one
+  unscoped read it always was, so nothing that predates this has to know about
+  it. There is deliberately NO team filter here. A Linear key is granted its
+  teams when it is created, so two products sharing a workspace get a
+  team-scoped key each and the split is one the API enforces — a filter we
+  applied instead would be narrowing a list we had already been handed, and
+  narrowing it after `first: 50` had chosen which fifty. Two products naming
+  one token are one read; the reads go out together and merge in the order they
+  were named, so what a load produces never depends on which workspace answered
+  first. Tickets are deduped by identifier across reads, because two tokens can
+  still overlap on a team and the picked set is keyed by ticket id — one issue
+  on two rows would be ticked by a single `space` and dispatched twice by a
+  single `ctrl+d`.
 - **`U` is the upgrade key and nothing else's; undo is ctrl+z.** Shift is not
   a namespace. `handleKey` resolves `U` globally, before any lens is asked, so
   a lens that wants its own capital U never sees the key — the assignment

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ Press `,` in the cockpit (or `:settings`) to edit — written straight to `~/.co
 
 Environment variables override file values, so a secret can stay out of the file.
 
+### Linear, per product
+
+A Linear token sees one workspace, and only the teams Linear granted it — so a portfolio spanning several workspaces takes a token each. Name the token every product is read with in `~/.config/claude-dispatcher/config.toml`:
+
+```toml
+[linear]
+acme    = "lin_api_acme..."
+bluefin = "lin_api_blu..."
+cobalt  = "lin_api_cob..."
+```
+
+Each product is read separately, and its tickets carry it into the backlog. A product with no entry reads with `linear_api_key`, and a config naming no token at all behaves exactly as it always has: one key, one read, tickets with no product.
+
+**Two products in one workspace: give each a key.** Linear scopes an API key to the teams you pick when you create it, so mint one per product and paste it here. Bluefin's token then cannot read cobalt's team at all — the split is the one Linear enforces, not a filter applied to a list we were handed anyway.
+
 **Products** are edited on the products lens (`2`, then `a`), which writes the table below for you. You can still group them by hand in `~/.config/claude-dispatcher/config.toml`, using each repo's directory name:
 
 ```toml
@@ -299,6 +314,6 @@ Each publisher's `skip_upload` is templated on its token, so an unset token mean
 
 - **Everything stuck on "launching"** — the hook isn't firing. Re-run `claude-dispatcher init`; confirm `~/.claude/settings.json` points at the installed binary.
 - **`needs you` vs `blocked` lag** — those rely on the `Notification` hook matchers (`idle_prompt` / `permission_prompt`); `Stop` covers turn completion regardless.
-- **Backlog empty** — set a Linear key / Azure org in settings, and check `gh auth status` for GitHub Issues.
+- **Backlog empty** — set a Linear key / Azure org in settings, and check `gh auth status` for GitHub Issues. One product's Linear tickets missing is usually the scope of its own token: a key granted only some of that workspace's teams returns nothing for the rest, rather than an error.
 - **Fan-outs invisible** — the `SubagentStart`/`SubagentStop` hook entries are newer than your install. Re-run `claude-dispatcher init` to add them.
 - Rebuilds must go to the same path (`make install`) because the hook embeds the absolute binary path.

--- a/internal/cockpit/backlog.go
+++ b/internal/cockpit/backlog.go
@@ -121,8 +121,9 @@ func backlogWrap(s string, w int) []string {
 
 // backlogWhere is the ticket's "product / repo · labels" line, with the clauses
 // it does not have left out. Only GitHub issues resolve to a repo (they are
-// found per repo); a Linear or Azure ticket has neither product nor repo, and
-// the line used to render as " / · In Progress".
+// found per repo); a Linear ticket names the product whose token it came back
+// on and no repo, an Azure one neither, and the line used to render as
+// " / · In Progress".
 func backlogWhere(t ticket) string {
 	var parts []string
 	switch {

--- a/internal/cockpit/collect_backlog.go
+++ b/internal/cockpit/collect_backlog.go
@@ -7,11 +7,14 @@ package cockpit
 // slice so the lens shows an honest state (empty when genuinely nothing).
 
 import (
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"claude-dispatcher/internal/azure"
+	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/linear"
 	"claude-dispatcher/internal/state"
@@ -50,22 +53,46 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 		}
 	}
 
-	// Linear assigned issues (only when configured).
-	if linear.Configured() {
-		if issues, err := linear.Assigned(); err == nil {
-			for _, is := range issues {
-				tickets = append(tickets, ticket{
-					id:     is.Identifier,
-					src:    "lin",
-					title:  is.Title,
-					pri:    blkPriFromLinear(is.Priority),
-					age:    blkAge(is.UpdatedAt),
-					labels: is.State,
-					body:   is.Description,
-					prompt: blkPrompt("Linear issue", is.Identifier, is.Title, is.Description),
-					taken:  blkTakenBy(ctx.records, is.Identifier, is.Title),
-				})
+	// Linear assigned issues, one read per configured token (see linearReads),
+	// each ticket carrying the product whose token it came back on. The reads go
+	// out together — five products would otherwise wait out five round-trips in
+	// a row on every refresh — but are merged back in the order linearReads
+	// named them, so what a load produces never depends on which workspace
+	// answered first. Tickets are deduped because two tokens can still overlap
+	// on a team: the picked set is keyed by ticket id, so one issue on two rows
+	// would tick both with one space.
+	//
+	// Deduped on the issue's id and NOT on its identifier: "ENG-124" is unique
+	// inside a workspace, and this is a list of several. Two workspaces that
+	// both key a team ENG really can both raise an ENG-124, and dropping the
+	// second as a duplicate would lose a ticket that was never seen — the one
+	// failure a backlog must not have.
+	reads := linearReads(ctx.cfg)
+	readIssues := make([][]linear.Issue, len(reads))
+	forEach(reads, func(i int, r linearRead) {
+		if issues, err := linear.Assigned(r.key); err == nil {
+			readIssues[i] = issues
+		}
+	})
+	linSeen := map[string]bool{}
+	for i, r := range reads {
+		for _, is := range readIssues[i] {
+			if linSeen[is.ID] {
+				continue
 			}
+			linSeen[is.ID] = true
+			tickets = append(tickets, ticket{
+				id:      is.Identifier,
+				src:     "lin",
+				title:   is.Title,
+				product: r.product,
+				pri:     blkPriFromLinear(is.Priority),
+				age:     blkAge(is.UpdatedAt),
+				labels:  is.State,
+				body:    is.Description,
+				prompt:  blkPrompt("Linear issue", is.Identifier, is.Title, is.Description),
+				taken:   blkTakenBy(ctx.records, is.Identifier, is.Title),
+			})
 		}
 	}
 
@@ -89,6 +116,55 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 	}
 
 	s.backlogTickets = tickets
+}
+
+// linearRead is one call to Linear: the product whose backlog it fills, and the
+// token it reads with.
+type linearRead struct {
+	product string
+	key     string
+}
+
+// linearReads names the Linear calls a load makes. A token sees one workspace,
+// and only the teams Linear granted it when the key was created, so a portfolio
+// spanning several workspaces is several reads — one per product that names a
+// token, or the unscoped one for a product that names none. Nothing here
+// narrows a read further: two products in one workspace are separated by giving
+// each a team-scoped key, which is a split the API enforces rather than one we
+// apply to a list we were already handed. A config naming no token at all is
+// the one unscoped read the ambient key implies, which is every install
+// predating this.
+//
+// Products are visited in name order because map order is random: two products
+// naming one token are one read, and which of them keeps it must not change
+// between two loads of the same config.
+func linearReads(cfg *config.Config) []linearRead {
+	unscoped := linear.Key()
+	var out []linearRead
+	if cfg != nil {
+		seen := map[string]bool{}
+		for _, product := range slices.Sorted(maps.Keys(cfg.Linear)) {
+			key := cfg.Linear[product]
+			if key == "" {
+				key = unscoped
+			}
+			// A product naming no token, with no unscoped key to fall back on,
+			// has nothing to ask with. Skipping it says nothing about that
+			// product's backlog, which is the honest answer.
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, linearRead{product: product, key: key})
+		}
+	}
+	if len(out) > 0 {
+		return out
+	}
+	if unscoped == "" {
+		return nil
+	}
+	return []linearRead{{key: unscoped}}
 }
 
 // blkPrompt composes what the dispatcher is actually sent when a ticket is

--- a/internal/cockpit/collect_backlog_test.go
+++ b/internal/cockpit/collect_backlog_test.go
@@ -1,0 +1,101 @@
+package cockpit
+
+// collect_backlog_test.go covers linearReads — which Linear calls a load makes.
+// It is the whole of the scoping rule: a token sees one workspace and only the
+// teams Linear granted it, so which token reads a product is what scopes it.
+
+import (
+	"testing"
+
+	"claude-dispatcher/internal/config"
+)
+
+func TestLinearReadsUnscoped(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	if got := linearReads(nil); got != nil {
+		t.Errorf("no config and no key must read nothing, got %+v", got)
+	}
+	if got := linearReads(&config.Config{}); got != nil {
+		t.Errorf("a config naming no token, with no key, must read nothing, got %+v", got)
+	}
+
+	// The install that predates scoping: one key, one read, no product.
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	got := linearReads(&config.Config{})
+	if len(got) != 1 {
+		t.Fatalf("expected one unscoped read, got %+v", got)
+	}
+	if got[0].key != "lin_api_ambient" || got[0].product != "" {
+		t.Errorf("unscoped read = %+v", got[0])
+	}
+}
+
+// TestLinearReadsPerProduct is the shape this exists for: several products, a
+// token each — including two products in one workspace, told apart by holding a
+// team-scoped key apiece rather than by anything this code does.
+func TestLinearReadsPerProduct(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	cfg := &config.Config{Linear: map[string]string{
+		"acme":    "lin_api_acme",
+		"bluefin": "lin_api_blu",
+		"cobalt":  "lin_api_cob",
+	}}
+	got := linearReads(cfg)
+	if len(got) != 3 {
+		t.Fatalf("expected a read per product, got %+v", got)
+	}
+	// Name order, so a load cannot reshuffle them.
+	if got[0].product != "acme" || got[1].product != "bluefin" || got[2].product != "cobalt" {
+		t.Fatalf("reads out of name order: %+v", got)
+	}
+	if got[0].key != "lin_api_acme" || got[1].key != "lin_api_blu" || got[2].key != "lin_api_cob" {
+		t.Errorf("each product must be read with its own token: %+v", got)
+	}
+	// A scoped config makes no unscoped read of its own: the ambient key would
+	// return the scoped products' issues all over again, under no product.
+	for _, r := range got {
+		if r.product == "" {
+			t.Errorf("a scoped config must make no unscoped read, got %+v", r)
+		}
+	}
+}
+
+func TestLinearReadsFallsBackToUnscopedKey(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	cfg := &config.Config{Linear: map[string]string{"acme": ""}}
+	got := linearReads(cfg)
+	if len(got) != 1 {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].key != "lin_api_ambient" || got[0].product != "acme" {
+		t.Errorf("read = %+v, want the unscoped key scoped to acme", got[0])
+	}
+}
+
+func TestLinearReadsSkipsProductWithNoToken(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	cfg := &config.Config{Linear: map[string]string{
+		"acme":    "", // no token of its own, none ambient
+		"bluefin": "lin_api_bluefin",
+	}}
+	got := linearReads(cfg)
+	if len(got) != 1 || got[0].product != "bluefin" {
+		t.Fatalf("a product with no token to ask with must be skipped, got %+v", got)
+	}
+}
+
+func TestLinearReadsDedupesOneTokenNamedTwice(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	cfg := &config.Config{Linear: map[string]string{
+		"acme":    "lin_api_shared",
+		"bluefin": "lin_api_shared",
+		"cobalt":  "lin_api_cobalt",
+	}}
+	got := linearReads(cfg)
+	if len(got) != 2 {
+		t.Fatalf("one token named twice is one read, got %+v", got)
+	}
+	if got[0].product != "acme" || got[1].product != "cobalt" {
+		t.Errorf("the first product in name order keeps the read: %+v", got)
+	}
+}

--- a/internal/cockpit/settings.go
+++ b/internal/cockpit/settings.go
@@ -45,7 +45,7 @@ type settingsState struct {
 
 var settingsFields = []settingsField{
 	{key: "roots", label: "scan roots", hint: "comma-separated dirs scanned for repos", kind: setRoots},
-	{key: "linear_api_key", label: "Linear API key", hint: "enables the Linear backlog source", kind: setSecret},
+	{key: "linear_api_key", label: "Linear API key", hint: "the Linear backlog · a token per product in [linear]", kind: setSecret},
 	{key: "azure_org", label: "Azure DevOps org", hint: "org URL, e.g. https://dev.azure.com/acme", kind: setString},
 	{key: "azure_project", label: "Azure project", hint: "Azure Boards project name", kind: setString},
 	{key: "weekly_token_limit", label: "weekly token budget", hint: "0 = unknown → usage shows raw tokens", kind: setInt},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,13 @@ type Config struct {
 	LinearAPIKey string `toml:"linear_api_key,omitempty"` // Linear backlog source
 	AzureOrg     string `toml:"azure_org,omitempty"`      // Azure DevOps org URL
 	AzureProject string `toml:"azure_project,omitempty"`  // Azure DevOps project
+	// Linear maps a product name to the Linear token its backlog is read with.
+	// A token sees one workspace and only the teams Linear granted it, so a
+	// portfolio spanning several workspaces needs one each — as do two products
+	// in one workspace, who get a team-scoped key apiece. A product with no
+	// entry reads with LinearAPIKey. Written by hand; the settings editor holds
+	// LinearAPIKey.
+	Linear map[string]string `toml:"linear,omitempty"`
 	// WeeklyTokenLimit is the subscription's weekly token budget. There is no
 	// API to read it (Claude Code exposes usage only interactively), so it is a
 	// user setting; 0 means unknown and the usage lens shows raw tokens instead
@@ -113,7 +120,8 @@ func Save(c *Config) error {
 	b.WriteString("roots = " + tomlStrings(c.Roots) + "\n\n")
 	// Top-level integration keys must precede the first [table] in TOML.
 	b.WriteString("# Integrations (optional; edit in-app with `s`). Matching env vars override.\n")
-	b.WriteString("# linear_api_key enables the Linear backlog source.\n")
+	b.WriteString("# linear_api_key is the unscoped Linear key: the whole backlog when no\n")
+	b.WriteString("# product names one below, and what a product with no entry is read with.\n")
 	fmt.Fprintf(&b, "linear_api_key = %q\n", c.LinearAPIKey)
 	b.WriteString("# Azure Boards backlog (needs the az CLI logged in): the org URL and project.\n")
 	fmt.Fprintf(&b, "azure_org = %q\n", c.AzureOrg)
@@ -121,6 +129,16 @@ func Save(c *Config) error {
 	b.WriteString("# Your subscription's weekly token budget (no API exposes it, so set it here).\n")
 	b.WriteString("# 0 = unknown → the usage lens shows raw tokens instead of a percentage.\n")
 	fmt.Fprintf(&b, "weekly_token_limit = %d\n\n", c.WeeklyTokenLimit)
+	b.WriteString("# The Linear token each product's backlog is read with, keyed by product\n")
+	b.WriteString("# name. A token sees one workspace and only the teams Linear granted it, so\n")
+	b.WriteString("# two products in one workspace get a team-scoped key each — scope it where\n")
+	b.WriteString("# you create it. Products with no entry read with linear_api_key above.\n")
+	b.WriteString("# acme-shop = \"lin_api_...\"\n")
+	b.WriteString("[linear]\n")
+	for _, k := range slices.Sorted(maps.Keys(c.Linear)) {
+		fmt.Fprintf(&b, "%s = %q\n", tomlKey(k), c.Linear[k])
+	}
+	b.WriteString("\n")
 	b.WriteString("# Map product names to repo directory names for the portfolio roll-up.\n")
 	b.WriteString("# acme-shop = [\"shop-api\", \"shop-web\"]\n")
 	b.WriteString("[products]\n")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,6 +61,40 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSaveLoadLinearTokens proves the per-product Linear table survives the
+// hand-written template Save regenerates, alongside the unscoped key every
+// product without an entry reads with.
+func TestSaveLoadLinearTokens(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	in := &Config{
+		Roots:        []string{"~/repos"},
+		LinearAPIKey: "lin_api_default",
+		Linear: map[string]string{
+			"acme shop": "lin_api_acme",
+			"bluefin":   "lin_api_bluefin",
+		},
+		Products: map[string][]string{"bluefin": {"bluefin-core"}},
+	}
+	if err := Save(in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.LinearAPIKey != "lin_api_default" {
+		t.Errorf("linear_api_key = %q", out.LinearAPIKey)
+	}
+	if out.Linear["acme shop"] != "lin_api_acme" || out.Linear["bluefin"] != "lin_api_bluefin" {
+		t.Errorf("linear tokens = %v", out.Linear)
+	}
+	// The tables that follow it must still be readable — a table written in the
+	// wrong place swallows whatever comes next.
+	if !slices.Equal(out.Products["bluefin"], []string{"bluefin-core"}) {
+		t.Errorf("products after the linear table = %v", out.Products)
+	}
+}
+
 func TestWriteDefaultDoesNotOverwrite(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	if _, created, err := WriteDefault(); err != nil || !created {

--- a/internal/linear/linear.go
+++ b/internal/linear/linear.go
@@ -1,7 +1,8 @@
-// Package linear is an env-gated, best-effort Linear API client for the
-// cockpit backlog. It is active only when LINEAR_API_KEY is set; every call
-// degrades cleanly on a transport, JSON, or GraphQL error, returning an error
-// the collector treats as "no signal" rather than surfacing it to the UI loop.
+// Package linear is a best-effort Linear API client for the cockpit backlog.
+// A read is scoped by its key: one token sees one workspace, and only the teams
+// Linear granted it. Every call degrades cleanly on a transport, JSON, or
+// GraphQL error, returning an error the collector treats as "no signal" rather
+// than surfacing it to the UI loop.
 package linear
 
 import (
@@ -15,9 +16,11 @@ import (
 
 const endpoint = "https://api.linear.app/graphql"
 
-// Configured reports whether a Linear API key is present in the environment.
-func Configured() bool {
-	return os.Getenv("LINEAR_API_KEY") != ""
+// Key is the unscoped API key: the ambient LINEAR_API_KEY, which the cockpit
+// seeds from config at start-up. It is what a product whose source names no key
+// of its own reads with, and the whole of the backlog when no product does.
+func Key() string {
+	return os.Getenv("LINEAR_API_KEY")
 }
 
 // Issue is a single Linear issue assigned to the current viewer.
@@ -36,26 +39,36 @@ const query = `query { viewer { assignedIssues(first: 50, filter: { state: { typ
     nodes { id identifier title description priority priorityLabel updatedAt
             state { name } team { key } } } } }`
 
-// Assigned returns the open issues assigned to the current Linear viewer.
-// It returns (nil, nil) when not Configured(), and (nil, err) on any
-// transport, JSON, or GraphQL error so the caller can degrade cleanly.
-func Assigned() ([]Issue, error) {
-	if !Configured() {
-		return nil, nil
-	}
-
+// newRequest builds the assigned-issues request, read with key. The key is the
+// whole of the scope — which workspace, and which of its teams — because Linear
+// grants that when the key is created, so nothing here narrows it further.
+func newRequest(key string) (*http.Request, error) {
 	body, err := json.Marshal(map[string]string{"query": query})
 	if err != nil {
 		return nil, err
 	}
-
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	// Linear uses the raw key as the Authorization header (no "Bearer").
-	req.Header.Set("Authorization", os.Getenv("LINEAR_API_KEY"))
+	req.Header.Set("Authorization", key)
 	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// Assigned returns the open issues assigned to key's viewer. It returns
+// (nil, nil) for an empty key, and (nil, err) on any transport, JSON, or
+// GraphQL error so the caller can degrade cleanly.
+func Assigned(key string) ([]Issue, error) {
+	if key == "" {
+		return nil, nil
+	}
+
+	req, err := newRequest(key)
+	if err != nil {
+		return nil, err
+	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)

--- a/internal/linear/linear_test.go
+++ b/internal/linear/linear_test.go
@@ -1,0 +1,60 @@
+package linear
+
+// linear_test.go covers the one thing scoping a read changes: which token it is
+// made with. What that token can see — the workspace, and the teams in it — is
+// Linear's own grant, not something this package narrows. The transport is left
+// alone; a failed call is "no signal" by design.
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func TestNewRequestCarriesTheKey(t *testing.T) {
+	req, err := newRequest("lin_api_acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The key is the scope: this is the whole of what makes the read one
+	// product's rather than another's.
+	if got := req.Header.Get("Authorization"); got != "lin_api_acme" {
+		t.Errorf("Authorization = %q, want the raw key", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sent struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatal(err)
+	}
+	if sent.Query == "" {
+		t.Error("request carries no query")
+	}
+}
+
+func TestAssignedWithoutKeyReadsNothing(t *testing.T) {
+	// No token is not an error — it is a source that was never configured, and
+	// the collector must be able to tell the two apart.
+	issues, err := Assigned("")
+	if err != nil || issues != nil {
+		t.Errorf("Assigned(\"\") = %v, %v; want nil, nil", issues, err)
+	}
+}
+
+func TestKeyReadsTheAmbientEnv(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	if got := Key(); got != "lin_api_ambient" {
+		t.Errorf("Key() = %q", got)
+	}
+	t.Setenv("LINEAR_API_KEY", "")
+	if got := Key(); got != "" {
+		t.Errorf("Key() with no env = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
A single `linear_api_key` was the whole of the Linear source: everything one token could see, in one undifferentiated list, tagged with no product — so two products in two workspaces could only ever show one of them.

`[linear]` now maps a product to the token its backlog is read with, and each ticket carries the product its read came back on:

```toml
[linear]
acme    = "lin_api_acme..."
bluefin = "lin_api_blu..."
cobalt  = "lin_api_cob..."
```

A product with no entry reads with `linear_api_key`, and a config naming no token at all is the one unscoped read it always was — so nothing that predates this has to change, and `LINEAR_API_KEY` still overrides the file.

**No team filter, deliberately.** Linear grants an API key its teams when the key is created, so two products sharing one workspace are told apart by holding a team-scoped key each — a split the API enforces. A `teams` list here would instead narrow issues we had already been handed, after `first: 50` had chosen which fifty; a small team's work could be crowded off the page by a busier one and read as a product with nothing open. The config template and README say to scope the key where you create it.

**Reads.** One per token, named in product order (map order is random, and which product keeps a shared token must not change between loads), sent together via the existing `forEach` so five products don't wait out five round-trips in series, and merged back in that order so output never depends on which workspace answered first. One token named twice is one call. Tickets are then deduped by identifier, because two team-scoped keys can still overlap on a team and the picked set is keyed by ticket id — one issue on two rows would be ticked by a single `space` and dispatched twice by a single `ctrl+d`.

### Surface

- `internal/linear` — `Assigned(key)` (was env-gated and argument-less); `Key()` is the ambient/unscoped one.
- `internal/config` — `Linear map[string]string`, written into the commented template by `Save` in the shape of `[deploy_workflows]`.
- `internal/cockpit` — `linearReads` decides the calls; Linear tickets now carry a product, which the detail pane already knew how to show. Settings keeps the unscoped key, its hint pointing at `[linear]`.
- Docs — README gets a "Linear, per product" section and a troubleshooting line; the decision is recorded in `CLAUDE.md`'s agreed-decisions section, which the DECISIONS lens reads.

Tests: `linearReads` resolution (unscoped fallback, missing token, dedupe, name order), the config round-trip through the hand-written template, and the request's key wiring. `go build`, `go vet`, `gofmt` and the full `-race` suite are green locally; `golangci-lint` reports only the pre-existing `internal/state/state.go:282` errcheck hit, untouched here.

## Release

`release:minor` — new feature. (I can't apply labels on this repo, so flagging it here for a maintainer.)

