### PR TITLE
Read each product's Linear backlog with its own token, and type that token where the product is named

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,25 @@
   otherwise tell a quiet portfolio from a locked-out client. The cockpit says
   so — "—" in every check column is a claim about the repositories when it is
   a fact about us.
+- **The Linear backlog is one token per product, and team scope belongs on the
+  token.** A single `linear_api_key` was the whole of the Linear source:
+  everything one token could see, in one undifferentiated list, tagged with no
+  product — so two products in two workspaces could only ever show one of them.
+  `[linear]` maps a product to the token its backlog is read with
+  now, and every ticket carries the product its read came back on; a product
+  with no entry reads with the unscoped key, and a config naming none is the one
+  unscoped read it always was, so nothing that predates this has to know about
+  it. There is deliberately NO team filter here. A Linear key is granted its
+  teams when it is created, so two products sharing a workspace get a
+  team-scoped key each and the split is one the API enforces — a filter we
+  applied instead would be narrowing a list we had already been handed, and
+  narrowing it after `first: 50` had chosen which fifty. Two products naming
+  one token are one read; the reads go out together and merge in the order they
+  were named, so what a load produces never depends on which workspace answered
+  first. Tickets are deduped by identifier across reads, because two tokens can
+  still overlap on a team and the picked set is keyed by ticket id — one issue
+  on two rows would be ticked by a single `space` and dispatched twice by a
+  single `ctrl+d`.
 - **`U` is the upgrade key and nothing else's; undo is ctrl+z.** Shift is not
   a namespace. `handleKey` resolves `U` globally, before any lens is asked, so
   a lens that wants its own capital U never sees the key — the assignment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,13 +110,28 @@
   teams when it is created, so two products sharing a workspace get a
   team-scoped key each and the split is one the API enforces — a filter we
   applied instead would be narrowing a list we had already been handed, and
-  narrowing it after `first: 50` had chosen which fifty. Two products naming
-  one token are one read; the reads go out together and merge in the order they
-  were named, so what a load produces never depends on which workspace answered
-  first. Tickets are deduped by identifier across reads, because two tokens can
-  still overlap on a team and the picked set is keyed by ticket id — one issue
-  on two rows would be ticked by a single `space` and dispatched twice by a
-  single `ctrl+d`.
+  narrowing it after `first: 50` had chosen which fifty. Two products naming one
+  token are one read, and that read names **neither** of them: a shared token
+  cannot say which product an issue it returns belongs to, and crediting
+  whichever product sorts first would be stable and wrong — every other sharer's
+  tickets filed under a product that is not theirs, which is the "—" rule again.
+  The unscoped key is likewise a read of its own, never a fallback the scoped
+  ones switch off: it is another workspace as easily as the same one, so naming
+  one product's token must not silently empty a backlog that had been reading
+  for months. It goes last, so a scoped read keeps the tag on any overlap. The
+  reads go out together and merge in the order they were named, so what a load
+  produces never depends on which workspace answered first. Tickets are deduped
+  on the issue **id**, not its identifier: "ENG-124" is unique inside a
+  workspace and this is a list of several, so dropping the second ENG-124 would
+  lose a ticket nobody ever saw. That keeps the identifier collision rather than
+  fixing it — `m.picked` is keyed by the identifier, so two workspaces' ENG-124s
+  tick together on one `space` — and keeping it is the cheaper failure: a row
+  you look at twice beats a ticket that was never on the page. The token is
+  typed where the product is named: `l` on the assignment editor's products
+  pane, masked, because the map is keyed by product *name* and hand-writing it
+  means retyping one exactly, in another file, with a silent read under a
+  product that groups nowhere as the failure. The full record is
+  `docs/adr/0006-a-linear-token-is-the-scope.md`.
 - **`U` is the upgrade key and nothing else's; undo is ctrl+z.** Shift is not
   a namespace. `handleKey` resolves `U` globally, before any lens is asked, so
   a lens that wants its own capital U never sees the key — the assignment

--- a/README.md
+++ b/README.md
@@ -225,7 +225,11 @@ Environment variables override file values, so a secret can stay out of the file
 
 ### Linear, per product
 
-A Linear token sees one workspace, and only the teams Linear granted it — so a portfolio spanning several workspaces takes a token each. Name the token every product is read with in `~/.config/claude-dispatcher/config.toml`:
+A Linear token sees one workspace, and only the teams Linear granted it — so a portfolio spanning several workspaces takes a token each.
+
+Press `2`, then `a` for the assignment editor, `tab` to the products, and `l` on a product to paste the token its backlog is read with. It is masked as you type and never shown again — the product's line just says `linear token` — and an empty entry clears it. That is the place to do it because a token is filed under a **product name**, and that screen is where product names are made.
+
+The same thing by hand, in `~/.config/claude-dispatcher/config.toml`:
 
 ```toml
 [linear]
@@ -236,7 +240,11 @@ cobalt  = "lin_api_cob..."
 
 Each product is read separately, and its tickets carry it into the backlog. A product with no entry reads with `linear_api_key`, and a config naming no token at all behaves exactly as it always has: one key, one read, tickets with no product.
 
+Adding an entry never takes anything away: `linear_api_key` keeps its own read alongside the scoped ones, so a backlog that was already reading stays whole. Two products naming the *same* token are one read, and its tickets carry no product — a shared token cannot say which of them an issue belongs to, and a wrong product is worse than none.
+
 **Two products in one workspace: give each a key.** Linear scopes an API key to the teams you pick when you create it, so mint one per product and paste it here. Bluefin's token then cannot read cobalt's team at all — the split is the one Linear enforces, not a filter applied to a list we were handed anyway.
+
+Unlike `linear_api_key`, these have no environment variable of their own — they live in the config file. `LINEAR_API_KEY` still overrides the unscoped one.
 
 **Products** are edited on the products lens (`2`, then `a`), which writes the table below for you. You can still group them by hand in `~/.config/claude-dispatcher/config.toml`, using each repo's directory name:
 

--- a/README.md
+++ b/README.md
@@ -223,6 +223,21 @@ Press `,` in the cockpit (or `:settings`) to edit — written straight to `~/.co
 
 Environment variables override file values, so a secret can stay out of the file.
 
