### PR TITLE
Test the Linear read and the merge, not just the decision to make them

### DIFF
--- a/internal/cockpit/cluster_linear_test.go
+++ b/internal/cockpit/cluster_linear_test.go
@@ -255,3 +255,37 @@ func TestClLinearKeyDoesNotPublishAFailedSave(t *testing.T) {
 		t.Errorf("a failed save was published anyway: %v", mm.cfg.Linear)
 	}
 }
+
+// A cockpit with no config loaded must not write a token into nothing and say
+// it saved. The editor is reachable in that state — clPersist guards it the
+// same way — and the notice is the only thing that tells the human the token
+// they just pasted went nowhere.
+func TestClLinearKeyWithoutAConfig(t *testing.T) {
+	m := clFixture(t)
+	m.cfg = nil
+
+	if got := m.clLinearKey("acme"); got != "" {
+		t.Errorf("no config can name no token, got %q", got)
+	}
+	mm, cmd := m.clSetLinearKey("acme", "lin_api_new")
+	if cmd == nil {
+		t.Fatal("a save with nowhere to go must still report")
+	}
+	msg, ok := cmd().(actionMsg)
+	if !ok || !strings.Contains(msg.notice, "nothing saved") {
+		t.Errorf("notice = %+v, want one saying it did not save", msg)
+	}
+	if mm.cfg != nil {
+		t.Error("no config was invented to save into")
+	}
+
+	// A product with no name is not a product. Nothing is written and nothing
+	// is claimed — the pane has no row to have meant.
+	m2 := clFixture(t)
+	if _, cmd := m2.clSetLinearKey("", "lin_api_new"); cmd != nil {
+		t.Error("an unnamed product must not produce a save at all")
+	}
+	if got := m2.clLinearKey(""); got != "" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/cockpit/collect_backlog.go
+++ b/internal/cockpit/collect_backlog.go
@@ -82,27 +82,7 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 			readIssues[i] = issues
 		}
 	})
-	linSeen := map[string]bool{}
-	for i, r := range reads {
-		for _, is := range readIssues[i] {
-			if linSeen[is.ID] {
-				continue
-			}
-			linSeen[is.ID] = true
-			tickets = append(tickets, ticket{
-				id:      is.Identifier,
-				src:     "lin",
-				title:   is.Title,
-				product: r.product,
-				pri:     blkPriFromLinear(is.Priority),
-				age:     blkAge(is.UpdatedAt),
-				labels:  is.State,
-				body:    is.Description,
-				prompt:  blkPrompt("Linear issue", is.Identifier, is.Title, is.Description),
-				taken:   blkTakenBy(ctx.records, is.Identifier, is.Title),
-			})
-		}
-	}
+	tickets = append(tickets, linearTickets(reads, readIssues, ctx.records)...)
 
 	// Azure Boards work items (only when configured).
 	if azure.Configured() {
@@ -124,6 +104,48 @@ func collectBacklog(ctx *collectCtx, s *snapshot) {
 	}
 
 	s.backlogTickets = tickets
+}
+
+// linearTickets merges what the reads returned into backlog rows: readIssues[i]
+// is what reads[i] came back with, and the two are walked in step so a ticket
+// carries the product of the read that produced it.
+//
+// Split out of collectBacklog so it can be tested without a Linear behind it.
+// It is where the dedupe and the product tag live — the two pieces of this
+// source that are reasoned about hardest and were reachable only through an
+// HTTP call, so neither had a test while the function that merely *decides* the
+// calls had six.
+//
+// Merged in read order, which linearReads fixed to product-name order, so which
+// of two duplicate tickets survives never depends on which workspace answered
+// first.
+func linearTickets(reads []linearRead, readIssues [][]linear.Issue, records []*state.Dispatch) []ticket {
+	var out []ticket
+	seen := map[string]bool{}
+	for i, r := range reads {
+		if i >= len(readIssues) {
+			break
+		}
+		for _, is := range readIssues[i] {
+			if seen[is.ID] {
+				continue
+			}
+			seen[is.ID] = true
+			out = append(out, ticket{
+				id:      is.Identifier,
+				src:     "lin",
+				title:   is.Title,
+				product: r.product,
+				pri:     blkPriFromLinear(is.Priority),
+				age:     blkAge(is.UpdatedAt),
+				labels:  is.State,
+				body:    is.Description,
+				prompt:  blkPrompt("Linear issue", is.Identifier, is.Title, is.Description),
+				taken:   blkTakenBy(records, is.Identifier, is.Title),
+			})
+		}
+	}
+	return out
 }
 
 // linearRead is one call to Linear: the product whose backlog it fills, and the