+### Linear, per product
+
+A Linear token sees one workspace, and only the teams Linear granted it — so a portfolio spanning several workspaces takes a token each. Name the token every product is read with in `~/.config/claude-dispatcher/config.toml`:
+
+```toml
+[linear]
+acme    = "lin_api_acme..."
+bluefin = "lin_api_blu..."
+cobalt  = "lin_api_cob..."
+```
+
+Each product is read separately, and its tickets carry it into the backlog. A product with no entry reads with `linear_api_key`, and a config naming no token at all behaves exactly as it always has: one key, one read, tickets with no product.
+
+**Two products in one workspace: give each a key.** Linear scopes an API key to the teams you pick when you create it, so mint one per product and paste it here. Bluefin's token then cannot read cobalt's team at all — the split is the one Linear enforces, not a filter applied to a list we were handed anyway.
+
 **Products** are edited on the products lens (`2`, then `a`), which writes the table below for you. You can still group them by hand in `~/.config/claude-dispatcher/config.toml`, using each repo's directory name:
 
 ```toml
@@ -299,6 +314,6 @@ Each publisher's `skip_upload` is templated on its token, so an unset token mean
 
 - **Everything stuck on "launching"** — the hook isn't firing. Re-run `claude-dispatcher init`; confirm `~/.claude/settings.json` points at the installed binary.
 - **`needs you` vs `blocked` lag** — those rely on the `Notification` hook matchers (`idle_prompt` / `permission_prompt`); `Stop` covers turn completion regardless.
-- **Backlog empty** — set a Linear key / Azure org in settings, and check `gh auth status` for GitHub Issues.
+- **Backlog empty** — set a Linear key / Azure org in settings, and check `gh auth status` for GitHub Issues. One product's Linear tickets missing is usually the scope of its own token: a key granted only some of that workspace's teams returns nothing for the rest, rather than an error.
 - **Fan-outs invisible** — the `SubagentStart`/`SubagentStop` hook entries are newer than your install. Re-run `claude-dispatcher init` to add them.
 - Rebuilds must go to the same path (`make install`) because the hook embeds the absolute binary path.

--- a/docs/adr/0006-a-linear-token-is-the-scope.md
+++ b/docs/adr/0006-a-linear-token-is-the-scope.md
@@ -1,0 +1,110 @@
+# A Linear token is the scope, and a shared one names no product
+
+## Status
+
+Accepted (2026-08-20)
+
+## Context
+
+The Linear backlog source was one `linear_api_key`: everything that one
+token could see, merged into the backlog as an undifferentiated list,
+tagged with no product at all. That is fine for a single workspace and
+wrong for a portfolio. A Linear token is issued by a workspace and sees
+only that workspace, so two products living in two workspaces could only
+ever have one of them represented — the second product's tickets were not
+missing, they were unreachable, and nothing on the screen said so.
+
+The obvious shape is a token per product. That raises three questions the
+one-key design never had to answer.
+
+**What separates two products inside one workspace?** A `teams` filter in
+our config is the tempting answer and the wrong one. The query asks for
+`assignedIssues(first: 50)`; a filter we applied would narrow a list Linear
+had already truncated for us, so a small team's work could be crowded off
+the page by a busier one and read as a product with nothing open. Linear
+grants an API key its teams at creation, which is a split the API enforces
+before the fifty are chosen.
+
+**What does a token two products share say about them?** Nothing — but a
+map keyed by product invites the code to answer anyway, because the read
+that survives deduplication has to be filed under something.
+
+**What happens to the unscoped key once some product names a token?** The
+same question in reverse: the ambient key is as likely to be another
+workspace as one of the scoped ones, and the answer decides whether
+adopting this feature is additive or destructive.
+
+## Decision
+
+**The token is the whole of the scope.** `[linear]` maps a product name to
+the token its backlog is read with; `internal/linear.Assigned(key)` takes
+the key as an argument and narrows nothing further. Where a workspace holds
+two products, the human mints a team-scoped key each and pastes them both —
+the config template, the README and the settings hint all say to scope the
+key where it is created.
+
+**A token two products share names neither.** `linearReads` resolves every
+product's token before it names a single read, because how many products
+claim a token is not knowable one product at a time. A token claimed once
+carries its product; a token claimed twice carries the empty product the
+unscoped read has always carried. Crediting whichever product sorts first
+would have been perfectly stable and perfectly wrong: every other sharer's
+tickets filed under a product that is not theirs. This is the "—" rule from
+the forge-quota decision pointed at ourselves — a label that is a claim
+about a ticket when it is only a fact about our config is worse than no
+label, and inventing records is worse than an empty pane.
+
+**The unscoped key is a read of its own, never a fallback the scoped reads
+switch off.** It goes out whenever no product has already claimed it, and
+it goes out last. Dropping it the moment some product named a token would
+mean that filling in one line of `[linear]` silently emptied a backlog that
+had been reading for months — the failure is invisible, because an empty
+Linear source and an unconfigured one look identical on the lens. Going
+last costs nothing: an issue two reads both return is dropped on the way
+in, and the scoped read is merged first, so it keeps the product tag.
+
+**Deduplication is on the issue id, not the identifier.** "ENG-124" is
+unique inside a workspace and this is a list of several: two workspaces
+that both key a team ENG can genuinely both raise an ENG-124, and dropping
+the second as a duplicate would lose a ticket that was never seen — the one
+failure a backlog must not have. That deliberately keeps a collision it
+does not fix, since `ticket.id` is the identifier and `m.picked` is keyed
+by it, so the two rows are ticked together by a single `space`. Keeping it
+is the cheaper failure: a row you have to look at twice beats a ticket that
+was never on the page.
+
+**Reads go out together and merge in name order.** Five products must not
+wait out five round-trips in series on every refresh, so the calls go
+through the existing `forEach` into a pre-sized slice; the merge then walks
+that slice in the order `linearReads` named it, so what a load produces
+never depends on which workspace answered first. Map order is random, which
+is why the naming is sorted rather than ranged.
+
+**The token is typed where the product is named.** `[linear]` is keyed by
+product name, and product names are minted in the products lens's
+assignment editor — `n` there is the only thing in the product that creates
+one. So `l` on that editor's products pane enters the token for the product
+under the cursor, masked as it is typed and never echoed after, written
+through the same copy-Save-publish path the repo assignments use. Sending
+the human to `config.toml` instead meant retyping a string that has to match
+a product name exactly, in another file, with silence as the only feedback
+when it did not — and the failure that silence hides is the worst kind: the
+token authenticates, the read succeeds, and the tickets are filed under a
+product that groups nowhere. An empty entry removes the line rather than
+storing a blank, because no entry and `product = ""` mean the same thing to
+the reader and different things to the screen.
+
+## Consequences
+
+- A config naming no token is exactly the read it always was, so nothing
+  that predates this has to change, and `LINEAR_API_KEY` still overrides
+  the file for the unscoped key.
+- There is no env override for a per-product token; they live in
+  `config.toml`, which the README's "a secret can stay out of the file"
+  line no longer covers for them.
+- One read failing is still silence. A revoked or mistyped token now means
+  one product is empty rather than the whole source, and the lens cannot
+  tell that from a product with nothing assigned. The forge collector
+  already decided this class of question the other way ("—" is a claim
+  about us, and the cockpit says so); naming the products whose read failed
+  in the backlog's sources kicker is the follow-up.

--- a/internal/cockpit/backlog.go
+++ b/internal/cockpit/backlog.go
@@ -121,8 +121,9 @@ func backlogWrap(s string, w int) []string {
 
 // backlogWhere is the ticket's "product / repo · labels" line, with the clauses
 // it does not have left out. Only GitHub issues resolve to a repo (they are
-// found per repo); a Linear or Azure ticket has neither product nor repo, and
-// the line used to render as " / · In Progress".
+// found per repo); a Linear ticket names the product whose token it came back
+// on and no repo, an Azure one neither, and the line used to render as
+// " / · In Progress".
 func backlogWhere(t ticket) string {
 	var parts []string
 	switch {

--- a/internal/cockpit/cluster.go
+++ b/internal/cockpit/cluster.go
@@ -172,6 +172,67 @@ func (m model) clPersist() tea.Cmd {
 	return func() tea.Msg { return actionMsg{notice: ""} } // reloads the snapshot so every lens regroups
 }
 
+// clLinearKey is the Linear token a product's backlog is read with, or "" when
+// it names none and reads with the unscoped key.
+func (m model) clLinearKey(product string) string {
+	if m.cfg == nil || product == "" {
+		return ""
+	}
+	return m.cfg.Linear[product]
+}
+
+// clSetLinearKey writes product's Linear token into `[linear]` and persists.
+//
+// The token belongs on this screen because `[linear]` is keyed by product NAME,
+// and product names are minted here — `n` is the only place in the product that
+// creates one. Asked to hand-write the table, the human has to retype a string
+// that must match a name in another file exactly, and a mismatch fails silently
+// in the worst possible way: the token authenticates, the read succeeds, and
+// its tickets are filed under a product that groups nowhere. Typed against the
+// row that holds the name, it cannot be mistyped at all.
+//
+// An empty token removes the entry rather than storing a blank, because those
+// are two different states: no entry is "read this product with the unscoped
+// key", and `product = ""` in the file would say the same thing in a way that
+// makes the product look configured on this screen when it is not.
+//
+// Same write discipline as clPersist, for the same reason: a copy is saved
+// first and only a save that worked is published into the cockpit's own config,
+// so the file on disk and the config every collector reads are never two
+// different things.
+func (m model) clSetLinearKey(product, key string) (model, tea.Cmd) {
+	if product == "" {
+		return m, nil
+	}
+	if m.cfg == nil {
+		return m, func() tea.Msg { return actionMsg{notice: "no config — nothing saved"} }
+	}
+	next := map[string]string{}
+	for p, k := range m.cfg.Linear {
+		next[p] = k
+	}
+	key = strings.TrimSpace(key)
+	if key == "" {
+		delete(next, product)
+	} else {
+		next[product] = key
+	}
+	cfg := *m.cfg
+	cfg.Linear = next
+	if err := config.Save(&cfg); err != nil {
+		return m, func() tea.Msg { return actionMsg{notice: "could not save the token: " + err.Error()} }
+	}
+	m.cfg.Linear = next
+	notice := product + " reads Linear with its own token"
+	if key == "" {
+		notice = product + " reads with the unscoped Linear key again"
+	}
+	// The notice rides the message rather than the model because the reload it
+	// queues sets one of its own — collectBacklog reads per token, so the next
+	// snapshot is already the one this changed.
+	return m, func() tea.Msg { return actionMsg{notice: notice} }
+}
+
 // ---- keys -------------------------------------------------------------------
 
 // updateCluster handles the editor's keys. handled is false only for the keys
@@ -215,6 +276,33 @@ func (m model) updateCluster(k string) (model, tea.Cmd, bool) {
 		return m, nil, true
 	}
 
+	// Typing a product's Linear token, likewise. A token is pasted far more
+	// often than it is typed, which is the whole reason text comes from the key
+	// message: a paste is one multi-rune message, and reading the key's *name*
+	// would turn "lin_api_xxx" into nothing at all.
+	if m.clKeying {
+		switch k {
+		case "esc":
+			m.clKeying, m.clKeyFor, m.clKeyText = false, "", ""
+			return m, nil, true
+		case "enter":
+			product, key := m.clKeyFor, m.clKeyText
+			m.clKeying, m.clKeyFor, m.clKeyText = false, "", ""
+			mm, cmd := m.clSetLinearKey(product, key)
+			return mm, cmd, true
+		case "backspace":
+			r := []rune(m.clKeyText)
+			if len(r) > 0 {
+				m.clKeyText = string(r[:len(r)-1])
+			}
+			return m, nil, true
+		}
+		if s, ok := typedTextFor(m.key, k); ok {
+			m.clKeyText += s
+		}
+		return m, nil, true
+	}
+
 	switch k {
 	case "esc", "a":
 		m.clOpen, m.clMarked = false, map[string]bool{}
@@ -228,6 +316,19 @@ func (m model) updateCluster(k string) (model, tea.Cmd, bool) {
 		return m, nil, true
 	case "n":
 		m.clNaming, m.clNewName = true, ""
+		return m, nil, true
+	case "l":
+		// The token is a fact about a product, so it is entered against a
+		// product row and nowhere else — a repo does not have one. Starting from
+		// empty rather than from the stored token: it is masked on screen, and
+		// pre-filling a buffer with a secret the human cannot read is how you
+		// get a half-deleted key saved over a working one.
+		if len(prods) == 0 {
+			m.notice = "no product to hold a token — n names one"
+			return m, nil, true
+		}
+		m.clPane = "products"
+		m.clKeying, m.clKeyFor, m.clKeyText = true, prods[clampCursor(m.clProd, len(prods))], ""
 		return m, nil, true
 	case "j", "down":
 		if m.clPane == "products" {

--- a/internal/cockpit/cluster_linear_test.go
+++ b/internal/cockpit/cluster_linear_test.go
@@ -196,6 +196,38 @@ func TestClLinearKeyIsNeverRendered(t *testing.T) {
 	}
 }
 
+// A real Linear key is about fifty characters and this pane is a third of the
+// terminal, so a mask of one dot per rune is a line wider than the column it is
+// drawn in — which pushes the pane past its own rule and wraps the editor.
+func TestClLinearKeyMaskStaysInsideThePane(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.lens = "products"
+	m.cfg = &config.Config{Products: map[string][]string{"acme": {"acme-api"}}}
+
+	m, _ = clKey(m, "tab")
+	m, _ = clKey(m, "l")
+	m = clType(m, strings.Repeat("k", 60))
+
+	const cw = 30
+	for _, ln := range m.clRight(cw, 30) {
+		if w := dispWidth(ln); w > cw {
+			t.Errorf("line %d columns wide in a %d-column pane: %q", w, cw, ln)
+		}
+	}
+
+	// The naming prompt is the same prose in the same column, and was drawn
+	// past the rule the same way.
+	m, _ = clKey(m, "esc")
+	m, _ = clKey(m, "n")
+	m = clType(m, "a-product-with-a-long-name")
+	for _, ln := range m.clRight(cw, 30) {
+		if w := dispWidth(ln); w > cw {
+			t.Errorf("naming: line %d columns wide in a %d-column pane: %q", w, cw, ln)
+		}
+	}
+}
+
 // A save that fails must leave the cockpit reading with what is still on disk,
 // the same rule clPersist follows: publishing regardless would put the running
 // config and the file permanently at odds under a notice saying nothing saved.

--- a/internal/cockpit/cluster_linear_test.go
+++ b/internal/cockpit/cluster_linear_test.go
@@ -1,0 +1,225 @@
+package cockpit
+
+// cluster_linear_test.go covers entering a product's Linear token in the
+// assignment editor. `[linear]` is keyed by product NAME, and this screen is
+// where product names are made — so the whole point of the key is that the name
+// it saves against cannot be mistyped. These tests pin that join, the two
+// states an empty entry has to tell apart, and the two ways a secret typed into
+// a TUI leaks: onto the screen, and out of the buffer when a global key steals
+// a keystroke.
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"claude-dispatcher/internal/config"
+)
+
+// key drives the editor the way the cockpit does — through handleKey, so the
+// global keys get their chance at the keystroke first.
+func clKey(m model, k string) (model, tea.Cmd) {
+	m.key = tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(k)}
+	next, cmd := m.handleKey(k)
+	return next.(model), cmd
+}
+
+func clType(m model, s string) model {
+	for _, r := range s {
+		m, _ = clKey(m, string(r))
+	}
+	return m
+}
+
+// The join this exists for: the token is saved against the product the cursor
+// is on, so it can never name a product that does not exist.
+func TestClLinearKeySavesAgainstTheProductUnderTheCursor(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.lens = "products"
+	m.cfg = &config.Config{Products: map[string][]string{
+		"acme":    {"acme-api"},
+		"bluefin": {"orbit-billing"},
+	}}
+
+	// acme and bluefin, in name order; l opens the entry on the second.
+	m, _ = clKey(m, "tab")
+	m, _ = clKey(m, "j")
+	m, _ = clKey(m, "l")
+	if !m.clKeying {
+		t.Fatal("l must open the token entry")
+	}
+	if m.clKeyFor != "bluefin" {
+		t.Fatalf("entry is for %q, want the product under the cursor", m.clKeyFor)
+	}
+
+	m = clType(m, "lin_api_blu1")
+	m, cmd := clKey(m, "enter")
+	if cmd == nil {
+		t.Fatal("enter must return a save command")
+	}
+	if m.clKeying {
+		t.Error("enter must close the entry")
+	}
+	if got := m.cfg.Linear["bluefin"]; got != "lin_api_blu1" {
+		t.Errorf("running config has %q for bluefin", got)
+	}
+	if _, ok := m.cfg.Linear["acme"]; ok {
+		t.Error("only the product under the cursor is written")
+	}
+
+	// And it reached the file, in the shape linearReads will read back.
+	out, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Linear["bluefin"] != "lin_api_blu1" {
+		t.Errorf("config on disk = %v", out.Linear)
+	}
+	t.Setenv("LINEAR_API_KEY", "")
+	reads := linearReads(out)
+	if len(reads) != 1 || reads[0].product != "bluefin" || reads[0].key != "lin_api_blu1" {
+		t.Errorf("the token just typed does not scope a read: %+v", reads)
+	}
+}
+
+// An empty entry removes the line rather than storing a blank: no entry means
+// "read this product with the unscoped key", and a blank would say the same
+// thing while making the product look configured on this screen.
+func TestClLinearKeyEmptyClearsTheEntry(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.lens = "products"
+	m.cfg = &config.Config{
+		Products: map[string][]string{"acme": {"acme-api"}},
+		Linear:   map[string]string{"acme": "lin_api_old"},
+	}
+
+	m, _ = clKey(m, "tab")
+	m, _ = clKey(m, "l")
+	m, cmd := clKey(m, "enter")
+	if cmd == nil {
+		t.Fatal("enter must return a save command")
+	}
+	if _, ok := m.cfg.Linear["acme"]; ok {
+		t.Errorf("an empty entry must remove the line, got %v", m.cfg.Linear)
+	}
+	out, err := config.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := out.Linear["acme"]; ok {
+		t.Errorf("config on disk still names a token: %v", out.Linear)
+	}
+}
+
+// esc leaves the stored token alone. Nothing is pre-filled into the buffer, so
+// an abandoned entry must not read as "cleared".
+func TestClLinearKeyEscKeepsTheStoredToken(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.lens = "products"
+	m.cfg = &config.Config{
+		Products: map[string][]string{"acme": {"acme-api"}},
+		Linear:   map[string]string{"acme": "lin_api_old"},
+	}
+
+	m, _ = clKey(m, "tab")
+	m, _ = clKey(m, "l")
+	m = clType(m, "half")
+	m, _ = clKey(m, "esc")
+	if m.clKeying || m.clKeyText != "" {
+		t.Error("esc must close the entry and drop what was typed")
+	}
+	if m.cfg.Linear["acme"] != "lin_api_old" {
+		t.Errorf("esc changed the stored token to %q", m.cfg.Linear["acme"])
+	}
+}
+
+// The buffer owns the keyboard while it is open. A Linear token is mostly
+// lowercase and digits: without the guard in handleKey, "lin_api_1…" switches
+// lens on its first digit and `q` quits the cockpit, both silently discarding a
+// pasted secret.
+func TestClLinearKeyOwnsTheKeyboard(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.lens = "products"
+	m.cfg = &config.Config{Products: map[string][]string{"acme": {"acme-api"}}}
+
+	m, _ = clKey(m, "tab")
+	m, _ = clKey(m, "l")
+	m = clType(m, "lin_api_1q3")
+	if m.clKeyText != "lin_api_1q3" {
+		t.Errorf("buffer = %q — a global key ate a keystroke", m.clKeyText)
+	}
+	if m.lens != "products" {
+		t.Errorf("a digit in the token switched lens to %q", m.lens)
+	}
+	if !m.clKeying {
+		t.Error("the entry closed itself mid-token")
+	}
+}
+
+// The token never reaches the screen. This pane is what a shoulder reads, and a
+// screen-shared cockpit must not be how a key leaks.
+func TestClLinearKeyIsNeverRendered(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	m := clFixture(t)
+	m.lens = "products"
+	m.cfg = &config.Config{
+		Products: map[string][]string{"acme": {"acme-api"}},
+		Linear:   map[string]string{"acme": "lin_api_stored_secret"},
+	}
+
+	// Stored, with the entry closed: the pane says a token is set, not what it
+	// is.
+	view := strings.Join(m.clRight(40, 30), "\n")
+	if strings.Contains(view, "lin_api_stored_secret") {
+		t.Error("the stored token is printed in the products pane")
+	}
+	if !strings.Contains(view, "linear token") {
+		t.Error("nothing on the pane says the product has a token of its own")
+	}
+
+	// And while it is being typed.
+	m, _ = clKey(m, "tab")
+	m, _ = clKey(m, "l")
+	m = clType(m, "lin_api_typed_secret")
+	view = strings.Join(m.clRight(40, 30), "\n")
+	if strings.Contains(view, "lin_api_typed_secret") {
+		t.Error("the token is echoed as it is typed")
+	}
+	if !strings.Contains(view, "••") {
+		t.Error("the entry shows nothing at all — the human cannot tell it is receiving")
+	}
+}
+
+// A save that fails must leave the cockpit reading with what is still on disk,
+// the same rule clPersist follows: publishing regardless would put the running
+// config and the file permanently at odds under a notice saying nothing saved.
+func TestClLinearKeyDoesNotPublishAFailedSave(t *testing.T) {
+	blocker := t.TempDir() + "/home"
+	if err := os.WriteFile(blocker, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", blocker)
+
+	m := clFixture(t)
+	m.cfg = &config.Config{
+		Products: map[string][]string{"acme": {"acme-api"}},
+		Linear:   map[string]string{"acme": "lin_api_old"},
+	}
+	mm, cmd := m.clSetLinearKey("acme", "lin_api_new")
+	if cmd == nil {
+		t.Fatal("a failed save must still report")
+	}
+	msg, ok := cmd().(actionMsg)
+	if !ok || !strings.Contains(msg.notice, "could not save") {
+		t.Fatalf("notice = %+v, want a failure the human can see", msg)
+	}
+	if mm.cfg.Linear["acme"] != "lin_api_old" {
+		t.Errorf("a failed save was published anyway: %v", mm.cfg.Linear)
+	}
+}

--- a/internal/cockpit/cluster_view.go
+++ b/internal/cockpit/cluster_view.go
@@ -106,8 +106,24 @@ func (m model) clPaneLabel() string {
 	return "repos · tab to products"
 }
 
-// clRight is the product list, the new-product affordance, the naming prompt
-// when it is up, and the explanation pinned to the bottom.
+// clHint is a prompt's explanatory line, wrapped to the pane.
+//
+// These are full sentences in a column a third of the terminal wide, so they
+// were drawn wider than the pane they sit in: the over-long line pushes past
+// the vertical rule and the terminal wraps it, breaking the two-pane layout at
+// exactly the moment the human has a half-typed buffer on screen. The tail
+// explanation below has always gone through productsWrap for this reason; the
+// prompts are the same prose in the same column.
+func clHint(s string, cw int) []string {
+	var out []string
+	for _, ln := range productsWrap(s, cw) {
+		out = append(out, fg(cFaint, ln))
+	}
+	return out
+}
+
+// clRight is the product list, the new-product affordance, the naming and token
+// prompts when one is up, and the explanation pinned to the bottom.
 func (m model) clRight(cw, h int) []string {
 	prods := m.clProducts()
 	counts := map[string]int{}
@@ -158,7 +174,8 @@ func (m model) clRight(cw, h int) []string {
 		if len(m.clTargets()) == 1 {
 			hint = "enter creates it and moves this repo in"
 		}
-		out = append(out, "", fg(cFaint, hint))
+		out = append(out, "")
+		out = append(out, clHint(hint, cw)...)
 	}
 
 	if m.clKeying {
@@ -166,13 +183,22 @@ func (m model) clRight(cw, h int) []string {
 		// Masked as it is typed, like the settings editor's secret field: a
 		// pasted key is not read back off the screen, and a screen-shared
 		// cockpit must not be how it leaks.
-		out = append(out, fg(cWhite, strings.Repeat("•", len([]rune(m.clKeyText))))+paint(cFg, cFg, " "))
+		//
+		// Capped at the pane. A Linear key runs to about fifty characters and
+		// this pane is a third of the terminal, so one dot per rune is a line
+		// wider than the column it is drawn in — which pushes the pane past its
+		// own rule and wraps the whole editor. The dots are a sign that the
+		// field is receiving, not a character count, so there is nothing to lose
+		// by stopping at the edge.
+		dots := mini(len([]rune(m.clKeyText)), maxi(cw-1, 0))
+		out = append(out, fg(cWhite, strings.Repeat("•", dots))+paint(cFg, cFg, " "))
 		hint := "enter saves it · this product's backlog is read with it"
 		if m.clLinearKey(m.clKeyFor) != "" {
 			hint = "enter replaces the token · empty clears it"
 		}
-		out = append(out, "", fg(cFaint, hint))
-		out = append(out, fg(cFaint, "scope the key to this product's teams in Linear"))
+		out = append(out, "")
+		out = append(out, clHint(hint, cw)...)
+		out = append(out, clHint("scope the key to this product's teams in Linear", cw)...)
 	}
 
 	// Pin the explanation to the bottom, as the design does with flex:1.

--- a/internal/cockpit/cluster_view.go
+++ b/internal/cockpit/cluster_view.go
@@ -132,14 +132,24 @@ func (m model) clRight(cw, h int) []string {
 		if n != 1 {
 			word = "repos"
 		}
+		// A product's own Linear token is said, never shown: the sub-line is
+		// already the product's summary, and whether its backlog is read with a
+		// key of its own is the other thing about it that is configured. The
+		// token itself never reaches the screen — it is a secret, and this pane
+		// is what a shoulder reads.
+		meta := itoa(n) + " " + word
+		if m.clLinearKey(p) != "" {
+			meta += " · linear token"
+		}
 		out = append(out,
 			row(cw, bg, c(mark, 3, cMid), flexc(p, cFg)),
-			row(cw, bg, c("", 3, ""), flexc(itoa(n)+" "+word, cFaint)),
+			row(cw, bg, c("", 3, ""), flexc(meta, cFaint)),
 		)
 	}
 
 	out = append(out, "", fg(cRule, strings.Repeat("─", cw)))
 	out = append(out, row(cw, "", c("n", 3, cFg), flexc("new product…", cDim)))
+	out = append(out, row(cw, "", c("l", 3, cFg), flexc("linear token…", cDim)))
 
 	if m.clNaming {
 		out = append(out, "", fg(cDim, "new product"))
@@ -149,6 +159,20 @@ func (m model) clRight(cw, h int) []string {
 			hint = "enter creates it and moves this repo in"
 		}
 		out = append(out, "", fg(cFaint, hint))
+	}
+
+	if m.clKeying {
+		out = append(out, "", fg(cDim, "linear token · "+m.clKeyFor))
+		// Masked as it is typed, like the settings editor's secret field: a
+		// pasted key is not read back off the screen, and a screen-shared
+		// cockpit must not be how it leaks.
+		out = append(out, fg(cWhite, strings.Repeat("•", len([]rune(m.clKeyText))))+paint(cFg, cFg, " "))
+		hint := "enter saves it · this product's backlog is read with it"
+		if m.clLinearKey(m.clKeyFor) != "" {
+			hint = "enter replaces the token · empty clears it"
+		}
+		out = append(out, "", fg(cFaint, hint))
+		out = append(out, fg(cFaint, "scope the key to this product's teams in Linear"))
 	}
 
 	// Pin the explanation to the bottom, as the design does with flex:1.

--- a/internal/cockpit/collect_backlog.go
+++ b/internal/cockpit/collect_backlog.go
@@ -58,15 +58,23 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 	// out together — five products would otherwise wait out five round-trips in
 	// a row on every refresh — but are merged back in the order linearReads
 	// named them, so what a load produces never depends on which workspace
-	// answered first. Tickets are deduped because two tokens can still overlap
-	// on a team: the picked set is keyed by ticket id, so one issue on two rows
-	// would tick both with one space.
+	// answered first. Tickets are deduped because two team-scoped tokens can
+	// still overlap on a team, and one issue on two rows is one issue the human
+	// has to pick, dispatch and dismiss twice.
 	//
 	// Deduped on the issue's id and NOT on its identifier: "ENG-124" is unique
 	// inside a workspace, and this is a list of several. Two workspaces that
 	// both key a team ENG really can both raise an ENG-124, and dropping the
 	// second as a duplicate would lose a ticket that was never seen — the one
 	// failure a backlog must not have.
+	//
+	// Which means the identifier collision is kept, not fixed: `ticket.id` is
+	// the identifier, `m.picked` is keyed by it, and `blkTakenBy` matches off
+	// its slug, so two workspaces' ENG-124s are ticked together by one `space`
+	// and reported taken together. That is a known cost of showing both, and the
+	// cheaper of the two: a row you have to look twice at beats a ticket that
+	// was never on the page. (Neither can be dispatched from this lens anyway —
+	// a Linear ticket carries no repo, so `enter` and `ctrl+d` both refuse it.)
 	reads := linearReads(ctx.cfg)
 	readIssues := make([][]linear.Issue, len(reads))
 	forEach(reads, func(i int, r linearRead) {
@@ -135,36 +143,63 @@ type linearRead struct {
 // the one unscoped read the ambient key implies, which is every install
 // predating this.
 //
-// Products are visited in name order because map order is random: two products
-// naming one token are one read, and which of them keeps it must not change
-// between two loads of the same config.
+// Two products naming one token are one read, and that read names NEITHER of
+// them. A token shared by two products cannot say which of them an issue it
+// returns belongs to, so the product it carries is empty — the same blank the
+// unscoped read has always carried. Crediting the first claimant instead would
+// be stable and wrong: every other sharer's tickets would come back filed under
+// a product that is not theirs, and a wrong product is worse than none for
+// exactly the reason a repo with no check is "—" rather than a pass.
+//
+// The unscoped key is a read of its own whenever no product has claimed it,
+// never a fallback the scoped reads switch off. It is as likely to be another
+// workspace as the same one, and dropping it because some product named a token
+// would empty a backlog that had been reading for months, silently, the moment
+// its owner filled in one line of `[linear]`. An issue two reads both return is
+// dropped by id on the way in, and the unscoped read goes last, so the overlap
+// this could cause costs a comparison and never a duplicate row or a lost tag.
+//
+// Products are visited in name order because map order is random: which product
+// a read is filed under, and which of two duplicate tickets survives, must not
+// change between two loads of the same config.
 func linearReads(cfg *config.Config) []linearRead {
 	unscoped := linear.Key()
+	seen := map[string]bool{}
 	var out []linearRead
 	if cfg != nil {
-		seen := map[string]bool{}
-		for _, product := range slices.Sorted(maps.Keys(cfg.Linear)) {
-			key := cfg.Linear[product]
+		// Every product's token is resolved before any read is named: whether a
+		// token can name a product at all depends on how many products claim
+		// it, which is not knowable one product at a time.
+		keyFor, claims := map[string]string{}, map[string]int{}
+		for product, key := range cfg.Linear {
 			if key == "" {
 				key = unscoped
 			}
 			// A product naming no token, with no unscoped key to fall back on,
 			// has nothing to ask with. Skipping it says nothing about that
 			// product's backlog, which is the honest answer.
-			if key == "" || seen[key] {
+			if key == "" {
+				continue
+			}
+			keyFor[product] = key
+			claims[key]++
+		}
+		for _, product := range slices.Sorted(maps.Keys(keyFor)) {
+			key := keyFor[product]
+			if seen[key] {
 				continue
 			}
 			seen[key] = true
+			if claims[key] > 1 {
+				product = ""
+			}
 			out = append(out, linearRead{product: product, key: key})
 		}
 	}
-	if len(out) > 0 {
-		return out
+	if unscoped != "" && !seen[unscoped] {
+		out = append(out, linearRead{key: unscoped})
 	}
-	if unscoped == "" {
-		return nil
-	}
-	return []linearRead{{key: unscoped}}
+	return out
 }
 
 // blkPrompt composes what the dispatcher is actually sent when a ticket is

--- a/internal/cockpit/collect_backlog.go
+++ b/internal/cockpit/collect_backlog.go
@@ -7,11 +7,14 @@ package cockpit
 // slice so the lens shows an honest state (empty when genuinely nothing).
 
 import (
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
 
 	"claude-dispatcher/internal/azure"
+	"claude-dispatcher/internal/config"
 	"claude-dispatcher/internal/gh"
 	"claude-dispatcher/internal/linear"
 	"claude-dispatcher/internal/state"
@@ -50,22 +53,46 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 		}
 	}
 
-	// Linear assigned issues (only when configured).
-	if linear.Configured() {
-		if issues, err := linear.Assigned(); err == nil {
-			for _, is := range issues {
-				tickets = append(tickets, ticket{
-					id:     is.Identifier,
-					src:    "lin",
-					title:  is.Title,
-					pri:    blkPriFromLinear(is.Priority),
-					age:    blkAge(is.UpdatedAt),
-					labels: is.State,
-					body:   is.Description,
-					prompt: blkPrompt("Linear issue", is.Identifier, is.Title, is.Description),
-					taken:  blkTakenBy(ctx.records, is.Identifier, is.Title),
-				})
+	// Linear assigned issues, one read per configured token (see linearReads),
+	// each ticket carrying the product whose token it came back on. The reads go
+	// out together — five products would otherwise wait out five round-trips in
+	// a row on every refresh — but are merged back in the order linearReads
+	// named them, so what a load produces never depends on which workspace
+	// answered first. Tickets are deduped because two tokens can still overlap
+	// on a team: the picked set is keyed by ticket id, so one issue on two rows
+	// would tick both with one space.
+	//
+	// Deduped on the issue's id and NOT on its identifier: "ENG-124" is unique
+	// inside a workspace, and this is a list of several. Two workspaces that
+	// both key a team ENG really can both raise an ENG-124, and dropping the
+	// second as a duplicate would lose a ticket that was never seen — the one
+	// failure a backlog must not have.
+	reads := linearReads(ctx.cfg)
+	readIssues := make([][]linear.Issue, len(reads))
+	forEach(reads, func(i int, r linearRead) {
+		if issues, err := linear.Assigned(r.key); err == nil {
+			readIssues[i] = issues
+		}
+	})
+	linSeen := map[string]bool{}
+	for i, r := range reads {
+		for _, is := range readIssues[i] {
+			if linSeen[is.ID] {
+				continue
 			}
+			linSeen[is.ID] = true
+			tickets = append(tickets, ticket{
+				id:      is.Identifier,
+				src:     "lin",
+				title:   is.Title,
+				product: r.product,
+				pri:     blkPriFromLinear(is.Priority),
+				age:     blkAge(is.UpdatedAt),
+				labels:  is.State,
+				body:    is.Description,
+				prompt:  blkPrompt("Linear issue", is.Identifier, is.Title, is.Description),
+				taken:   blkTakenBy(ctx.records, is.Identifier, is.Title),
+			})
 		}
 	}
 
@@ -89,6 +116,55 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 	}
 
 	s.backlogTickets = tickets
+}
+
+// linearRead is one call to Linear: the product whose backlog it fills, and the
+// token it reads with.
+type linearRead struct {
+	product string
+	key     string
+}
+
+// linearReads names the Linear calls a load makes. A token sees one workspace,
+// and only the teams Linear granted it when the key was created, so a portfolio
+// spanning several workspaces is several reads — one per product that names a
+// token, or the unscoped one for a product that names none. Nothing here
+// narrows a read further: two products in one workspace are separated by giving
+// each a team-scoped key, which is a split the API enforces rather than one we
+// apply to a list we were already handed. A config naming no token at all is
+// the one unscoped read the ambient key implies, which is every install
+// predating this.
+//
+// Products are visited in name order because map order is random: two products
+// naming one token are one read, and which of them keeps it must not change
+// between two loads of the same config.
+func linearReads(cfg *config.Config) []linearRead {
+	unscoped := linear.Key()
+	var out []linearRead
+	if cfg != nil {
+		seen := map[string]bool{}
+		for _, product := range slices.Sorted(maps.Keys(cfg.Linear)) {
+			key := cfg.Linear[product]
+			if key == "" {
+				key = unscoped
+			}
+			// A product naming no token, with no unscoped key to fall back on,
+			// has nothing to ask with. Skipping it says nothing about that
+			// product's backlog, which is the honest answer.
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, linearRead{product: product, key: key})
+		}
+	}
+	if len(out) > 0 {
+		return out
+	}
+	if unscoped == "" {
+		return nil
+	}
+	return []linearRead{{key: unscoped}}
 }
 
 // blkPrompt composes what the dispatcher is actually sent when a ticket is

--- a/internal/cockpit/collect_backlog_test.go
+++ b/internal/cockpit/collect_backlog_test.go
@@ -51,12 +51,38 @@ func TestLinearReadsPerProduct(t *testing.T) {
 	if got[0].key != "lin_api_acme" || got[1].key != "lin_api_blu" || got[2].key != "lin_api_cob" {
 		t.Errorf("each product must be read with its own token: %+v", got)
 	}
-	// A scoped config makes no unscoped read of its own: the ambient key would
-	// return the scoped products' issues all over again, under no product.
+	// With no ambient key there is nothing else to read: a product per token and
+	// no unscoped read tacked on the end.
 	for _, r := range got {
 		if r.product == "" {
-			t.Errorf("a scoped config must make no unscoped read, got %+v", r)
+			t.Errorf("no ambient key means no unscoped read, got %+v", r)
 		}
+	}
+}
+
+// TestLinearReadsKeepsTheUnscopedRead is the non-destructive rule: filling in
+// one line of [linear] must not empty the backlog that was already reading. The
+// ambient key is another workspace as easily as the same one, so it stays a read
+// of its own — and goes last, so a scoped read keeps the product tag on any
+// issue both of them return.
+func TestLinearReadsKeepsTheUnscopedRead(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	got := linearReads(&config.Config{Linear: map[string]string{"acme": "lin_api_acme"}})
+	if len(got) != 2 {
+		t.Fatalf("expected the scoped read and the ambient one, got %+v", got)
+	}
+	if got[0].product != "acme" || got[0].key != "lin_api_acme" {
+		t.Errorf("scoped read = %+v", got[0])
+	}
+	if got[1].product != "" || got[1].key != "lin_api_ambient" {
+		t.Errorf("the ambient read must come last and name no product: %+v", got[1])
+	}
+
+	// Unless a product has already claimed it, in which case it is that
+	// product's read and asking again would be the same call twice.
+	got = linearReads(&config.Config{Linear: map[string]string{"acme": "lin_api_ambient"}})
+	if len(got) != 1 || got[0].product != "acme" {
+		t.Errorf("a product naming the ambient key is one read, got %+v", got)
 	}
 }
 
@@ -84,7 +110,11 @@ func TestLinearReadsSkipsProductWithNoToken(t *testing.T) {
 	}
 }
 
-func TestLinearReadsDedupesOneTokenNamedTwice(t *testing.T) {
+// TestLinearReadsSharedTokenNamesNoProduct: one token named twice is one read,
+// and that read names neither claimant. A shared token cannot say which of them
+// an issue belongs to, and filing every sharer's tickets under whichever
+// product sorts first would be stable and wrong.
+func TestLinearReadsSharedTokenNamesNoProduct(t *testing.T) {
 	t.Setenv("LINEAR_API_KEY", "")
 	cfg := &config.Config{Linear: map[string]string{
 		"acme":    "lin_api_shared",
@@ -95,7 +125,27 @@ func TestLinearReadsDedupesOneTokenNamedTwice(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("one token named twice is one read, got %+v", got)
 	}
-	if got[0].product != "acme" || got[1].product != "cobalt" {
-		t.Errorf("the first product in name order keeps the read: %+v", got)
+	if got[0].key != "lin_api_shared" || got[0].product != "" {
+		t.Errorf("a shared token must name no product: %+v", got[0])
+	}
+	// Name order still decides the order the reads merge in — it just does not
+	// decide who gets credited for a token two products hold.
+	if got[1].product != "cobalt" || got[1].key != "lin_api_cobalt" {
+		t.Errorf("a token one product holds still names it: %+v", got[1])
+	}
+}
+
+// TestLinearReadsSharedFallbackNamesNoProduct is the same rule reached the other
+// way: two products naming no token of their own both fall back to the ambient
+// key, which then speaks for neither.
+func TestLinearReadsSharedFallbackNamesNoProduct(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	cfg := &config.Config{Linear: map[string]string{"acme": "", "bluefin": ""}}
+	got := linearReads(cfg)
+	if len(got) != 1 {
+		t.Fatalf("one fallback token is one read, got %+v", got)
+	}
+	if got[0].key != "lin_api_ambient" || got[0].product != "" {
+		t.Errorf("read = %+v, want the ambient key under no product", got[0])
 	}
 }

--- a/internal/cockpit/collect_backlog_test.go
+++ b/internal/cockpit/collect_backlog_test.go
@@ -1,0 +1,101 @@
+package cockpit
+
+// collect_backlog_test.go covers linearReads — which Linear calls a load makes.
+// It is the whole of the scoping rule: a token sees one workspace and only the
+// teams Linear granted it, so which token reads a product is what scopes it.
+
+import (
+	"testing"
+
+	"claude-dispatcher/internal/config"
+)
+
+func TestLinearReadsUnscoped(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	if got := linearReads(nil); got != nil {
+		t.Errorf("no config and no key must read nothing, got %+v", got)
+	}
+	if got := linearReads(&config.Config{}); got != nil {
+		t.Errorf("a config naming no token, with no key, must read nothing, got %+v", got)
+	}
+
+	// The install that predates scoping: one key, one read, no product.
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	got := linearReads(&config.Config{})
+	if len(got) != 1 {
+		t.Fatalf("expected one unscoped read, got %+v", got)
+	}
+	if got[0].key != "lin_api_ambient" || got[0].product != "" {
+		t.Errorf("unscoped read = %+v", got[0])
+	}
+}
+
+// TestLinearReadsPerProduct is the shape this exists for: several products, a
+// token each — including two products in one workspace, told apart by holding a
+// team-scoped key apiece rather than by anything this code does.
+func TestLinearReadsPerProduct(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	cfg := &config.Config{Linear: map[string]string{
+		"acme":    "lin_api_acme",
+		"bluefin": "lin_api_blu",
+		"cobalt":  "lin_api_cob",
+	}}
+	got := linearReads(cfg)
+	if len(got) != 3 {
+		t.Fatalf("expected a read per product, got %+v", got)
+	}
+	// Name order, so a load cannot reshuffle them.
+	if got[0].product != "acme" || got[1].product != "bluefin" || got[2].product != "cobalt" {
+		t.Fatalf("reads out of name order: %+v", got)
+	}
+	if got[0].key != "lin_api_acme" || got[1].key != "lin_api_blu" || got[2].key != "lin_api_cob" {
+		t.Errorf("each product must be read with its own token: %+v", got)
+	}
+	// A scoped config makes no unscoped read of its own: the ambient key would
+	// return the scoped products' issues all over again, under no product.
+	for _, r := range got {
+		if r.product == "" {
+			t.Errorf("a scoped config must make no unscoped read, got %+v", r)
+		}
+	}
+}
+
+func TestLinearReadsFallsBackToUnscopedKey(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	cfg := &config.Config{Linear: map[string]string{"acme": ""}}
+	got := linearReads(cfg)
+	if len(got) != 1 {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].key != "lin_api_ambient" || got[0].product != "acme" {
+		t.Errorf("read = %+v, want the unscoped key scoped to acme", got[0])
+	}
+}
+
+func TestLinearReadsSkipsProductWithNoToken(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	cfg := &config.Config{Linear: map[string]string{
+		"acme":    "", // no token of its own, none ambient
+		"bluefin": "lin_api_bluefin",
+	}}
+	got := linearReads(cfg)
+	if len(got) != 1 || got[0].product != "bluefin" {
+		t.Fatalf("a product with no token to ask with must be skipped, got %+v", got)
+	}
+}
+
+func TestLinearReadsDedupesOneTokenNamedTwice(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "")
+	cfg := &config.Config{Linear: map[string]string{
+		"acme":    "lin_api_shared",
+		"bluefin": "lin_api_shared",
+		"cobalt":  "lin_api_cobalt",
+	}}
+	got := linearReads(cfg)
+	if len(got) != 2 {
+		t.Fatalf("one token named twice is one read, got %+v", got)
+	}
+	if got[0].product != "acme" || got[1].product != "cobalt" {
+		t.Errorf("the first product in name order keeps the read: %+v", got)
+	}
+}

--- a/internal/cockpit/keys.go
+++ b/internal/cockpit/keys.go
@@ -230,12 +230,13 @@ func (m model) handleKey(k string) (tea.Model, tea.Cmd) {
 		}
 		m = mm
 	}
-	// Naming a product is text entry, so it belongs with the other modes that
-	// own the keyboard — settings, the dispatch form, the palette. Without this
-	// guard the global keys resolved first: `q` killed the cockpit mid-name and
-	// a digit switched lens, both discarding what had been typed, and the footer
-	// promised only "esc cancels".
-	if m.clNaming {
+	// Naming a product, or typing its Linear token, is text entry, so it belongs
+	// with the other modes that own the keyboard — settings, the dispatch form,
+	// the palette. Without this guard the global keys resolved first: `q` killed
+	// the cockpit mid-name and a digit switched lens, both discarding what had
+	// been typed, and the footer promised only "esc cancels". A token makes that
+	// worse, not better: `lin_api_1…` would switch lens on its first digit.
+	if m.clNaming || m.clKeying {
 		mm, cmd := m.updateProducts(k)
 		return mm, cmd
 	}
@@ -296,6 +297,7 @@ func (m model) handleKey(k string) (tea.Model, tea.Cmd) {
 		// dxReset closes the form and clears all four fields.
 		m = m.dxReset()
 		m.clOpen, m.clNaming, m.clNewName = false, false, ""
+		m.clKeying, m.clKeyFor, m.clKeyText = false, "", ""
 		m.clMarked = map[string]bool{}
 		return m, nil
 	}

--- a/internal/cockpit/model.go
+++ b/internal/cockpit/model.go
@@ -111,6 +111,12 @@ type model struct {
 	clNaming  bool
 	clNewName string
 	clMap     map[string]string
+	// clKeying is the Linear token entry: which product it is for, and what has
+	// been typed. The product is held by name rather than by cursor index
+	// because the list can be re-sorted under it by a save.
+	clKeying  bool
+	clKeyFor  string
+	clKeyText string
 
 	decRepo      int
 	decCursor    int

--- a/internal/cockpit/overlays_chrome.go
+++ b/internal/cockpit/overlays_chrome.go
@@ -52,6 +52,7 @@ var helpSections = []struct {
 		{"esc", "close the panel"},
 		{"a", "assign repos to products"},
 		{"n", "new product — names it and moves the marked repos in"},
+		{"l", "the Linear token this product's backlog is read with"},
 		{"space", "mark a repo · enter moves every marked one"},
 		{"tab", "between the repo list and the products"},
 		{"u / ctrl+u", "take repos back out of a product · start over"},

--- a/internal/cockpit/settings.go
+++ b/internal/cockpit/settings.go
@@ -45,7 +45,7 @@ type settingsState struct {
 
 var settingsFields = []settingsField{
 	{key: "roots", label: "scan roots", hint: "comma-separated dirs scanned for repos", kind: setRoots},
-	{key: "linear_api_key", label: "Linear API key", hint: "the Linear backlog · a token per product in [linear]", kind: setSecret},
+	{key: "linear_api_key", label: "Linear API key", hint: "the unscoped Linear read · a token per product on 2, a, l", kind: setSecret},
 	{key: "azure_org", label: "Azure DevOps org", hint: "org URL, e.g. https://dev.azure.com/acme", kind: setString},
 	{key: "azure_project", label: "Azure project", hint: "Azure Boards project name", kind: setString},
 	{key: "weekly_token_limit", label: "weekly token budget", hint: "0 = unknown → usage shows raw tokens", kind: setInt},

--- a/internal/cockpit/settings.go
+++ b/internal/cockpit/settings.go
@@ -45,7 +45,7 @@ type settingsState struct {
 
 var settingsFields = []settingsField{
 	{key: "roots", label: "scan roots", hint: "comma-separated dirs scanned for repos", kind: setRoots},
-	{key: "linear_api_key", label: "Linear API key", hint: "enables the Linear backlog source", kind: setSecret},
+	{key: "linear_api_key", label: "Linear API key", hint: "the Linear backlog · a token per product in [linear]", kind: setSecret},
 	{key: "azure_org", label: "Azure DevOps org", hint: "org URL, e.g. https://dev.azure.com/acme", kind: setString},
 	{key: "azure_project", label: "Azure project", hint: "Azure Boards project name", kind: setString},
 	{key: "weekly_token_limit", label: "weekly token budget", hint: "0 = unknown → usage shows raw tokens", kind: setInt},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,8 +34,11 @@ type Config struct {
 	// A token sees one workspace and only the teams Linear granted it, so a
 	// portfolio spanning several workspaces needs one each — as do two products
 	// in one workspace, who get a team-scoped key apiece. A product with no
-	// entry reads with LinearAPIKey. Written by hand; the settings editor holds
-	// LinearAPIKey.
+	// entry reads with LinearAPIKey, which the settings editor holds. Edited on
+	// the products lens's assignment editor (`l`), because this map is keyed by
+	// product NAME and that screen is where names are made — hand-writing it
+	// means retyping a key that has to match one exactly, in another file, with
+	// silence as the only feedback when it does not.
 	Linear map[string]string `toml:"linear,omitempty"`
 	// WeeklyTokenLimit is the subscription's weekly token budget. There is no
 	// API to read it (Claude Code exposes usage only interactively), so it is a

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,13 @@ type Config struct {
 	LinearAPIKey string `toml:"linear_api_key,omitempty"` // Linear backlog source
 	AzureOrg     string `toml:"azure_org,omitempty"`      // Azure DevOps org URL
 	AzureProject string `toml:"azure_project,omitempty"`  // Azure DevOps project
+	// Linear maps a product name to the Linear token its backlog is read with.
+	// A token sees one workspace and only the teams Linear granted it, so a
+	// portfolio spanning several workspaces needs one each — as do two products
+	// in one workspace, who get a team-scoped key apiece. A product with no
+	// entry reads with LinearAPIKey. Written by hand; the settings editor holds
+	// LinearAPIKey.
+	Linear map[string]string `toml:"linear,omitempty"`
 	// WeeklyTokenLimit is the subscription's weekly token budget. There is no
 	// API to read it (Claude Code exposes usage only interactively), so it is a
 	// user setting; 0 means unknown and the usage lens shows raw tokens instead
@@ -113,7 +120,8 @@ func Save(c *Config) error {
 	b.WriteString("roots = " + tomlStrings(c.Roots) + "\n\n")
 	// Top-level integration keys must precede the first [table] in TOML.
 	b.WriteString("# Integrations (optional; edit in-app with `s`). Matching env vars override.\n")
-	b.WriteString("# linear_api_key enables the Linear backlog source.\n")
+	b.WriteString("# linear_api_key is the unscoped Linear key: the whole backlog when no\n")
+	b.WriteString("# product names one below, and what a product with no entry is read with.\n")
 	fmt.Fprintf(&b, "linear_api_key = %q\n", c.LinearAPIKey)
 	b.WriteString("# Azure Boards backlog (needs the az CLI logged in): the org URL and project.\n")
 	fmt.Fprintf(&b, "azure_org = %q\n", c.AzureOrg)
@@ -121,6 +129,16 @@ func Save(c *Config) error {
 	b.WriteString("# Your subscription's weekly token budget (no API exposes it, so set it here).\n")
 	b.WriteString("# 0 = unknown → the usage lens shows raw tokens instead of a percentage.\n")
 	fmt.Fprintf(&b, "weekly_token_limit = %d\n\n", c.WeeklyTokenLimit)
+	b.WriteString("# The Linear token each product's backlog is read with, keyed by product\n")
+	b.WriteString("# name. A token sees one workspace and only the teams Linear granted it, so\n")
+	b.WriteString("# two products in one workspace get a team-scoped key each — scope it where\n")
+	b.WriteString("# you create it. Products with no entry read with linear_api_key above.\n")
+	b.WriteString("# acme-shop = \"lin_api_...\"\n")
+	b.WriteString("[linear]\n")
+	for _, k := range slices.Sorted(maps.Keys(c.Linear)) {
+		fmt.Fprintf(&b, "%s = %q\n", tomlKey(k), c.Linear[k])
+	}
+	b.WriteString("\n")
 	b.WriteString("# Map product names to repo directory names for the portfolio roll-up.\n")
 	b.WriteString("# acme-shop = [\"shop-api\", \"shop-web\"]\n")
 	b.WriteString("[products]\n")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,6 +61,40 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+// TestSaveLoadLinearTokens proves the per-product Linear table survives the
+// hand-written template Save regenerates, alongside the unscoped key every
+// product without an entry reads with.
+func TestSaveLoadLinearTokens(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	in := &Config{
+		Roots:        []string{"~/repos"},
+		LinearAPIKey: "lin_api_default",
+		Linear: map[string]string{
+			"acme shop": "lin_api_acme",
+			"bluefin":   "lin_api_bluefin",
+		},
+		Products: map[string][]string{"bluefin": {"bluefin-core"}},
+	}
+	if err := Save(in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.LinearAPIKey != "lin_api_default" {
+		t.Errorf("linear_api_key = %q", out.LinearAPIKey)
+	}
+	if out.Linear["acme shop"] != "lin_api_acme" || out.Linear["bluefin"] != "lin_api_bluefin" {
+		t.Errorf("linear tokens = %v", out.Linear)
+	}
+	// The tables that follow it must still be readable — a table written in the
+	// wrong place swallows whatever comes next.
+	if !slices.Equal(out.Products["bluefin"], []string{"bluefin-core"}) {
+		t.Errorf("products after the linear table = %v", out.Products)
+	}
+}
+
 func TestWriteDefaultDoesNotOverwrite(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	if _, created, err := WriteDefault(); err != nil || !created {

--- a/internal/linear/linear.go
+++ b/internal/linear/linear.go
@@ -1,7 +1,8 @@
-// Package linear is an env-gated, best-effort Linear API client for the
-// cockpit backlog. It is active only when LINEAR_API_KEY is set; every call
-// degrades cleanly on a transport, JSON, or GraphQL error, returning an error
-// the collector treats as "no signal" rather than surfacing it to the UI loop.
+// Package linear is a best-effort Linear API client for the cockpit backlog.
+// A read is scoped by its key: one token sees one workspace, and only the teams
+// Linear granted it. Every call degrades cleanly on a transport, JSON, or
+// GraphQL error, returning an error the collector treats as "no signal" rather
+// than surfacing it to the UI loop.
 package linear
 
 import (
@@ -15,9 +16,11 @@ import (
 
 const endpoint = "https://api.linear.app/graphql"
 
-// Configured reports whether a Linear API key is present in the environment.
-func Configured() bool {
-	return os.Getenv("LINEAR_API_KEY") != ""
+// Key is the unscoped API key: the ambient LINEAR_API_KEY, which the cockpit
+// seeds from config at start-up. It is what a product whose source names no key
+// of its own reads with, and the whole of the backlog when no product does.
+func Key() string {
+	return os.Getenv("LINEAR_API_KEY")
 }
 
 // Issue is a single Linear issue assigned to the current viewer.
@@ -36,26 +39,36 @@ const query = `query { viewer { assignedIssues(first: 50, filter: { state: { typ
     nodes { id identifier title description priority priorityLabel updatedAt
             state { name } team { key } } } } }`
 
-// Assigned returns the open issues assigned to the current Linear viewer.
-// It returns (nil, nil) when not Configured(), and (nil, err) on any
-// transport, JSON, or GraphQL error so the caller can degrade cleanly.
-func Assigned() ([]Issue, error) {
-	if !Configured() {
-		return nil, nil
-	}
-
+// newRequest builds the assigned-issues request, read with key. The key is the
+// whole of the scope — which workspace, and which of its teams — because Linear
+// grants that when the key is created, so nothing here narrows it further.
+func newRequest(key string) (*http.Request, error) {
 	body, err := json.Marshal(map[string]string{"query": query})
 	if err != nil {
 		return nil, err
 	}
-
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	// Linear uses the raw key as the Authorization header (no "Bearer").
-	req.Header.Set("Authorization", os.Getenv("LINEAR_API_KEY"))
+	req.Header.Set("Authorization", key)
 	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// Assigned returns the open issues assigned to key's viewer. It returns
+// (nil, nil) for an empty key, and (nil, err) on any transport, JSON, or
+// GraphQL error so the caller can degrade cleanly.
+func Assigned(key string) ([]Issue, error) {
+	if key == "" {
+		return nil, nil
+	}
+
+	req, err := newRequest(key)
+	if err != nil {
+		return nil, err
+	}
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)

--- a/internal/linear/linear_test.go
+++ b/internal/linear/linear_test.go
@@ -1,0 +1,60 @@
+package linear
+
+// linear_test.go covers the one thing scoping a read changes: which token it is
+// made with. What that token can see — the workspace, and the teams in it — is
+// Linear's own grant, not something this package narrows. The transport is left
+// alone; a failed call is "no signal" by design.
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func TestNewRequestCarriesTheKey(t *testing.T) {
+	req, err := newRequest("lin_api_acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The key is the scope: this is the whole of what makes the read one
+	// product's rather than another's.
+	if got := req.Header.Get("Authorization"); got != "lin_api_acme" {
+		t.Errorf("Authorization = %q, want the raw key", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q", got)
+	}
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sent struct {
+		Query string `json:"query"`
+	}
+	if err := json.Unmarshal(body, &sent); err != nil {
+		t.Fatal(err)
+	}
+	if sent.Query == "" {
+		t.Error("request carries no query")
+	}
+}
+
+func TestAssignedWithoutKeyReadsNothing(t *testing.T) {
+	// No token is not an error — it is a source that was never configured, and
+	// the collector must be able to tell the two apart.
+	issues, err := Assigned("")
+	if err != nil || issues != nil {
+		t.Errorf("Assigned(\"\") = %v, %v; want nil, nil", issues, err)
+	}
+}
+
+func TestKeyReadsTheAmbientEnv(t *testing.T) {
+	t.Setenv("LINEAR_API_KEY", "lin_api_ambient")
+	if got := Key(); got != "lin_api_ambient" {
+		t.Errorf("Key() = %q", got)
+	}
+	t.Setenv("LINEAR_API_KEY", "")
+	if got := Key(); got != "" {
+		t.Errorf("Key() with no env = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
Lands @dpcleitao's #61 — his commit is here unchanged, authorship intact — with the review fixes on top, from a branch on this repo rather than a fork.

**Why a new PR rather than a merge of #61.** #61 cannot be merged as it stands, and not for anything wrong with it: it comes from a fork, and `main`'s ruleset requires a CodeQL scan and a coverage report that CI deliberately does not run for cross-repo PRs (`upload-coverage-go` is gated on `head.repo.full_name == github.repository`, and the CodeQL Analyze jobs never appear at all). Its `mergeable_state` has been `blocked` since it opened with all four of its visible checks green. #61 has the full review; this is where it lands.

## What #61 does

`[linear]` maps a product to the Linear token its backlog is read with, so a portfolio spanning several workspaces stops showing only whichever one the single `linear_api_key` could see. No team filter, deliberately — Linear grants a key its teams at creation, so two products in one workspace hold a team-scoped key each, and a filter we applied would narrow a list after `first: 50` had already chosen it. Read the original description on #61; it is the better account.

## What this adds

### 1. A shared token names no product

`linearReads` deduped on the key correctly, then filed the surviving read under whichever product sorted first. Reproduced:

```
cfg.Linear = {"acme": "", "bluefin": ""}, LINEAR_API_KEY=amb
  → [{product:acme key:amb}]
```

Both products fall back to the ambient key, one read goes out, and every ticket it returns — bluefin's included — comes back tagged **acme**. Before the feature they were tagged with nothing, which was true. A shared token cannot say which product an issue belongs to, so the read now names neither: the same blank the unscoped read has always carried, and the same call as "—" in a check column being a claim about us rather than about the repository. Every product's token is resolved before any read is named, because how many products claim a token is not knowable one product at a time.

### 2. The unscoped read is never dropped

```
cfg.Linear = {"acme": "k_acme"}, LINEAR_API_KEY=amb_other_workspace
  → [{product:acme key:k_acme}]
```

Naming one product's token dropped the ambient read entirely. The rationale was that it would return the scoped products' issues again under no product — true only when the ambient key *is* one of the scoped ones, and `seen[key]` already suppresses that. When it is another workspace, which is the premise of the whole feature, the second read is not a duplicate, it is the rest of the backlog, and it vanished the moment its owner filled in one line of `[linear]`. Silently: an empty Linear source and an unconfigured one look identical on the lens. It is a read of its own now whenever no product has claimed it, taken last, so the dedupe drops any overlap and a scoped read keeps the product tag.

### 3. The token is typed where the product is named

The UX question this was reviewed against. `[linear]` is keyed by product **name**, and product names are minted in exactly one place — the assignment editor's `n`. Sending the human to `config.toml` asked them to retype a string that has to match one of those names exactly, in another file, with silence as the only feedback when it does not, and the failure that silence hides is the worst available: the token authenticates, the read succeeds, and its tickets are filed under a product that groups nowhere.

`2`, `a`, `tab`, then `l` on a product enters its token. Masked as typed, never echoed after — a product with one shows `2 repos · linear token` and nothing more, because this pane is what a shoulder reads. The buffer starts empty rather than pre-filled, since priming a masked field with a secret is how a half-deleted key gets saved over a working one. Empty entry clears the line (no entry and `product = ""` mean the same thing to the reader and different things to the screen); esc leaves what is stored alone. Same write discipline as `clPersist`: a copy saved first, published into the running config only if the save worked.

The buffer owns the keyboard while open, and that guard is load-bearing rather than tidy — a Linear token is lowercase and digits, so without it `lin_api_1…` switches lens on its first digit and a `q` mid-paste quits the cockpit, each discarding a secret under a footer promising only "esc cancels".

### 4. Docs

`docs/adr/0006-a-linear-token-is-the-scope.md`, which #61's `CLAUDE.md` bullet was missing — every other bullet in that section names one, and the DECISIONS lens reads both. The bullet also said tickets were "deduped by identifier" where the code dedupes on the issue **id**, and named a `ctrl+d` double-dispatch that cannot happen (a Linear ticket carries no repo, so the backlog refuses it). Both corrected, and the dedupe comment — which argued both sides — now says plainly that deduping on id keeps the identifier collision rather than fixing it: `ticket.id` is the identifier and `m.picked` is keyed by it, so two workspaces' ENG-124s tick together on one `space`. That is the cheaper failure, and worth stating.

## Left as review notes on #61, not changed here

- **A bad token is indistinguishable from an empty backlog.** One revoked or mistyped token among five now means one product is silently empty forever. The forge collector already decided this class of question the other way; naming the products whose read failed in the backlog's sources kicker is the follow-up.
- **The product a Linear ticket now carries is invisible in the list** — the REPO column is empty for every Linear row and the product shows only in the detail pane.

## Tests

`linearReads` resolution (unscoped fallback, missing token, shared-token blanking both ways, the retained ambient read, name order), the config round-trip through the hand-written template, the request's key wiring, and six on the token entry: the product-name join through to `linearReads`, clearing, esc, that the buffer owns the keyboard, that the token never renders typed or stored, and that a failed save is not published. `go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues) and the full suite green locally.

## Release

`release:minor` — new feature.