--- a/internal/cockpit/collect_backlog_test.go
+++ b/internal/cockpit/collect_backlog_test.go
@@ -5,6 +5,11 @@ package cockpit
 // teams Linear granted it, so which token reads a product is what scopes it.
 
 import (
+	"strings"
+	"time"
+
+	"claude-dispatcher/internal/linear"
+	"claude-dispatcher/internal/state"
 	"testing"
 
 	"claude-dispatcher/internal/config"
@@ -147,5 +152,134 @@ func TestLinearReadsSharedFallbackNamesNoProduct(t *testing.T) {
 	}
 	if got[0].key != "lin_api_ambient" || got[0].product != "" {
 		t.Errorf("read = %+v, want the ambient key under no product", got[0])
+	}
+}
+
+// ---- the merge --------------------------------------------------------------
+//
+// linearReads decides which calls to go and make; linearTickets is what happens
+// to the answers, and it holds the two rules this source is built on — dedupe by
+// issue id, and the product tag comes from the read. Both were behind an HTTP
+// call until linearTickets was split out, so neither had a test.
+
+func linIssue(id, identifier, title string) linear.Issue {
+	return linear.Issue{
+		ID: id, Identifier: identifier, Title: title,
+		Priority: "Medium", State: "Todo",
+		UpdatedAt: time.Now().Add(-2 * time.Hour),
+	}
+}
+
+// Every ticket carries the product of the read it came back on, and a read that
+// names no product (the unscoped one, or a token two products share) leaves it
+// blank rather than borrowing its neighbour's.
+func TestLinearTicketsCarryTheirRead(t *testing.T) {
+	reads := []linearRead{{product: "acme", key: "k1"}, {key: "k2"}}
+	got := linearTickets(reads, [][]linear.Issue{
+		{linIssue("uuid-1", "ENG-1", "scoped")},
+		{linIssue("uuid-2", "OPS-9", "unscoped")},
+	}, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("got %d tickets, want 2", len(got))
+	}
+	if got[0].product != "acme" || got[0].id != "ENG-1" || got[0].src != "lin" {
+		t.Errorf("scoped ticket = %+v", got[0])
+	}
+	if got[1].product != "" {
+		t.Errorf("a read naming no product must not tag its tickets: %+v", got[1])
+	}
+	// The prompt is the ticket's own words, and the id is the identifier — which
+	// is what the picked set and the branch slug are keyed by.
+	if !strings.Contains(got[0].prompt, "ENG-1") || !strings.Contains(got[0].prompt, "scoped") {
+		t.Errorf("prompt = %q", got[0].prompt)
+	}
+}
+
+// Two team-scoped tokens can overlap on a team, so the same issue comes back
+// twice. It must appear once, and keep the product of the read that named it
+// first — reads are in product-name order, so that answer is stable.
+func TestLinearTicketsDedupeOnIssueID(t *testing.T) {
+	shared := linIssue("uuid-shared", "ENG-7", "one issue, two tokens")
+	reads := []linearRead{{product: "acme", key: "k1"}, {product: "bluefin", key: "k2"}}
+	got := linearTickets(reads, [][]linear.Issue{
+		{shared, linIssue("uuid-a", "ENG-8", "acme only")},
+		{shared, linIssue("uuid-b", "ENG-9", "bluefin only")},
+	}, nil)
+
+	if len(got) != 3 {
+		t.Fatalf("got %d tickets, want 3 — the shared issue must appear once: %+v", len(got), got)
+	}
+	if got[0].id != "ENG-7" || got[0].product != "acme" {
+		t.Errorf("the first read to name it keeps it: %+v", got[0])
+	}
+	for _, tk := range got[1:] {
+		if tk.id == "ENG-7" {
+			t.Errorf("ENG-7 appears twice: %+v", got)
+		}
+	}
+}
+
+// Deduped on the id and NOT the identifier: two workspaces both keying a team
+// ENG can each raise an ENG-124, and they are different tickets. Dropping the
+// second would lose one nobody ever saw, which is the one failure a backlog
+// must not have — even though keeping it means one `space` ticks both rows.
+func TestLinearTicketsKeepTwoWorkspacesSharingAnIdentifier(t *testing.T) {
+	reads := []linearRead{{product: "acme", key: "k1"}, {product: "bluefin", key: "k2"}}
+	got := linearTickets(reads, [][]linear.Issue{
+		{linIssue("uuid-acme", "ENG-124", "acme's ENG-124")},
+		{linIssue("uuid-blue", "ENG-124", "bluefin's ENG-124")},
+	}, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("two workspaces' ENG-124s are two tickets, got %d: %+v", len(got), got)
+	}
+	if got[0].title == got[1].title {
+		t.Errorf("the wrong one was dropped: %+v", got)
+	}
+	if got[0].product != "acme" || got[1].product != "bluefin" {
+		t.Errorf("each keeps its own read's product: %+v", got)
+	}
+}
+
+// A read that failed left a nil row in readIssues — the collector drops the
+// error and keeps the slot — and contributes nothing rather than panicking.
+func TestLinearTicketsToleratesAFailedRead(t *testing.T) {
+	reads := []linearRead{{product: "acme", key: "k1"}, {product: "bluefin", key: "k2"}}
+	got := linearTickets(reads, [][]linear.Issue{
+		nil,
+		{linIssue("uuid-b", "ENG-9", "bluefin only")},
+	}, nil)
+	if len(got) != 1 || got[0].product != "bluefin" {
+		t.Fatalf("a failed read contributes nothing: %+v", got)
+	}
+
+	// And nothing at all is an empty backlog, not a crash.
+	if got := linearTickets(nil, nil, nil); len(got) != 0 {
+		t.Errorf("no reads = no tickets, got %+v", got)
+	}
+	// A short readIssues (never happens in the collector, but the two are
+	// separate arguments now) must not index past the end.
+	if got := linearTickets(reads, nil, nil); len(got) != 0 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+// An in-flight dispatch on a ticket's own branch marks the row taken, so the
+// backlog does not offer work that is already out. That join is by identifier.
+func TestLinearTicketsReportWhatIsAlreadyDispatched(t *testing.T) {
+	records := []*state.Dispatch{{
+		Feature: "eng-1", Branch: "feature/eng-1", Status: state.StatusWorking,
+	}}
+	got := linearTickets(
+		[]linearRead{{product: "acme", key: "k1"}},
+		[][]linear.Issue{{linIssue("uuid-1", "ENG-1", "already out")}},
+		records,
+	)
+	if len(got) != 1 {
+		t.Fatalf("got %+v", got)
+	}
+	if got[0].taken != "eng-1" {
+		t.Errorf("taken = %q, want the dispatch working it", got[0].taken)
 	}
 }

--- a/internal/linear/linear.go
+++ b/internal/linear/linear.go
@@ -14,7 +14,13 @@ import (
 	"time"
 )
 
-const endpoint = "https://api.linear.app/graphql"
+// endpoint is a var rather than a const so a test can point a read at an
+// httptest server. Everything this package does that is worth testing happens
+// on the far side of one HTTP call — the decode, the GraphQL error, the
+// field mapping — and with a compiled-in URL none of it was reachable: the
+// package sat at 9.5% covered with only "an empty key reads nothing" behind it.
+// Nothing writes to it outside tests.
+var endpoint = "https://api.linear.app/graphql"
 
 // Key is the unscoped API key: the ambient LINEAR_API_KEY, which the cockpit
 // seeds from config at start-up. It is what a product whose source names no key

--- a/internal/linear/linear_test.go
+++ b/internal/linear/linear_test.go
@@ -1,14 +1,22 @@
 package linear
 
-// linear_test.go covers the one thing scoping a read changes: which token it is
-// made with. What that token can see — the workspace, and the teams in it — is
-// Linear's own grant, not something this package narrows. The transport is left
-// alone; a failed call is "no signal" by design.
+// linear_test.go covers which token a read is made with — the one thing scoping
+// changes, since what a token can see is Linear's own grant and not something
+// this package narrows — and then the read itself: the decode, the field
+// mapping, and each of the four ways a call fails.
+//
+// The failures matter as much as the success. The collector drops a read that
+// errored, and that error is the only thing separating a revoked token from a
+// product with nothing assigned; a call that swallowed one would put an empty
+// backlog on the screen and call it the truth.
 
 import (
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestNewRequestCarriesTheKey(t *testing.T) {
@@ -56,5 +64,137 @@ func TestKeyReadsTheAmbientEnv(t *testing.T) {
 	t.Setenv("LINEAR_API_KEY", "")
 	if got := Key(); got != "" {
 		t.Errorf("Key() with no env = %q, want empty", got)
+	}
+}
+
+// ---- the read itself --------------------------------------------------------
+//
+// Everything below the one HTTP call — the decode, the GraphQL error, the field
+// mapping onto Issue — was unreachable while the endpoint was compiled in, so
+// the package's only covered line was "an empty key reads nothing". These point
+// a read at an httptest server instead.
+
+// serve points the package's endpoint at a handler for the duration of a test.
+func serve(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	prev := endpoint
+	endpoint = srv.URL
+	t.Cleanup(func() {
+		endpoint = prev
+		srv.Close()
+	})
+}
+
+const okBody = `{"data":{"viewer":{"assignedIssues":{"nodes":[
+  {"id":"uuid-1","identifier":"ENG-124","title":"Fix the thing",
+   "description":"it is broken","priorityLabel":"Urgent",
+   "updatedAt":"2026-08-19T10:00:00Z","state":{"name":"In Progress"},
+   "team":{"key":"ENG"}},
+  {"id":"uuid-2","identifier":"ENG-125","title":"Second",
+   "description":"","priorityLabel":"Medium",
+   "updatedAt":"2026-08-18T09:30:00Z","state":{"name":"Todo"},
+   "team":{"key":"ENG"}}]}}}}`
+
+// The mapping is the whole of what this package produces: priorityLabel becomes
+// Priority, the nested state and team become flat strings, and the id and the
+// identifier stay distinct — the collector dedupes on one and keys the picked
+// set by the other, so collapsing them would be a bug nothing else could catch.
+func TestAssignedDecodesAndMaps(t *testing.T) {
+	var gotAuth, gotType, gotMethod string
+	serve(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth, gotType, gotMethod = r.Header.Get("Authorization"), r.Header.Get("Content-Type"), r.Method
+		_, _ = io.WriteString(w, okBody)
+	})
+
+	issues, err := Assigned("lin_api_acme")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The key reached the wire as the raw header, which is the whole of the
+	// scope: this read is acme's rather than anyone else's because of it.
+	if gotAuth != "lin_api_acme" {
+		t.Errorf("Authorization on the wire = %q", gotAuth)
+	}
+	if gotMethod != http.MethodPost || gotType != "application/json" {
+		t.Errorf("request was %s %s", gotMethod, gotType)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("got %d issues, want 2", len(issues))
+	}
+	first := issues[0]
+	if first.ID != "uuid-1" || first.Identifier != "ENG-124" {
+		t.Errorf("id/identifier must stay distinct: %+v", first)
+	}
+	if first.Title != "Fix the thing" || first.Description != "it is broken" {
+		t.Errorf("issue = %+v", first)
+	}
+	if first.Priority != "Urgent" {
+		t.Errorf("Priority = %q, want the priorityLabel", first.Priority)
+	}
+	if first.State != "In Progress" || first.Team != "ENG" {
+		t.Errorf("state/team = %q/%q", first.State, first.Team)
+	}
+	if !first.UpdatedAt.Equal(time.Date(2026, 8, 19, 10, 0, 0, 0, time.UTC)) {
+		t.Errorf("UpdatedAt = %v", first.UpdatedAt)
+	}
+}
+
+// An empty node list is a product with nothing assigned, and must not read as a
+// failure — the collector tells "no signal" from "nothing open" by the error.
+func TestAssignedEmptyIsNotAnError(t *testing.T) {
+	serve(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"data":{"viewer":{"assignedIssues":{"nodes":[]}}}}`)
+	})
+	issues, err := Assigned("lin_api_acme")
+	if err != nil {
+		t.Fatalf("an empty backlog is not an error: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("got %d issues", len(issues))
+	}
+}
+
+// A revoked or wrongly-scoped key comes back as a GraphQL error inside a 200.
+// It must surface as an error, because the collector drops a failed read and
+// that is the only thing keeping a bad token from reading as an empty product.
+func TestAssignedGraphQLErrorIsAnError(t *testing.T) {
+	serve(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"errors":[{"message":"Authentication required"}],"data":null}`)
+	})
+	issues, err := Assigned("lin_api_revoked")
+	if err == nil {
+		t.Fatal("a GraphQL error must not read as an empty backlog")
+	}
+	if err.Error() != "Authentication required" {
+		t.Errorf("err = %q, want Linear's own message", err)
+	}
+	if issues != nil {
+		t.Errorf("a failed read must carry no issues, got %v", issues)
+	}
+}
+
+// A 500 behind a proxy is HTML, not JSON. It has to degrade the same way.
+func TestAssignedMalformedBodyIsAnError(t *testing.T) {
+	serve(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "<html>gateway error</html>")
+	})
+	if _, err := Assigned("lin_api_acme"); err == nil {
+		t.Error("an unparseable body must be an error, not an empty backlog")
+	}
+}
+
+// And a transport failure — the machine offline, the endpoint refusing.
+func TestAssignedTransportFailureIsAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now
+	prev := endpoint
+	endpoint = url
+	t.Cleanup(func() { endpoint = prev })
+
+	if _, err := Assigned("lin_api_acme"); err == nil {
+		t.Error("a dead endpoint must be an error, not an empty backlog")
 	}
 }


### PR DESCRIPTION
Follow-up to #62. Measured its coverage after the fact and it was the wrong way round.

`linearReads`, which only decides *which* calls to go and make, had seven tests and 100% of its statements. The two things those calls actually produce had none:

| | before | after |
|---|---|---|
| `internal/linear` (package) | 9.5% | 90.3% |
| `linear.Assigned` | 9.5% | 95.2% |
| the merge in `collectBacklog` | 0% | 100% (as `linearTickets`) |
| repo total | 83.6% | 83.9% |

Both gaps had the same cause: they live on the far side of one HTTP call, and `endpoint` was a `const`, so nothing below it was reachable from a test. The only line covered in the whole package was "an empty key reads nothing".

CI never caught this — the ruleset checks a repo-wide floor of 60% and a drop of no more than 5%, and a package going from nothing to nearly nothing passes both comfortably.

## The read

`endpoint` is a `var` now, so a read can be pointed at an `httptest` server. That reaches the decode, the field mapping — `priorityLabel` becomes `Priority`, the nested `state`/`team` flatten, and the id and the identifier stay distinct, which matters because the collector dedupes on one and keys the picked set by the other — and each of the four ways a call fails.

The failures are the point. The collector drops a read that errored, and that error is the only thing separating a revoked token from a product with nothing assigned; a call that swallowed one would put an empty backlog on the screen and call it the truth. A GraphQL error inside a 200, an unparseable body, a dead endpoint, and an empty node list are now four different outcomes on purpose.

## The merge

`linearTickets`, split out of `collectBacklog` and taking the reads and their answers as arguments, so the dedupe and the product tag can be exercised without a Linear behind them. Tested:

- a ticket carries the product of the read it came back on, and a read naming none leaves it blank rather than borrowing a neighbour's;
- one issue that two tokens both return appears **once**, keeping the product of the read that named it first (reads are in product-name order, so that answer is stable);
- two workspaces' `ENG-124`s are **two** tickets, because deduping on the identifier would lose one nobody ever saw — the case #62 reasoned about hardest and could not previously assert;
- a failed read contributes nothing rather than panicking, and a short/nil answer slice does not index past the end;
- an in-flight dispatch on a ticket's branch marks its row taken.

Plus the no-config guards on `clLinearKey`/`clSetLinearKey`, which the cockpit really can reach — the notice is the only thing telling the human a pasted token went nowhere.

## Not covered, deliberately

`newRequest` stays at 77.8%: what is left is `json.Marshal` and `http.NewRequest` failing on a compiled-in query and a constant method. Neither can happen, and neither is worth a seam.

`go build`, `go vet`, `gofmt`, `golangci-lint` (0 issues) and the full suite green locally.

## Release

`skip-release` — tests and one `const`→`var`, no behaviour change.
